### PR TITLE
Tile to Layout Method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,5 @@ script:
   - "export JAVA_HOME=/usr/lib/jvm/java-8-oracle"
   - cd geopyspark-backend && ./sbt "project geotrellis-backend" assembly
   - cd .. && pytest -k "not methods"
-  - pytest geopyspark/tests/tile_layer_methods_test.py
+  - pytest -k "cut_tiles" geopyspark/tests/tile_layer_methods_test.py
+  - pytest -k "tile_to_layout" geopyspark/tests/tile_layer_methods_test.py

--- a/geopyspark/geotrellis/tile_layer_methods.py
+++ b/geopyspark/geotrellis/tile_layer_methods.py
@@ -106,3 +106,29 @@ class TileLayerMethods(metaclass=SingletonBase):
                         self.geopysc,
                         result._2(),
                         self.avroregistry)
+
+    def tile_to_layout(self,
+                       rdd,
+                       tile_layout_metadata,
+                       resample_method=None):
+
+        schema_json = json.loads(rdd.schema)
+        types = self._get_key_value_types(schema_json)
+        java_rdd = self._convert_to_java_rdd(rdd)
+
+        if resample_method is None:
+            resample_dict = {}
+        else:
+            resample_dict = {"resampleMethod": resample_method}
+
+        result = self._tiler_wrapper.tileToLayout(types[0],
+                                                  types[1],
+                                                  java_rdd.rdd(),
+                                                  rdd.schema,
+                                                  json.dumps(tile_layer_metadata),
+                                                  resample_dict)
+
+        return GeoPyRDD(result._1(),
+                        self.geopysc,
+                        result._2(),
+                        self.avroregistry)

--- a/geopyspark/tests/tile_layer_methods_test.py
+++ b/geopyspark/tests/tile_layer_methods_test.py
@@ -63,6 +63,20 @@ class TileLayerMethodsTest(unittest.TestCase):
         self.assertEqual([0,0], [key_bounds.col, key_bounds.row])
         self.assertTrue((self.value[1] == tile).all())
 
+    def test_tile_to_layout(self):
+        metadata = self.methods.collect_metadata(self.rdd,
+                                                 self.new_extent,
+                                                 self.layout,
+                                                 epsg_code=self.value[0].epsg_code)
+
+        result = self.methods.cut_tiles(self.rdd,
+                                        metadata)
+
+        (key_bounds, tile) = result.collect()[0]
+
+        self.assertEqual([0,0], [key_bounds.col, key_bounds.row])
+        self.assertTrue((self.value[1] == tile).all())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR is based on another branch that is still under review, #34 . The main feature that is added in this PR is the ability to restructure an RDD into a specified TileLayoutDefinition.