### PR TITLE
Python 3 Update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ backend-assembly:
 run-pyspark:
 	spark-submit \
 		--master "local[*]" \
-		--jars geopyspark-backend/geotrellis/target/scala-2.10/geotrellis-backend-assembly-0.0.1.jar \
+		--jars geopyspark-backend/geotrellis/target/scala-2.11/geotrellis-backend-assembly-0.1.0.jar \
 		geopyspark/extent_test.py
 
 run: install backend-assembly run-pyspark

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,4 @@ run-pyspark:
 		geopyspark/extent_test.py
 
 run: install backend-assembly run-pyspark
+#run: install run-pyspark

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 install:
-	python setup.py install --user
+	python3 setup.py install --user
 
 backend-assembly:
 	cd geopyspark-backend && sbt "project geotrellis-backend" assembly

--- a/geopyspark-backend/geotrellis/build.sbt
+++ b/geopyspark-backend/geotrellis/build.sbt
@@ -1,5 +1,6 @@
 name := "geotrellis-backend"
-resolvers += "Location Tech GeoTrellis Snapshots" at "https://repo.locationtech.org/content/repositories/geotrellis-snapshots"
+resolvers ++= ("Location Tech GeoTrellis Snapshots" at "https://repo.locationtech.org/content/repositories/geotrellis-snapshots"i,
+  Resolver.mavenLocal)
 libraryDependencies ++= Seq(
   "org.locationtech.geotrellis" % "geotrellis-spark_2.11" % Version.geotrellis,
   "org.locationtech.geotrellis" % "geotrellis-spark-etl_2.11" % Version.geotrellis,

--- a/geopyspark-backend/geotrellis/build.sbt
+++ b/geopyspark-backend/geotrellis/build.sbt
@@ -1,5 +1,5 @@
 name := "geotrellis-backend"
-resolvers ++= ("Location Tech GeoTrellis Snapshots" at "https://repo.locationtech.org/content/repositories/geotrellis-snapshots"i,
+resolvers ++= Seq("Location Tech GeoTrellis Snapshots" at "https://repo.locationtech.org/content/repositories/geotrellis-snapshots",
   Resolver.mavenLocal)
 libraryDependencies ++= Seq(
   "org.locationtech.geotrellis" % "geotrellis-spark_2.11" % Version.geotrellis,

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ExtentWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ExtentWrapper.scala
@@ -19,7 +19,8 @@ object ExtentWrapper {
     PythonTranslator.toPython(testRdd(sc))
 
   def testIn(rdd: RDD[Array[Byte]], schema: String) =
-    PythonTranslator.fromPython[Extent](rdd, Some(schema)).foreach(println)
+    rdd.collect().foreach(println)
+    //PythonTranslator.fromPython[Extent](rdd, Some(schema)).foreach(println)
 
   def testRdd(sc: SparkContext): RDD[Extent] = {
     val arr = Array(

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ExtentWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ExtentWrapper.scala
@@ -34,12 +34,12 @@ object ExtentWrapper {
   }
 
   def encodeRdd(rdd: RDD[Extent]): RDD[Array[Byte]] = {
-    rdd.map { key => ExtendedAvroEncoder.toBinary(key, deflate = false)
+    rdd.map { key => AvroEncoder.toBinary(key, deflate = false)
     }
   }
 
   def encodeRddText(rdd: RDD[Extent]): RDD[String] = {
-      rdd.map { key => ExtendedAvroEncoder.toBinary(key, deflate = false).mkString("")
+      rdd.map { key => AvroEncoder.toBinary(key, deflate = false).mkString("")
       }
     }
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ExtentWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ExtentWrapper.scala
@@ -5,12 +5,22 @@ import geotrellis.raster._
 import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.avro._
+import geotrellis.spark.util.KryoWrapper
 
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
+import org.apache.spark.api.java.JavaRDD
 import org.apache.avro._
 
+import scala.reflect.ClassTag
+
 object ExtentWrapper {
+  def testOut(sc: SparkContext) =
+    PythonTranslator.toPython(testRdd(sc))
+
+  def testIn(rdd: RDD[Array[Byte]], schema: String) =
+    PythonTranslator.fromPython[Extent](rdd, Some(schema)).foreach(println)
+
   def testRdd(sc: SparkContext): RDD[Extent] = {
     val arr = Array(
       Extent(0, 0, 1, 1),
@@ -45,5 +55,27 @@ object ExtentWrapper {
     println("THIS IS THE RESULT OF TURNING THE EXTENTS INTO RASTER EXTENTS")
     collection.foreach(println)
     println("\n\n\n")
+  }
+}
+
+object PythonTranslator {
+  def toPython[T: AvroRecordCodec](rdd: RDD[T]): (JavaRDD[Array[Byte]], String) = {
+    val jrdd =
+      rdd
+        .map { v =>
+          ExtendedAvroEncoder.toBinary(v, deflate = false)
+        }
+        .toJavaRDD
+    (jrdd, implicitly[AvroRecordCodec[T]].schema.toString)
+  }
+
+  def fromPython[T: AvroRecordCodec: ClassTag](rdd: RDD[Array[Byte]], schemaJson: Option[String] = None): RDD[T] = {
+    val schema = schemaJson.map { json => (new Schema.Parser).parse(json) }
+    val _recordCodec = implicitly[AvroRecordCodec[T]]
+    val kwWriterSchema = KryoWrapper(schema)
+
+    rdd.map { bytes =>
+      AvroEncoder.fromBinary(kwWriterSchema.value.getOrElse(_recordCodec.schema), bytes)(_recordCodec)
+    }
   }
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ExtentWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ExtentWrapper.scala
@@ -19,8 +19,7 @@ object ExtentWrapper {
     PythonTranslator.toPython(testRdd(sc))
 
   def testIn(rdd: RDD[Array[Byte]], schema: String) =
-    rdd.collect().foreach(println)
-    //PythonTranslator.fromPython[Extent](rdd, Some(schema)).foreach(println)
+    PythonTranslator.fromPython[Extent](rdd, Some(schema)).foreach(println)
 
   def testRdd(sc: SparkContext): RDD[Extent] = {
     val arr = Array(
@@ -76,7 +75,7 @@ object PythonTranslator {
     val kwWriterSchema = KryoWrapper(schema)
 
     rdd.map { bytes =>
-      AvroEncoder.fromBinary(kwWriterSchema.value.getOrElse(_recordCodec.schema), bytes)(_recordCodec)
+      ExtendedAvroEncoder.fromBinary(kwWriterSchema.value.getOrElse(_recordCodec.schema), bytes)(_recordCodec)
     }
   }
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/PythonTranslator.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/PythonTranslator.scala
@@ -1,0 +1,34 @@
+package geopyspark.geotrellis
+
+import geotrellis.spark.io._
+import geotrellis.spark.io.avro._
+import geotrellis.spark.util.KryoWrapper
+
+import org.apache.spark._
+import org.apache.spark.rdd.RDD
+import org.apache.spark.api.java.JavaRDD
+import org.apache.avro._
+
+import scala.reflect.ClassTag
+
+object PythonTranslator {
+  def toPython[T: AvroRecordCodec](rdd: RDD[T]): (JavaRDD[Array[Byte]], String) = {
+    val jrdd =
+      rdd
+        .map { v =>
+          ExtendedAvroEncoder.toBinary(v, deflate = false)
+        }
+        .toJavaRDD
+    (jrdd, implicitly[AvroRecordCodec[T]].schema.toString)
+  }
+
+  def fromPython[T: AvroRecordCodec: ClassTag](rdd: RDD[Array[Byte]], schemaJson: Option[String] = None): RDD[T] = {
+    val schema = schemaJson.map { json => (new Schema.Parser).parse(json) }
+    val _recordCodec = implicitly[AvroRecordCodec[T]]
+    val kwWriterSchema = KryoWrapper(schema)
+
+    rdd.map { bytes =>
+      ExtendedAvroEncoder.fromBinary(kwWriterSchema.value.getOrElse(_recordCodec.schema), bytes)(_recordCodec)
+    }
+  }
+}

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/PythonTranslator.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/PythonTranslator.scala
@@ -16,7 +16,7 @@ object PythonTranslator {
     val jrdd =
       rdd
         .map { v =>
-          ExtendedAvroEncoder.toBinary(v, deflate = false)
+          AvroEncoder.toBinary(v, deflate = false)
         }
         .toJavaRDD
     (jrdd, implicitly[AvroRecordCodec[T]].schema.toString)
@@ -28,7 +28,7 @@ object PythonTranslator {
     val kwWriterSchema = KryoWrapper(schema)
 
     rdd.map { bytes =>
-      ExtendedAvroEncoder.fromBinary(kwWriterSchema.value.getOrElse(_recordCodec.schema), bytes)(_recordCodec)
+      AvroEncoder.fromBinary(kwWriterSchema.value.getOrElse(_recordCodec.schema), bytes, false)(_recordCodec)
     }
   }
 }

--- a/geopyspark/avroserializer.py
+++ b/geopyspark/avroserializer.py
@@ -81,7 +81,7 @@ class AvroSerializer(FramedSerializer):
 
         schema_name = self.schema().name
         if schema_name == EXTENT:
-            return Extent(i.get('xmin'), i.get('ymin'), i.get('xmax'), i.get('ymax'))
+            return [Extent(i.get('xmin'), i.get('ymin'), i.get('xmax'), i.get('ymax'))]
         elif schema_name == SPATIALKEY:
             return SpatialKey(i.get('col'), i.get('row'))
         else:

--- a/geopyspark/avroserializer.py
+++ b/geopyspark/avroserializer.py
@@ -1,12 +1,12 @@
 from pyspark.serializers import Serializer, FramedSerializer, AutoBatchedSerializer
-from spatial_key import SpatialKey
-from extent import Extent
+from geopyspark.spatial_key import SpatialKey
+from geopyspark.extent import Extent
 
 import io
 import avro
 import avro.io
 import binascii
-import StringIO
+from io import StringIO
 
 # Constants
 
@@ -22,10 +22,17 @@ SPATIALKEY = 'SpatialKey'
 
 class AvroSerializer(FramedSerializer):
 
-    def __init__(self, schema):
-        self.schema = avro.schema.parse(schema)
-        self.reader = avro.io.DatumReader(self.schema)
-        self.datum_writer = avro.io.DatumWriter(self.schema)
+    def __init__(self, schemaJson):
+        self._schemaJson = schemaJson
+
+    def schema(self):
+        return avro.schema.Parse(self._schemaJson)
+
+    def reader(self):
+        return avro.io.DatumReader(self.schema())
+
+    def datum_writer(self):
+        return avro.io.DatumWriter(self.schema())
 
     def make_datum(self, obj):
         if isinstance(obj, Extent):
@@ -40,10 +47,11 @@ class AvroSerializer(FramedSerializer):
             raise Exception("COULD NOT MAKE THE DATUM")
 
     """
-    Deserializes a byte array into an object.
+    Serialize an object into a byte array.
+    When batching is used, this will be called with an array of objects.
     """
     def dumps(self, obj, schema):
-        s = avro.schema.parse(schema)
+        s = avro.schema.Parse(schema)
         writer = avro.io.DatumWriter(s)
         bytes_writer = io.BytesIO()
         encoder = avro.io.BinaryEncoder(bytes_writer)
@@ -63,20 +71,18 @@ class AvroSerializer(FramedSerializer):
         return b
         '''
 
-
     """
-    Serialize an object into a byte array.
-    When batching is used, this will be called with an array of objects.
+    Deserializes a byte array into an object.
     """
-
     def loads(self, obj):
         buf = io.BytesIO(obj)
         decoder = avro.io.BinaryDecoder(buf)
-        i = self.reader.read(decoder)
+        i = self.reader().read(decoder)
 
-        if self.schema.name == EXTENT:
-            return [Extent(i.get('xmin'), i.get('ymin'), i.get('xmax'), i.get('ymax'))]
-        elif self.schema.name == SPATIALKEY:
-            return [SpatialKey(i.get('col'), i.get('row'))]
+        schema_name = self.schema().name
+        if schema_name == EXTENT:
+            return Extent(i.get('xmin'), i.get('ymin'), i.get('xmax'), i.get('ymax'))
+        elif schema_name == SPATIALKEY:
+            return SpatialKey(i.get('col'), i.get('row'))
         else:
             raise Exception("COULDN'T FIND THE SCHEMA")

--- a/geopyspark/extent_test.py
+++ b/geopyspark/extent_test.py
@@ -10,30 +10,31 @@ import io
 import sys
 
 
+def get_rdd(pysc):
+    sc = pysc._jsc.sc()
+    ew = pysc._gateway.jvm.ExtentWrapper
+
+    tup = ew.testOut(sc)
+    (java_rdd, schema) = (tup._1(), tup._2())
+    print(type(java_rdd))
+    print(schema)
+
+    ser = AvroSerializer(schema)
+    return (RDD(java_rdd, pysc, AutoBatchedSerializer(ser)), schema)
+
+def set_rdd(pysc, rdd, schema):
+    ew = pysc._gateway.jvm.ExtentWrapper
+
+    ew.testIn(rdd, schema)
+
 if __name__ == "__main__":
     sc = SparkContext(master="local", appName="extent-test")
 
     java_import(sc._gateway.jvm, "geopyspark.geotrellis.ExtentWrapper")
 
-    test_rdd = sc._gateway.jvm.ExtentWrapper.testRdd(sc._jsc.sc())
-    encoded_rdd = sc._gateway.jvm.ExtentWrapper.encodeRdd(test_rdd)
-    java_rdd = encoded_rdd.toJavaRDD()
+    (extents, schema) = get_rdd(sc)
 
-    schema = sc._gateway.jvm.ExtentWrapper.keySchema()
+    new_extents = extents.map(lambda s: Extent(s.xmin+1, s.ymin+1, s.xmax+1, s.ymax+1))
+    print(new_extents.count())
 
-    ser = AvroSerializer(schema)
-
-    python_rdd = RDD(java_rdd, sc, AutoBatchedSerializer(ser))
-    python_rdd2 = python_rdd.map(lambda s: Extent(s.xmin+1, s.ymin+1, s.xmax+1, s.ymax+1))
-    python_rdd3 = python_rdd2.map(lambda s: ser.dumps(s, schema))
-    final_python_rdd = python_rdd3.map(lambda s: bytearray(s))
-
-    collection = python_rdd2.collect()
-
-    print '\n\n\n'
-    print "THESE ARE THE EXTENTS THAT HAVE BEEN MODIFIED ON THE PYTHON SIDE"
-    for x in collection: print x
-    print '\n\n\n'
-
-    new_java_rdd = final_python_rdd._to_java_object_rdd()
-    sc._gateway.jvm.ExtentWrapper.makeRasterExtent(new_java_rdd.rdd())
+    set_rdd(sc, new_extents, schema)

--- a/geopyspark/extent_test.py
+++ b/geopyspark/extent_test.py
@@ -25,10 +25,10 @@ def set_rdd(pysc, rdd, schema):
     dumped = rdd.map(lambda s: ser.dumps(s, schema))
     arrs = dumped.map(lambda s: bytearray(s))
 
-    java_rdd = arrs._to_java_object_rdd()
-    #ew = pysc._gateway.jvm.ExtentWrapper
-    #raise Exception("HO HO HO!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-    #ew.testIn(java_rdd.rdd(), schema)
+    new_java_rdd = dumped._to_java_object_rdd()
+    ew = pysc._gateway.jvm.ExtentWrapper
+
+    ew.testIn(new_java_rdd.rdd(), schema)
 
 if __name__ == "__main__":
     sc = SparkContext(master="local", appName="extent-test")

--- a/geopyspark/test.py
+++ b/geopyspark/test.py
@@ -26,8 +26,8 @@ if __name__ == "__main__":
     box_python_rdd = RDD(box_java_rdd, sc, AutoBatchedSerializer(box_ser))
 
     thing = box_python_rdd.collect()
-    print "THIS IS THE ITEM HELD WITHIN THE PYTHON RDD:", thing
+    print("THIS IS THE ITEM HELD WITHIN THE PYTHON RDD:", thing)
 
     rdd2 = box_python_rdd.map(lambda s: SpatialKey(s.col+1, s.row+1))
     result = rdd2.collect()
-    print "THIS IS THE RESULT OF THE PYTHON RDD BEING MAPPED OVER:", result
+    print("THIS IS THE RESULT OF THE PYTHON RDD BEING MAPPED OVER:", result)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
         download_url='http://github.com/geotrellis/geopyspark',
         author_email='jbouffard@azavea.com',
         version='0.1',
-        install_requires=['py4j, pyspark'],
+        install_requires=['avro-python3'],
         packages=['geopyspark'],
         scripts=[],
         name='geopyspark'


### PR DESCRIPTION
This PR updates `GeoPySpark` so that is runs using `Python3`. In addition, refactoring has been done on much of the code.

It should be noted, though, that this PR [1952](https://github.com/locationtech/geotrellis/pull/1952) needs to be merged for this PR to work.