### PR TITLE
HadoopGeoTiffRDDWrapper for GeoPySpark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# GeoTiff Test Files
+geopyspark/tests/data_files/geotiff_test_files/

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ run-pyspark:
 	spark-submit \
 		--master "local[*]" \
 		--jars geopyspark-backend/geotrellis/target/scala-2.11/geotrellis-backend-assembly-0.1.0.jar \
-		geopyspark/tests/keys_test.py
+		geopyspark/tests/geotiff_rdd_io_test.py
 
 run-all: install backend-assembly run-pyspark
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ProjectedExtentWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ProjectedExtentWrapper.scala
@@ -1,0 +1,20 @@
+package geopyspark.geotrellis
+
+import geotrellis.proj4._
+import geotrellis.vector._
+import geotrellis.spark._
+import geotrellis.spark.io._
+
+import org.apache.spark._
+import org.apache.spark.rdd.RDD
+
+object ProjectedExtentWrapper extends Wrapper[ProjectedExtent]{
+
+  def testRdd(sc: SparkContext): RDD[ProjectedExtent] = {
+    val arr = Array(
+      ProjectedExtent(Extent(0, 0, 1, 1), CRS.fromEpsgCode(2004)),
+      ProjectedExtent(Extent(1, 2, 3, 4), CRS.fromEpsgCode(2004)),
+      ProjectedExtent(Extent(5, 6, 7, 8), CRS.fromEpsgCode(2004)))
+    sc.parallelize(arr)
+  }
+}

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalProjectedExtentWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalProjectedExtentWrapper.scala
@@ -1,0 +1,20 @@
+package geopyspark.geotrellis
+
+import geotrellis.proj4._
+import geotrellis.vector.Extent
+import geotrellis.spark._
+import geotrellis.spark.io._
+
+import org.apache.spark._
+import org.apache.spark.rdd.RDD
+
+object TemporalProjectedExtentWrapper extends Wrapper[TemporalProjectedExtent]{
+
+  def testRdd(sc: SparkContext): RDD[TemporalProjectedExtent] = {
+    val arr = Array(
+      TemporalProjectedExtent(Extent(0, 0, 1, 1), CRS.fromEpsgCode(2004), 0.toLong),
+      TemporalProjectedExtent(Extent(1, 2, 3, 4), CRS.fromEpsgCode(2004), 1.toLong),
+      TemporalProjectedExtent(Extent(5, 6, 7, 8), CRS.fromEpsgCode(2004), 2.toLong))
+    sc.parallelize(arr)
+  }
+}

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/hadoop/HadoopGeoTiffRDDWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/hadoop/HadoopGeoTiffRDDWrapper.scala
@@ -1,0 +1,95 @@
+package geopyspark.geotrellis.io.hadoop
+
+import geopyspark.geotrellis._
+
+import geotrellis.proj4._
+import geotrellis.raster._
+import geotrellis.vector._
+import geotrellis.spark.io.hadoop._
+import geotrellis.spark.io.avro._
+
+import scala.collection.JavaConverters._
+import java.util.Map
+
+import org.apache.spark._
+import org.apache.spark.rdd.RDD
+import org.apache.spark.api.java.JavaRDD
+
+import org.apache.hadoop.fs.Path
+
+
+object HadoopGeoTiffRDDOptions {
+  def default = HadoopGeoTiffRDD.Options.DEFAULT
+
+  def setValues(javaMap: java.util.Map[String, Any]): HadoopGeoTiffRDD.Options = {
+    //TODO: Find a better way of creating Options from python
+
+    val stringValues = List("timeTag", "timeFormat")
+    val scalaMap = javaMap.asScala
+
+    val intMap =
+      scalaMap.filterKeys(x => !(stringValues.contains(x)))
+        .mapValues(x => x.asInstanceOf[Int])
+
+    val stringMap =
+      scalaMap.filterKeys(x => stringValues.contains(x))
+        .mapValues(x => x.asInstanceOf[String])
+
+    val crs: Option[CRS] =
+      if (intMap.contains("crs"))
+        Some(CRS.fromEpsgCode(intMap("crs")))
+      else
+        None
+
+    HadoopGeoTiffRDD.Options(
+      crs = crs,
+      timeTag = stringMap.getOrElse("timeTag", default.timeTag),
+      timeFormat = stringMap.getOrElse("timeFormat", default.timeFormat),
+      maxTileSize = intMap.get("maxTileSize"),
+      numPartitions = intMap.get("numPartitions"),
+      chunkSize = intMap.get("chunkSize"))
+  }
+}
+
+
+object HadoopGeoTiffRDDWrapper {
+  def spatial(path: String, sc: SparkContext): (JavaRDD[Array[Byte]], String) =
+    PythonTranslator.toPython(HadoopGeoTiffRDD.spatial(path)(sc))
+
+  def spatial(path: String, options: java.util.Map[String, Any],
+    sc: SparkContext): (JavaRDD[Array[Byte]], String) = {
+    val hadoopOptions = HadoopGeoTiffRDDOptions.setValues(options)
+
+    PythonTranslator.toPython(HadoopGeoTiffRDD.spatial(path, hadoopOptions)(sc))
+  }
+
+  def spatialMultiband(path: String, sc: SparkContext): (JavaRDD[Array[Byte]], String) =
+    PythonTranslator.toPython(HadoopGeoTiffRDD.spatialMultiband(path)(sc))
+
+  def spatialMultiband(path: String, options: java.util.Map[String, Any],
+    sc: SparkContext): (JavaRDD[Array[Byte]], String) = {
+    val hadoopOptions = HadoopGeoTiffRDDOptions.setValues(options)
+
+    PythonTranslator.toPython(HadoopGeoTiffRDD.spatialMultiband(path, hadoopOptions)(sc))
+  }
+
+  def temporal(path: Path, sc: SparkContext): (JavaRDD[Array[Byte]], String) =
+    PythonTranslator.toPython(HadoopGeoTiffRDD.temporal(path)(sc))
+
+  def temporal(path: Path, options: java.util.Map[String, Any],
+    sc: SparkContext): (JavaRDD[Array[Byte]], String) = {
+    val hadoopOptions = HadoopGeoTiffRDDOptions.setValues(options)
+
+    PythonTranslator.toPython(HadoopGeoTiffRDD.temporal(path, hadoopOptions)(sc))
+  }
+
+  def temporalMultiband(path: Path, sc: SparkContext): (JavaRDD[Array[Byte]], String) =
+    PythonTranslator.toPython(HadoopGeoTiffRDD.temporalMultiband(path)(sc))
+
+  def temporalMultiband(path: Path, options: java.util.Map[String, Any],
+    sc: SparkContext): (JavaRDD[Array[Byte]], String) = {
+    val hadoopOptions = HadoopGeoTiffRDDOptions.setValues(options)
+
+    PythonTranslator.toPython(HadoopGeoTiffRDD.temporalMultiband(path, hadoopOptions)(sc))
+  }
+}

--- a/geopyspark/avroserializer.py
+++ b/geopyspark/avroserializer.py
@@ -1,6 +1,11 @@
 from pyspark.serializers import Serializer, FramedSerializer
 from geopyspark.geotrellis_decoders import get_decoder
+<<<<<<< 700fe9b093d7ab3bc518e21bc99b85d6ce8c00c2
 from geopyspark.geotrellis_encoders import get_encoder
+=======
+from geopyspark.geotrellis_encoders import get_encoded_object
+from geopyspark.serialization_constants import COLLECTIONS
+>>>>>>> AvroSerializer now depends on geotrellis_encoders for serialization
 
 import io
 import avro
@@ -24,7 +29,10 @@ class AvroSerializer(FramedSerializer):
         self.custom_encoder = custom_encoder
 
         self._decoding_method = None
+<<<<<<< 700fe9b093d7ab3bc518e21bc99b85d6ce8c00c2
         self._encoding_method = None
+=======
+>>>>>>> AvroSerializer now depends on geotrellis_encoders for serialization
 
     def schema(self):
         return avro.schema.Parse(self._schema_json)
@@ -80,5 +88,7 @@ class AvroSerializer(FramedSerializer):
                     custom_decoder=self.custom_decoder)
 
         result = self._decoding_method(i)
+                    custom_name=self.custom_name,
+                    custom_decoder=self.custom_decoder)
 
         return [result]

--- a/geopyspark/avroserializer.py
+++ b/geopyspark/avroserializer.py
@@ -1,11 +1,6 @@
 from pyspark.serializers import Serializer, FramedSerializer
 from geopyspark.geotrellis_decoders import get_decoder
-<<<<<<< 700fe9b093d7ab3bc518e21bc99b85d6ce8c00c2
 from geopyspark.geotrellis_encoders import get_encoder
-=======
-from geopyspark.geotrellis_encoders import get_encoded_object
-from geopyspark.serialization_constants import COLLECTIONS
->>>>>>> AvroSerializer now depends on geotrellis_encoders for serialization
 
 import io
 import avro
@@ -29,10 +24,7 @@ class AvroSerializer(FramedSerializer):
         self.custom_encoder = custom_encoder
 
         self._decoding_method = None
-<<<<<<< 700fe9b093d7ab3bc518e21bc99b85d6ce8c00c2
         self._encoding_method = None
-=======
->>>>>>> AvroSerializer now depends on geotrellis_encoders for serialization
 
     def schema(self):
         return avro.schema.Parse(self._schema_json)
@@ -88,7 +80,5 @@ class AvroSerializer(FramedSerializer):
                     custom_decoder=self.custom_decoder)
 
         result = self._decoding_method(i)
-                    custom_name=self.custom_name,
-                    custom_decoder=self.custom_decoder)
 
         return [result]

--- a/geopyspark/geotrellis_decoders.py
+++ b/geopyspark/geotrellis_decoders.py
@@ -137,7 +137,7 @@ def get_decoder(name, schema_dict, custom_name=None, custom_decoder=None):
     elif name == PROJECTEDEXTENT:
         return projected_extent_decoder
 
-    elif name == TEMPORLAPROJECTEDEXTENT:
+    elif name == TEMPORALPROJECTEDEXTENT:
         return temporal_projected_extent_decoder
 
     elif name == SPATIALKEY:

--- a/geopyspark/geotrellis_decoders.py
+++ b/geopyspark/geotrellis_decoders.py
@@ -56,7 +56,7 @@ def spacetime_key_decoder(i):
 
 def multiband_decoder(i):
     bands = i['bands']
-    objs = [tile_decoder(x) for x in bands]
+    objs = list(map(tile_decoder, bands))
 
     return objs
 
@@ -77,7 +77,7 @@ def key_value_record_decoder(i, schema_dict, custom_name=None, custom_decoder=No
             custom_name=custom_name,
             custom_decoder=custom_decoder)
 
-    objs = [decoder(x) for x in pairs]
+    objs = list(map(decoder, pairs))
 
     return objs
 

--- a/geopyspark/geotrellis_decoders.py
+++ b/geopyspark/geotrellis_decoders.py
@@ -27,6 +27,23 @@ def extent_decoder(i):
 
     return Extent(i['xmin'], i['ymin'], i['xmax'], i['ymax'])
 
+def projected_extent_decoder(i):
+    from geopyspark.projected_extent import ProjectedExtent
+
+    extent = extent_decoder(i['extent'])
+    epsg = i['epsg']
+
+    return ProjectedExtent(extent, epsg)
+
+def temporal_projected_extent_decoder(i):
+    from geopyspark.temporal_projected_extent import TemporalProjectedExtent
+
+    extent = extent_decoder(i['extent'])
+    epsg = i['epsg']
+    instant = i['instant']
+
+    return TemporalProjectedExtent(extent, epsg, instant)
+
 def spatial_key_decoder(i):
     from geopyspark.keys import SpatialKey
 
@@ -116,6 +133,12 @@ def get_decoder(name, schema_dict, custom_name=None, custom_decoder=None):
 
     elif name == EXTENT:
         return extent_decoder
+
+    elif name == PROJECTEDEXTENT:
+        return projected_extent_decoder
+
+    elif name == TEMPORLAPROJECTEDEXTENT:
+        return temporal_projected_extent_decoder
 
     elif name == SPATIALKEY:
         return spatial_key_decoder

--- a/geopyspark/geotrellis_encoders.py
+++ b/geopyspark/geotrellis_encoders.py
@@ -1,6 +1,8 @@
 from geopyspark.keys import SpatialKey, SpaceTimeKey
 from geopyspark.extent import Extent
 from geopyspark.tile import TileArray
+from geopyspark.projected_extent import ProjectedExtent
+from geopyspark.temporal_projected_extent import TemporalProjectedExtent
 
 from functools import partial
 
@@ -38,6 +40,23 @@ def extent_encoder(obj):
             'xmax': obj.xmax,
             'ymin': obj.ymin,
             'ymax': obj.ymax
+            }
+
+    return datum
+
+def projected_extent_encoder(obj):
+    datum = {
+            'extent': extent_encoder(obj.extent),
+            'epsg': obj.epsg_code
+            }
+
+    return datum
+
+def temporal_projected_extent_encoder(obj):
+    datum = {
+            'extent': extent_encoder(obj.extent),
+            'epsg': obj.epsg_code,
+            'instant': obj.instant
             }
 
     return datum
@@ -133,6 +152,12 @@ def get_encoder(obj, custom_class=None, custom_encoder=None):
 
     elif isinstance(obj, Extent):
         return extent_encoder
+
+    elif isinstance(obj, ProjectedExtent):
+        return projected_extent_encoder
+
+    elif isinstance(obj, TemporalProjectedExtent):
+        return temporal_projected_extent_encoder
 
     elif isinstance(obj, SpatialKey):
         return spatial_key_encoder

--- a/geopyspark/geotrellis_encoders.py
+++ b/geopyspark/geotrellis_encoders.py
@@ -79,7 +79,7 @@ def spacetime_key_encoder(obj):
     return datum
 
 def multiband_encoder(obj):
-    tile_datums = [tile_encoder(tile) for tile in obj]
+    tile_datums = list(map(tile_encoder, obj))
 
     datum = {
             'bands': tile_datums
@@ -106,7 +106,7 @@ def key_value_record_encoder(obj, custom_class=None, custom_encoder=None):
             custom_class=custom_class,
             custom_encoder=custom_encoder)
 
-    tuple_datums = [encoder(tup) for tup in obj]
+    tuple_datums = list(map(encoder, obj))
 
     datum = {
             'pairs': tuple_datums

--- a/geopyspark/projected_extent.py
+++ b/geopyspark/projected_extent.py
@@ -1,0 +1,9 @@
+class ProjectedExtent(object):
+    def __init__(self, extent, epsg_code):
+        self.extent = extent
+        self.epsg_code = epsg_code
+
+    def __repr__(self):
+        return 'ProjectedExtent(Extent: {}, EPSG: {})'.format(
+                self.extent,
+                self.epsg_code)

--- a/geopyspark/serialization_constants.py
+++ b/geopyspark/serialization_constants.py
@@ -18,3 +18,7 @@ SPACETIMEKEY = 'SpaceTimeKey'
 TUPLE = 'Tuple2'
 
 KEYVALUERECORD = 'KeyValueRecord'
+
+PROJECTEDEXTENT = 'ProjectedExtent'
+
+TEMPORALPROJECTEDEXTENT = 'TemporalProjectedExtent'

--- a/geopyspark/temporal_projected_extent.py
+++ b/geopyspark/temporal_projected_extent.py
@@ -1,0 +1,11 @@
+class TemporalProjectedExtent(object):
+    def __init__(self, extent, epsg_code, instant):
+        self.extent = extent
+        self.epsg_code = epsg_code
+        self.instant = instant
+
+    def __repr__(self):
+        return 'TemporalProjectedExtent(Extemt: {}, EPSG: {}, Instant: {})'.format(
+                self.extent,
+                self.epsg_code,
+                self.instan)

--- a/geopyspark/tests/geotiff_rdd_io_test.py
+++ b/geopyspark/tests/geotiff_rdd_io_test.py
@@ -146,4 +146,5 @@ class Multiband(GeoTiffIOTest, unittest.TestCase):
 
 
 if __name__ == "__main__":
+    check_directory()
     unittest.main()

--- a/geopyspark/tests/geotiff_rdd_io_test.py
+++ b/geopyspark/tests/geotiff_rdd_io_test.py
@@ -1,0 +1,149 @@
+#!/bin/env python3
+
+from pyspark import SparkConf, SparkContext, RDD
+from pyspark.serializers import Serializer, FramedSerializer, AutoBatchedSerializer
+from py4j.java_gateway import java_import
+from geopyspark.avroserializer import AvroSerializer
+from python_test_utils import *
+from os import walk, path
+
+import rasterio
+import unittest
+
+
+class GeoTiffIOTest(unittest.TestCase):
+    pysc = SparkContext(master="local", appName="hadoop-geotiff-test")
+    sc = pysc._jsc.sc()
+
+    java_import(pysc._gateway.jvm,
+            "geopyspark.geotrellis.io.hadoop.HadoopGeoTiffRDDWrapper")
+
+    java_import(pysc._gateway.jvm,
+            "geopyspark.geotrellis.io.hadoop.HadoopGeoTiffRDDOptions")
+
+    hadoop_wrapper = pysc._gateway.jvm.HadoopGeoTiffRDDWrapper
+    geotiff_rdd_options = pysc._gateway.jvm.HadoopGeoTiffRDDOptions
+
+    def get_filepaths(self, dir_path):
+        files = []
+
+        for (fd, dn, filenames) in walk(dir_path):
+            files.extend(filenames)
+
+        return [path.join(dir_path, x) for x in files]
+
+    def read_geotiff_rasterio(self, paths, windowed):
+        rasterio_tiles = []
+
+        windows = [((0, 256), (0, 256)),
+                ((256, 512), (0, 256)),
+                ((0, 256), (256, 512)),
+                ((256, 512), (256, 512))]
+
+        for f in paths:
+            with rasterio.open(f) as src:
+                if not windowed:
+                    rasterio_tiles.append(src.read())
+                else:
+                    for window in windows:
+                        rasterio_tiles.append(src.read(window=window))
+
+        return rasterio_tiles
+
+
+class Singleband(GeoTiffIOTest):
+    dir_path = test_path("one-month-tiles/")
+
+    def read_singleband_geotrellis(self, options=None):
+        if options is None:
+            tup = self.hadoop_wrapper.spatial(self.dir_path, self.sc)
+        else:
+            tup = self.hadoop_wrapper.spatial(self.dir_path, options, self.sc)
+
+        (java_rdd, schema) = (tup._1(), tup._2())
+
+        ser = AvroSerializer(schema)
+        rdd = RDD(java_rdd, self.pysc, AutoBatchedSerializer(ser))
+        tiles = [x[1] for x in rdd.collect()]
+
+        return tiles
+
+    def test_whole_tiles(self):
+
+        geotrellis_tiles = self.read_singleband_geotrellis()
+
+        file_paths = self.get_filepaths(self.dir_path)
+        rasterio_tiles = self.read_geotiff_rasterio(file_paths, False)
+
+        for x, y in zip(geotrellis_tiles, rasterio_tiles):
+            self.assertTrue((x == y).all())
+
+
+    def windowed_result_checker(self, windowed_tiles):
+        self.assertEqual(len(windowed_tiles), 24)
+
+    def test_windowed_tiles(self):
+        options = {
+                'maxTileSize': 256,
+                }
+
+        geotrellis_tiles = self.read_singleband_geotrellis(options)
+
+        file_paths = self.get_filepaths(self.dir_path)
+        rasterio_tiles = self.read_geotiff_rasterio(file_paths, True)
+
+        self.windowed_result_checker(geotrellis_tiles)
+
+        for x, y in zip(geotrellis_tiles, rasterio_tiles):
+            self.assertTrue((x == y).all())
+
+
+class Multiband(GeoTiffIOTest, unittest.TestCase):
+    dir_path = test_path("one-month-tiles-multiband/")
+
+    def read_multiband_geotrellis(self, options=None):
+        if options is None:
+            tup = self.hadoop_wrapper.spatialMultiband(self.dir_path, self.sc)
+        else:
+            tup = self.hadoop_wrapper.spatialMultiband(self.dir_path, options, self.sc)
+
+        (java_rdd, schema) = (tup._1(), tup._2())
+
+        ser = AvroSerializer(schema)
+        rdd = RDD(java_rdd, self.pysc, AutoBatchedSerializer(ser))
+        collection = rdd.collect()
+
+        tiles = [x[1] for x in collection]
+
+        return tiles
+
+    def test_whole_tiles(self):
+        geotrellis_tiles = self.read_multiband_geotrellis()
+
+        file_paths = self.get_filepaths(self.dir_path)
+        rasterio_tiles = self.read_geotiff_rasterio(file_paths, False)
+
+        for x, y in zip(geotrellis_tiles, rasterio_tiles):
+            self.assertTrue((x == y).all())
+
+    def windowed_result_checker(self, windowed_tiles):
+        self.assertEqual(len(windowed_tiles), 4)
+
+    def test_windowed_tiles(self):
+        options = {
+                'maxTileSize': 256,
+                }
+
+        geotrellis_tiles = self.read_multiband_geotrellis(options=options)
+
+        file_paths = self.get_filepaths(self.dir_path)
+        rasterio_tiles = self.read_geotiff_rasterio(file_paths, True)
+
+        self.windowed_result_checker(geotrellis_tiles)
+
+        for x, y in zip(geotrellis_tiles, rasterio_tiles):
+            self.assertTrue((x == y).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/geopyspark/tests/projected_extent_test.py
+++ b/geopyspark/tests/projected_extent_test.py
@@ -1,0 +1,38 @@
+#!/bin/env python3
+
+from pyspark import SparkConf, SparkContext, RDD
+from pyspark.serializers import Serializer, FramedSerializer, AutoBatchedSerializer
+from py4j.java_gateway import java_import
+from geopyspark.avroserializer import AvroSerializer
+
+import io
+import sys
+
+
+def get_rdd(pysc):
+    sc = pysc._jsc.sc()
+    pew = pysc._gateway.jvm.ProjectedExtentWrapper
+
+    tup = pew.testOut(sc)
+    (java_rdd, schema) = (tup._1(), tup._2())
+
+    ser = AvroSerializer(schema)
+    return (RDD(java_rdd, pysc, AutoBatchedSerializer(ser)), schema)
+
+def set_rdd(pysc, rdd, schema):
+    ser = AvroSerializer(schema)
+    dumped = rdd.map(lambda s: ser.dumps(s, schema))
+    arrs = dumped.map(lambda s: bytearray(s))
+
+    new_java_rdd = dumped._to_java_object_rdd()
+    ew = pysc._gateway.jvm.ProjectedExtentWrapper
+
+    ew.testIn(new_java_rdd.rdd(), schema)
+
+if __name__ == "__main__":
+    sc = SparkContext(master="local", appName="projectedextent-test")
+
+    java_import(sc._gateway.jvm, "geopyspark.geotrellis.ProjectedExtentWrapper")
+
+    (extents, schema) = get_rdd(sc)
+    set_rdd(sc, extents, schema)

--- a/geopyspark/tests/python_test_utils.py
+++ b/geopyspark/tests/python_test_utils.py
@@ -6,14 +6,11 @@ import os
 
 
 def test_path(string):
-    return "geopyspark/tests/data_files/geotiff_test_files/" + string
+    return "".join(["geopyspark/tests/data_files/geotiff_test_files/", string])
 
 def check_directory():
-    path = "geopyspark/tests/data_files/geotiff_test_files"
-    if not path.exists(path):
-        zip_files = zipped(path)
-        for f in zip_files:
-            if f.endswith('/'):
-                os.makedirs(f)
-            else:
-                zipped.extract(f)
+    test_path = "geopyspark/tests/data_files/geotiff_test_files/"
+    if not path.exists(test_path):
+        zip_files = zipped('geopyspark/tests/data_files/geotiff_test_files.zip')
+        zip_files.extractall('geopyspark/tests/data_files/')
+        zip_files.close()

--- a/geopyspark/tests/python_test_utils.py
+++ b/geopyspark/tests/python_test_utils.py
@@ -1,0 +1,19 @@
+from os import path
+from zipfile import ZipFile as zipped
+
+import numpy as np
+import os
+
+
+def test_path(string):
+    return "geopyspark/tests/data_files/geotiff_test_files/" + string
+
+def check_directory():
+    path = "geopyspark/tests/data_files/geotiff_test_files"
+    if not path.exists(path):
+        zip_files = zipped(path)
+        for f in zip_files:
+            if f.endswith('/'):
+                os.makedirs(f)
+            else:
+                zipped.extract(f)

--- a/geopyspark/tests/temporal_projected_extent_test.py
+++ b/geopyspark/tests/temporal_projected_extent_test.py
@@ -1,0 +1,38 @@
+#!/bin/env python3
+
+from pyspark import SparkConf, SparkContext, RDD
+from pyspark.serializers import Serializer, FramedSerializer, AutoBatchedSerializer
+from py4j.java_gateway import java_import
+from geopyspark.avroserializer import AvroSerializer
+
+import io
+import sys
+
+
+def get_rdd(pysc):
+    sc = pysc._jsc.sc()
+    tpew = pysc._gateway.jvm.TemporalProjectedExtentWrapper
+
+    tup = tpew.testOut(sc)
+    (java_rdd, schema) = (tup._1(), tup._2())
+
+    ser = AvroSerializer(schema)
+    return (RDD(java_rdd, pysc, AutoBatchedSerializer(ser)), schema)
+
+def set_rdd(pysc, rdd, schema):
+    ser = AvroSerializer(schema)
+    dumped = rdd.map(lambda s: ser.dumps(s, schema))
+    arrs = dumped.map(lambda s: bytearray(s))
+
+    new_java_rdd = dumped._to_java_object_rdd()
+    ew = pysc._gateway.jvm.TemporalProjectedExtentWrapper
+
+    ew.testIn(new_java_rdd.rdd(), schema)
+
+if __name__ == "__main__":
+    sc = SparkContext(master="local", appName="temporalprojectedextent-test")
+
+    java_import(sc._gateway.jvm, "geopyspark.geotrellis.TemporalProjectedExtentWrapper")
+
+    (extents, schema) = get_rdd(sc)
+    set_rdd(sc, extents, schema)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,12 @@ setup(
         download_url='http://github.com/geotrellis/geopyspark',
         author_email='jbouffard@azavea.com',
         version='0.1',
-        install_requires=['avro-python3>=1.8', 'numpy>=1', 'shapely>=1.6b3'],
+        install_requires=[
+            'avro-python3>=1.8',
+            'numpy>=1',
+            'shapely>=1.6b3',
+            'rasterio>=0.36.0'
+            ],
         packages=['geopyspark'],
         scripts=[],
         name='geopyspark'


### PR DESCRIPTION
For this PR to work, this [PR](https://github.com/locationtech/geotrellis/pull/1971) must first be merged.

This PR adds the `HadoopGeoTiffRDDWRapper` to GeoPySpark. Thus, allowing users to read in geotiffs both local and on HDFS as `RDD`s into GeoPySpark. In addition, this PR adds a new testing framework for GeoPySpark.

To run the tests in this PR, simply go to the root folder of `GeoPySpark` and run `make run-all`. This will reassemble the scala backend, reinstall `GeoPySpark`, and then run `./spark-submit`.