### PR TITLE
Test Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,4 @@ script:
   - "export SPARK_HOME=./spark-2.1.0-bin-hadoop2.7/"
   - "export JAVA_HOME=/usr/lib/jvm/java-8-oracle"
   - cd geopyspark-backend && ./sbt "project geotrellis-backend" assembly
-  - cd .. && pytest -k "not methods"
-  - pytest -k "cut_tiles" geopyspark/tests/tile_layer_methods_test.py
-  - pytest -k "tile_to_layout" geopyspark/tests/tile_layer_methods_test.py
-  - pytest -k "merge" geopyspark/tests/tile_layer_methods_test.py
+  - cd .. && pytest

--- a/geopyspark/tests/base_test_class.py
+++ b/geopyspark/tests/base_test_class.py
@@ -1,0 +1,11 @@
+from pyspark import SparkContext
+from geopyspark.geopycontext import GeoPyContext
+
+import unittest
+import pytest
+
+
+class BaseTestClass(unittest.TestCase):
+    pysc = SparkContext(master="local[*]",
+                        appName="metadata-test")
+    geopysc = GeoPyContext(pysc)

--- a/geopyspark/tests/base_test_class.py
+++ b/geopyspark/tests/base_test_class.py
@@ -7,5 +7,5 @@ import pytest
 
 class BaseTestClass(unittest.TestCase):
     pysc = SparkContext(master="local[*]",
-                        appName="metadata-test")
+                        appName="test")
     geopysc = GeoPyContext(pysc)

--- a/geopyspark/tests/extent_test.py
+++ b/geopyspark/tests/extent_test.py
@@ -7,33 +7,25 @@ from py4j.java_gateway import java_import
 from geopyspark.geotrellis.extent import Extent
 from geopyspark.avroserializer import AvroSerializer
 from geopyspark.avroregistry import AvroRegistry
+from geopyspark.tests.base_test_class import BaseTestClass
 
 import unittest
 import pytest
 
 
-class ExtentSchemaTest(unittest.TestCase):
-    def setUp(self):
-        self.pysc = SparkContext(master="local[*]", appName="extent-test")
-        self.path = "geopyspark.geotrellis.tests.schemas.ExtentWrapper"
-        java_import(self.pysc._gateway.jvm, self.path)
-
-    @pytest.fixture(autouse=True)
-    def tearDown(self):
-        yield
-        self.pysc.stop()
-        self.pysc._gateway.close()
-
+class ExtentSchemaTest(BaseTestClass):
+    path = "geopyspark.geotrellis.tests.schemas.ExtentWrapper"
+    java_import(BaseTestClass.pysc._gateway.jvm, path)
 
     def get_rdd(self):
-        sc = self.pysc._jsc.sc()
-        ew = self.pysc._gateway.jvm.ExtentWrapper
+        sc = BaseTestClass.pysc._jsc.sc()
+        ew = BaseTestClass.pysc._gateway.jvm.ExtentWrapper
 
         tup = ew.testOut(sc)
         (java_rdd, schema) = (tup._1(), tup._2())
 
         ser = AvroSerializer(schema)
-        return (RDD(java_rdd, self.pysc, AutoBatchedSerializer(ser)), schema)
+        return (RDD(java_rdd, BaseTestClass.pysc, AutoBatchedSerializer(ser)), schema)
 
     def get_extents(self):
         (extents, schema) = self.get_rdd()
@@ -47,10 +39,10 @@ class ExtentSchemaTest(unittest.TestCase):
         actual_encoded = encoded.collect()
 
         expected_encoded = [
-                {'xmin': 0, 'ymin': 0, 'xmax': 1, 'ymax': 1},
-                {'xmin': 1, 'ymin': 2, 'xmax': 3, 'ymax': 4},
-                {'xmin': 5, 'ymin': 6, 'xmax': 7, 'ymax': 8}
-                ]
+            {'xmin': 0, 'ymin': 0, 'xmax': 1, 'ymax': 1},
+            {'xmin': 1, 'ymin': 2, 'xmax': 3, 'ymax': 4},
+            {'xmin': 5, 'ymin': 6, 'xmax': 7, 'ymax': 8}
+        ]
 
         for actual, expected in zip(actual_encoded, expected_encoded):
             self.assertEqual(actual, expected)
@@ -59,10 +51,10 @@ class ExtentSchemaTest(unittest.TestCase):
         actual_extents = self.get_extents()
 
         expected_extents = [
-                Extent(0, 0, 1, 1),
-                Extent(1, 2, 3, 4),
-                Extent(5, 6, 7, 8)
-                ]
+            Extent(0, 0, 1, 1),
+            Extent(1, 2, 3, 4),
+            Extent(5, 6, 7, 8)
+        ]
 
         for actual, expected in zip(actual_extents, expected_extents):
             self.assertEqual(actual, expected)

--- a/geopyspark/tests/hadoop_geotiff_rdd_test.py
+++ b/geopyspark/tests/hadoop_geotiff_rdd_test.py
@@ -5,6 +5,7 @@ check_directory()
 from pyspark import SparkContext
 from geopyspark.geotrellis.geotiff_rdd import HadoopGeoTiffRDD
 from geopyspark.geopycontext import GeoPyContext
+from geopyspark.tests.base_test_class import BaseTestClass
 from os import walk, path
 
 import rasterio
@@ -41,20 +42,11 @@ class GeoTiffIOTest(object):
         return rasterio_tiles
 
 
-class Singleband(GeoTiffIOTest, unittest.TestCase):
-    def setUp(self):
-        self.geopysc = GeoPyContext.construct(
-            master="local[*]", appName="hadoop-singleband-geotiff-test")
-        self.hadoop_geotiff = HadoopGeoTiffRDD(self.geopysc)
+class Singleband(GeoTiffIOTest, BaseTestClass):
+    hadoop_geotiff = HadoopGeoTiffRDD(BaseTestClass.geopysc)
 
-        self.dir_path = geotiff_test_path("one-month-tiles/")
-        self.options = {'maxTileSize': 256}
-
-    @pytest.fixture(autouse=True)
-    def tearDown(self):
-        yield
-        self.geopysc.pysc.stop()
-        self.geopysc.pysc._gateway.close()
+    dir_path = geotiff_test_path("one-month-tiles/")
+    options = {'maxTileSize': 256}
 
     def read_singleband_geotrellis(self, options=None):
         if options is None:
@@ -88,19 +80,10 @@ class Singleband(GeoTiffIOTest, unittest.TestCase):
             self.assertTrue((x == y).all())
 
 
-class Multiband(GeoTiffIOTest, unittest.TestCase):
-    def setUp(self):
-        self.geopysc = GeoPyContext.construct(
-            master="local[*]", appName="hadoop-multiband-geotiff-test")
-        self.hadoop_geotiff = HadoopGeoTiffRDD(self.geopysc)
-        self.dir_path = geotiff_test_path("one-month-tiles-multiband/")
-        self.options = {'maxTileSize': 256}
-
-    @pytest.fixture(autouse=True)
-    def tearDown(self):
-        yield
-        self.geopysc.pysc.stop()
-        self.geopysc.pysc._gateway.close()
+class Multiband(GeoTiffIOTest, BaseTestClass):
+    hadoop_geotiff = HadoopGeoTiffRDD(BaseTestClass.geopysc)
+    dir_path = geotiff_test_path("one-month-tiles-multiband/")
+    options = {'maxTileSize': 256}
 
     def read_multiband_geotrellis(self, options=None):
         if options is None:

--- a/geopyspark/tests/key_value_test.py
+++ b/geopyspark/tests/key_value_test.py
@@ -8,6 +8,7 @@ from geopyspark.avroserializer import AvroSerializer
 from geopyspark.geotrellis.extent import Extent
 from geopyspark.geotrellis.tile import TileArray
 from geopyspark.avroregistry import AvroRegistry
+from geopyspark.tests.base_test_class import BaseTestClass
 
 import numpy as np
 import unittest
@@ -15,39 +16,31 @@ import pytest
 
 
 class KeyValueRecordSchemaTest(unittest.TestCase):
-    def setUp(self):
-        self.pysc = SparkContext(master="local[*]", appName="key-value-test")
-        path = "geopyspark.geotrellis.tests.schemas.KeyValueRecordWrapper"
-        java_import(self.pysc._gateway.jvm, path)
+    path = "geopyspark.geotrellis.tests.schemas.KeyValueRecordWrapper"
+    java_import(BaseTestClass.pysc._gateway.jvm, path)
 
-        self.extents = [Extent(0, 0, 1, 1), Extent(1, 2, 3, 4), Extent(5, 6, 7, 8)]
-        self.arrs = [
-                TileArray(np.array(bytearray([0, 1, 2, 3, 4, 5])).reshape(3, 2), -128),
-                TileArray(np.array(bytearray([0, 1, 2, 3, 4, 5])).reshape(2, 3), -128),
-                TileArray(np.array(bytearray([0, 1, 2, 3, 4, 5])).reshape(6, 1), -128)
-                ]
+    extents = [Extent(0, 0, 1, 1), Extent(1, 2, 3, 4), Extent(5, 6, 7, 8)]
+    arrs = [
+        TileArray(np.array(bytearray([0, 1, 2, 3, 4, 5])).reshape(3, 2), -128),
+        TileArray(np.array(bytearray([0, 1, 2, 3, 4, 5])).reshape(2, 3), -128),
+        TileArray(np.array(bytearray([0, 1, 2, 3, 4, 5])).reshape(6, 1), -128)
+    ]
 
-        self.tuple_list= [
-                (self.arrs[0], self.extents[0]),
-                (self.arrs[1], self.extents[1]),
-                (self.arrs[2], self.extents[2])
-                ]
-
-    @pytest.fixture(autouse=True)
-    def tearDown(self):
-        yield
-        self.pysc.stop()
-        self.pysc._gateway.close()
+    tuple_list= [
+        (arrs[0], extents[0]),
+        (arrs[1], extents[1]),
+        (arrs[2], extents[2])
+    ]
 
     def get_rdd(self):
-        sc = self.pysc._jsc.sc()
-        ew = self.pysc._gateway.jvm.KeyValueRecordWrapper
+        sc = BaseTestClass.pysc._jsc.sc()
+        ew = BaseTestClass.pysc._gateway.jvm.KeyValueRecordWrapper
 
         tup = ew.testOut(sc)
         (java_rdd, schema) = (tup._1(), tup._2())
 
         ser = AvroSerializer(schema)
-        return (RDD(java_rdd, self.pysc, AutoBatchedSerializer(ser)), schema)
+        return (RDD(java_rdd, BaseTestClass.pysc, AutoBatchedSerializer(ser)), schema)
 
     def get_kvs(self):
         (kvs, schema) = self.get_rdd()
@@ -62,13 +55,13 @@ class KeyValueRecordSchemaTest(unittest.TestCase):
         actual_encoded = encoded.collect()
 
         pairs = [AvroRegistry.tuple_encoder(x,
-            AvroRegistry.tile_encoder,
-            AvroRegistry.extent_encoder) for x in self.tuple_list]
+                                            AvroRegistry.tile_encoder,
+                                            AvroRegistry.extent_encoder) for x in self.tuple_list]
 
         expected_encoded = [
-                {'pairs': pairs},
-                {'pairs': pairs},
-                ]
+            {'pairs': pairs},
+            {'pairs': pairs},
+        ]
 
         self.assertEqual(actual_encoded, expected_encoded)
 
@@ -76,9 +69,9 @@ class KeyValueRecordSchemaTest(unittest.TestCase):
         actual_kvs = self.get_kvs()
 
         expected_kvs = [
-                self.tuple_list,
-                self.tuple_list
-                ]
+            self.tuple_list,
+            self.tuple_list
+        ]
 
         for actual_tuples, expected_tuples in zip(actual_kvs, expected_kvs):
             for actual, expected in zip(actual_tuples, expected_tuples):

--- a/geopyspark/tests/keys_test.py
+++ b/geopyspark/tests/keys_test.py
@@ -7,32 +7,25 @@ from py4j.java_gateway import java_import
 from geopyspark.geotrellis.keys import SpatialKey, SpaceTimeKey
 from geopyspark.avroserializer import AvroSerializer
 from geopyspark.avroregistry import AvroRegistry
+from geopyspark.tests.base_test_class import BaseTestClass
 
 import unittest
 import pytest
 
 
-class SpatialKeySchemaTest(unittest.TestCase):
-    def setUp(self):
-        self.pysc = SparkContext(master="local[*]", appName="spatial-key-test")
-        self.path = "geopyspark.geotrellis.tests.schemas.SpatialKeyWrapper"
-        java_import(self.pysc._gateway.jvm, self.path)
-
-    @pytest.fixture(autouse=True)
-    def tearDown(self):
-        yield
-        self.pysc.stop()
-        self.pysc._gateway.close()
+class SpatialKeySchemaTest(BaseTestClass):
+    path = "geopyspark.geotrellis.tests.schemas.SpatialKeyWrapper"
+    java_import(BaseTestClass.pysc._gateway.jvm, path)
 
     def get_rdd(self):
-        sc = self.pysc._jsc.sc()
-        ew = self.pysc._gateway.jvm.SpatialKeyWrapper
+        sc = BaseTestClass.pysc._jsc.sc()
+        ew = BaseTestClass.pysc._gateway.jvm.SpatialKeyWrapper
 
         tup = ew.testOut(sc)
         (java_rdd, schema) = (tup._1(), tup._2())
 
         ser = AvroSerializer(schema)
-        return (RDD(java_rdd, self.pysc, AutoBatchedSerializer(ser)), schema)
+        return (RDD(java_rdd, BaseTestClass.pysc, AutoBatchedSerializer(ser)), schema)
 
     def get_skeys(self):
         (skeys, schema) = self.get_rdd()
@@ -63,26 +56,20 @@ class SpatialKeySchemaTest(unittest.TestCase):
             self.assertEqual(actual, expected)
 
 
-class SpaceTimeKeySchemaTest(unittest.TestCase):
-    def setUp(self):
-        self.pysc = SparkContext(master="local[*]", appName="spacetime-key-test")
-        self.path = "geopyspark.geotrellis.tests.schemas.SpaceTimeKeyWrapper"
-        java_import(self.pysc._gateway.jvm, self.path)
-
-    def tearDown(self):
-        self.pysc.stop()
-        self.pysc._gateway.close()
+class SpaceTimeKeySchemaTest(BaseTestClass):
+    path = "geopyspark.geotrellis.tests.schemas.SpaceTimeKeyWrapper"
+    java_import(BaseTestClass.pysc._gateway.jvm, path)
 
     def get_rdd(self):
-        java_import(self.pysc._gateway.jvm, self.path)
-        sc = self.pysc._jsc.sc()
-        ew = self.pysc._gateway.jvm.SpaceTimeKeyWrapper
+        java_import(BaseTestClass.pysc._gateway.jvm, self.path)
+        sc = BaseTestClass.pysc._jsc.sc()
+        ew = BaseTestClass.pysc._gateway.jvm.SpaceTimeKeyWrapper
 
         tup = ew.testOut(sc)
         (java_rdd, schema) = (tup._1(), tup._2())
 
         ser = AvroSerializer(schema)
-        return (RDD(java_rdd, self.pysc, AutoBatchedSerializer(ser)), schema)
+        return (RDD(java_rdd, BaseTestClass.pysc, AutoBatchedSerializer(ser)), schema)
 
     def get_skeys(self):
         (skeys, schema) = self.get_rdd()

--- a/geopyspark/tests/multiband_test.py
+++ b/geopyspark/tests/multiband_test.py
@@ -7,36 +7,29 @@ from py4j.java_gateway import java_import
 from geopyspark.avroserializer import AvroSerializer
 from geopyspark.geotrellis.tile import TileArray
 from geopyspark.avroregistry import AvroRegistry
+from geopyspark.tests.base_test_class import BaseTestClass
 
 import numpy as np
 import unittest
 import pytest
 
 
-class MultibandSchemaTest(unittest.TestCase):
-    def setUp(self):
-        self.pysc = SparkContext(master="local[*]", appName="multibandtile-test")
-        self.path = "geopyspark.geotrellis.tests.schemas.ArrayMultibandTileWrapper"
-        java_import(self.pysc._gateway.jvm, self.path)
+class MultibandSchemaTest(BaseTestClass):
+    path = "geopyspark.geotrellis.tests.schemas.ArrayMultibandTileWrapper"
+    java_import(BaseTestClass.pysc._gateway.jvm, path)
 
-        self.arr = TileArray(np.array(bytearray([0, 0, 1, 1])).reshape(2, 2), -128)
-        self.multiband_tile = [self.arr, self.arr, self.arr]
-
-    @pytest.fixture(autouse=True)
-    def tearDown(self):
-        yield
-        self.pysc.stop()
-        self.pysc._gateway.close()
+    arr = TileArray(np.array(bytearray([0, 0, 1, 1])).reshape(2, 2), -128)
+    multiband_tile = [arr, arr, arr]
 
     def get_rdd(self):
-        sc = self.pysc._jsc.sc()
-        mw = self.pysc._gateway.jvm.ArrayMultibandTileWrapper
+        sc = BaseTestClass.pysc._jsc.sc()
+        mw = BaseTestClass.pysc._gateway.jvm.ArrayMultibandTileWrapper
 
         tup = mw.testOut(sc)
         (java_rdd, schema) = (tup._1(), tup._2())
 
         ser = AvroSerializer(schema)
-        return (RDD(java_rdd, self.pysc, AutoBatchedSerializer(ser)), schema)
+        return (RDD(java_rdd, BaseTestClass.pysc, AutoBatchedSerializer(ser)), schema)
 
     def get_multibands(self):
         (multibands, schema) = self.get_rdd()

--- a/geopyspark/tests/projected_extent_test.py
+++ b/geopyspark/tests/projected_extent_test.py
@@ -8,34 +8,27 @@ from geopyspark.avroserializer import AvroSerializer
 from geopyspark.geotrellis.extent import Extent
 from geopyspark.geotrellis.projected_extent import ProjectedExtent
 from geopyspark.avroregistry import AvroRegistry
+from geopyspark.tests.base_test_class import BaseTestClass
 
 import unittest
 import pytest
 
 
-class ProjectedExtentSchemaTest(unittest.TestCase):
-    def setUp(self):
-        self.pysc = SparkContext(master="local[*]", appName="projectedextent-test")
-        self.path = "geopyspark.geotrellis.tests.schemas.ProjectedExtentWrapper"
-        java_import(self.pysc._gateway.jvm, self.path)
+class ProjectedExtentSchemaTest(BaseTestClass):
+    path = "geopyspark.geotrellis.tests.schemas.ProjectedExtentWrapper"
+    java_import(BaseTestClass.pysc._gateway.jvm, path)
 
-        self.extents = [Extent(0, 0, 1, 1), Extent(1, 2, 3, 4), Extent(5, 6, 7, 8)]
-
-    @pytest.fixture(autouse=True)
-    def tearDown(self):
-        yield
-        self.pysc.stop()
-        self.pysc._gateway.close()
+    extents = [Extent(0, 0, 1, 1), Extent(1, 2, 3, 4), Extent(5, 6, 7, 8)]
 
     def get_rdd(self):
-        sc = self.pysc._jsc.sc()
-        ew = self.pysc._gateway.jvm.ProjectedExtentWrapper
+        sc = BaseTestClass.pysc._jsc.sc()
+        ew = BaseTestClass.pysc._gateway.jvm.ProjectedExtentWrapper
 
         tup = ew.testOut(sc)
         (java_rdd, schema) = (tup._1(), tup._2())
 
         ser = AvroSerializer(schema)
-        return (RDD(java_rdd, self.pysc, AutoBatchedSerializer(ser)), schema)
+        return (RDD(java_rdd, BaseTestClass.pysc, AutoBatchedSerializer(ser)), schema)
 
     def get_pextents(self):
         (pextents, schema) = self.get_rdd()

--- a/geopyspark/tests/s3_geotiff_rdd_test.py
+++ b/geopyspark/tests/s3_geotiff_rdd_test.py
@@ -5,6 +5,7 @@ check_directory()
 from pyspark import SparkContext
 from geopyspark.geotrellis.geotiff_rdd import S3GeoTiffRDD
 from geopyspark.geopycontext import GeoPyContext
+from geopyspark.tests.base_test_class import BaseTestClass
 from py4j.java_gateway import java_import
 from os import walk, path
 
@@ -41,24 +42,14 @@ class S3GeoTiffIOTest(object):
         return rasterio_tiles
 
 
-class Singleband(S3GeoTiffIOTest, unittest.TestCase):
-    def setUp(self):
-        pysc = SparkContext(master="local[*]", appName="s3-singlebandgeotiff-test")
-        self.geopysc = GeoPyContext(pysc)
+class Singleband(S3GeoTiffIOTest, BaseTestClass):
+    java_import(BaseTestClass.geopysc._jvm,
+            "geopyspark.geotrellis.testkit.MockS3ClientWrapper")
 
-        java_import(self.geopysc._jvm,
-                "geopyspark.geotrellis.testkit.MockS3ClientWrapper")
+    mock_wrapper = BaseTestClass.geopysc._jvm.MockS3ClientWrapper
+    client = mock_wrapper.mockClient()
 
-        self.mock_wrapper = self.geopysc._jvm.MockS3ClientWrapper
-        self.client = self.mock_wrapper.mockClient()
-
-        self.s3_geotiff = S3GeoTiffRDD(self.geopysc)
-
-    @pytest.fixture(autouse=True)
-    def tearDown(self):
-        yield
-        self.geopysc.pysc.stop()
-        self.geopysc.pysc._gateway.close()
+    s3_geotiff = S3GeoTiffRDD(BaseTestClass.geopysc)
 
     key = "one-month-tiles/test-200506000000_0_0.tif"
     bucket = "test"
@@ -97,24 +88,14 @@ class Singleband(S3GeoTiffIOTest, unittest.TestCase):
             self.assertTrue((x == y).all())
 
 
-class Multiband(S3GeoTiffIOTest, unittest.TestCase):
-    def setUp(self):
-        pysc = SparkContext(master="local[*]", appName="s3-multibandgeotiff-test")
-        self.geopysc = GeoPyContext(pysc)
+class Multiband(S3GeoTiffIOTest, BaseTestClass):
+    java_import(BaseTestClass.geopysc._jvm,
+            "geopyspark.geotrellis.testkit.MockS3ClientWrapper")
 
-        java_import(self.geopysc._jvm,
-                "geopyspark.geotrellis.testkit.MockS3ClientWrapper")
+    mock_wrapper = BaseTestClass.geopysc._jvm.MockS3ClientWrapper
+    client = mock_wrapper.mockClient()
 
-        self.mock_wrapper = self.geopysc._jvm.MockS3ClientWrapper
-        self.client = self.mock_wrapper.mockClient()
-
-        self.s3_geotiff = S3GeoTiffRDD(self.geopysc)
-
-    @pytest.fixture(autouse=True)
-    def tearDown(self):
-        yield
-        self.geopysc.pysc.stop()
-        self.geopysc.pysc._gateway.close()
+    s3_geotiff = S3GeoTiffRDD(BaseTestClass.geopysc)
 
     key = "one-month-tiles-multiband/result.tif"
     bucket = "test"

--- a/geopyspark/tests/temporal_projected_extent_test.py
+++ b/geopyspark/tests/temporal_projected_extent_test.py
@@ -8,33 +8,26 @@ from geopyspark.avroserializer import AvroSerializer
 from geopyspark.geotrellis.extent import Extent
 from geopyspark.geotrellis.temporal_projected_extent import TemporalProjectedExtent
 from geopyspark.avroregistry import AvroRegistry
+from geopyspark.tests.base_test_class import BaseTestClass
 
 import unittest
 import pytest
 
 
-class TemporalProjectedExtentSchemaTest(unittest.TestCase):
-    def setUp(self):
-        self.pysc = SparkContext(master="local[*]", appName="tpe-test")
-        self.path = "geopyspark.geotrellis.tests.schemas.TemporalProjectedExtentWrapper"
-        java_import(self.pysc._gateway.jvm, self.path)
-        self.extents = [Extent(0, 0, 1, 1), Extent(1, 2, 3, 4), Extent(5, 6, 7, 8)]
-
-    @pytest.fixture(autouse=True)
-    def tearDown(self):
-        yield
-        self.pysc.stop()
-        self.pysc._gateway.close()
+class TemporalProjectedExtentSchemaTest(BaseTestClass):
+    path = "geopyspark.geotrellis.tests.schemas.TemporalProjectedExtentWrapper"
+    java_import(BaseTestClass.pysc._gateway.jvm, path)
+    extents = [Extent(0, 0, 1, 1), Extent(1, 2, 3, 4), Extent(5, 6, 7, 8)]
 
     def get_rdd(self):
-        sc = self.pysc._jsc.sc()
-        ew = self.pysc._gateway.jvm.TemporalProjectedExtentWrapper
+        sc = BaseTestClass.pysc._jsc.sc()
+        ew = BaseTestClass.pysc._gateway.jvm.TemporalProjectedExtentWrapper
 
         tup = ew.testOut(sc)
         (java_rdd, schema) = (tup._1(), tup._2())
 
         ser = AvroSerializer(schema)
-        return (RDD(java_rdd, self.pysc, AutoBatchedSerializer(ser)), schema)
+        return (RDD(java_rdd, BaseTestClass.pysc, AutoBatchedSerializer(ser)), schema)
 
     def get_tpextents(self):
         (tpextents, schema) = self.get_rdd()

--- a/geopyspark/tests/tile_layer_metadata_test.py
+++ b/geopyspark/tests/tile_layer_metadata_test.py
@@ -8,27 +8,19 @@ from geopyspark.geotrellis.geotiff_rdd import HadoopGeoTiffRDD
 from py4j.java_gateway import java_import
 from geopyspark.avroserializer import AvroSerializer
 from geopyspark.geopycontext import GeoPyContext
+from geopyspark.tests.base_test_class import BaseTestClass
 
 import unittest
 import pytest
 import json
 
 
-class TileLayerMetadataTest(unittest.TestCase):
-    def setUp(self):
-        pysc = SparkContext(master="local[*]", appName="metadata-test")
-        self.geopysc = GeoPyContext(pysc)
-        self.metadata = TileLayerMethods(self.geopysc)
-        self.hadoop_geotiff = HadoopGeoTiffRDD(self.geopysc)
+class TileLayerMetadataTest(BaseTestClass):
+    metadata = TileLayerMethods(BaseTestClass.geopysc)
+    hadoop_geotiff = HadoopGeoTiffRDD(BaseTestClass.geopysc)
 
-        self.dir_path = geotiff_test_path("all-ones.tif")
-        self.options = {'maxTileSize': 256}
-
-    @pytest.fixture(autouse=True)
-    def tearDown(self):
-        yield
-        self.geopysc.stop()
-        self.geopysc.close_gateway()
+    dir_path = geotiff_test_path("all-ones.tif")
+    options = {'maxTileSize': 256}
 
     def check_results(self, actual, expected):
         if isinstance(actual, list) and isinstance(expected, list):

--- a/geopyspark/tests/tile_layer_methods_test.py
+++ b/geopyspark/tests/tile_layer_methods_test.py
@@ -5,49 +5,40 @@ check_directory()
 from pyspark import SparkContext
 from geopyspark.geotrellis.tile_layer_methods import TileLayerMethods
 from geopyspark.geotrellis.geotiff_rdd import HadoopGeoTiffRDD
-from geopyspark.geopycontext import GeoPyContext
+from geopyspark.tests.base_test_class import BaseTestClass
 
 import unittest
 import pytest
 import numpy as np
 
 
-class TileLayerMethodsTest(unittest.TestCase):
-    def setUp(self):
-        self.pysc = SparkContext(master="local[*]", appName="metadata-test")
-        self.geopysc = GeoPyContext(self.pysc)
-        self.methods = TileLayerMethods(self.geopysc)
-        self.hadoop_geotiff = HadoopGeoTiffRDD(self.geopysc)
+class TileLayerMethodsTest(BaseTestClass):
+    methods = TileLayerMethods(BaseTestClass.geopysc)
+    hadoop_geotiff = HadoopGeoTiffRDD(BaseTestClass.geopysc)
 
-        self.dir_path = geotiff_test_path("all-ones.tif")
-        self.rdd = self.hadoop_geotiff.get_spatial(self.dir_path)
+    dir_path = geotiff_test_path("all-ones.tif")
+    rdd = hadoop_geotiff.get_spatial(dir_path)
 
-        self.value = self.rdd.collect()[0]
+    value = rdd.collect()[0]
 
-        _projected_extent = self.value[0]
-        _old_extent = _projected_extent.extent
+    _projected_extent = value[0]
+    _old_extent = _projected_extent.extent
 
-        self.new_extent = {
-            "xmin": _old_extent.xmin,
-            "ymin": _old_extent.ymin,
-            "xmax": _old_extent.xmax,
-            "ymax": _old_extent.ymax
-        }
+    new_extent = {
+        "xmin": _old_extent.xmin,
+        "ymin": _old_extent.ymin,
+        "xmax": _old_extent.xmax,
+        "ymax": _old_extent.ymax
+    }
 
-        (_rows, _cols) = self.value[1].shape
+    (_rows, _cols) = value[1].shape
 
-        self.layout = {
-            "layoutCols": 1,
-            "layoutRows": 1,
-            "tileCols": _cols,
-            "tileRows": _rows
-        }
-
-    @pytest.fixture(autouse=True)
-    def tearDown(self):
-        yield
-        self.geopysc.pysc.stop()
-        self.geopysc.pysc._gateway.close()
+    layout = {
+        "layoutCols": 1,
+        "layoutRows": 1,
+        "tileCols": _cols,
+        "tileRows": _rows
+    }
 
     def test_cut_tiles(self):
         metadata = self.methods.collect_metadata(self.rdd,

--- a/geopyspark/tests/tile_test.py
+++ b/geopyspark/tests/tile_test.py
@@ -7,6 +7,7 @@ from py4j.java_gateway import java_import
 from geopyspark.avroserializer import AvroSerializer
 from geopyspark.avroregistry import AvroRegistry
 from geopyspark.geotrellis.tile import TileArray
+from geopyspark.tests.base_test_class import BaseTestClass
 
 import numpy as np
 import unittest
@@ -16,33 +17,25 @@ import pytest
 # TODO: CLEANUP THESE TESTS TO MAKE IT MORE DRY
 
 
-class ShortTileSchemaTest(unittest.TestCase):
-    def setUp(self):
-        self.pysc = SparkContext(master="local[*]", appName="short-tile-test")
-        self.path = "geopyspark.geotrellis.tests.schemas.ShortArrayTileWrapper"
-        java_import(self.pysc._gateway.jvm, self.path)
+class ShortTileSchemaTest(BaseTestClass):
+    path = "geopyspark.geotrellis.tests.schemas.ShortArrayTileWrapper"
+    java_import(BaseTestClass.pysc._gateway.jvm, path)
 
-        self.tiles = [
-                TileArray(np.array([0, 0, 1, 1]).reshape(2, 2), -32768),
-                TileArray(np.array([1, 2, 3, 4]).reshape(2, 2), -32768),
-                TileArray(np.array([5, 6, 7, 8]).reshape(2, 2), -32768)
-                ]
-
-    @pytest.fixture(autouse=True)
-    def tearDown(self):
-        yield
-        self.pysc.stop()
-        self.pysc._gateway.close()
+    tiles = [
+        TileArray(np.array([0, 0, 1, 1]).reshape(2, 2), -32768),
+        TileArray(np.array([1, 2, 3, 4]).reshape(2, 2), -32768),
+        TileArray(np.array([5, 6, 7, 8]).reshape(2, 2), -32768)
+    ]
 
     def get_rdd(self):
-        sc = self.pysc._jsc.sc()
-        tw = self.pysc._gateway.jvm.ShortArrayTileWrapper
+        sc = BaseTestClass.pysc._jsc.sc()
+        tw = BaseTestClass.pysc._gateway.jvm.ShortArrayTileWrapper
 
         tup = tw.testOut(sc)
         (java_rdd, schema) = (tup._1(), tup._2())
 
         ser = AvroSerializer(schema)
-        return (RDD(java_rdd, self.pysc, AutoBatchedSerializer(ser)), schema)
+        return (RDD(java_rdd, BaseTestClass.pysc, AutoBatchedSerializer(ser)), schema)
 
     def get_tiles(self):
         (tiles, schema) = self.get_rdd()
@@ -56,10 +49,10 @@ class ShortTileSchemaTest(unittest.TestCase):
         actual_encoded = encoded.collect()
 
         expected_encoded = [
-                {'cols': 2, 'rows': 2, 'cells': [0, 0, 1, 1], 'noDataValue': -32768},
-                {'cols': 2, 'rows': 2, 'cells': [1, 2, 3, 4], 'noDataValue': -32768},
-                {'cols': 2, 'rows': 2, 'cells': [5, 6, 7, 8], 'noDataValue': -32768}
-                ]
+            {'cols': 2, 'rows': 2, 'cells': [0, 0, 1, 1], 'noDataValue': -32768},
+            {'cols': 2, 'rows': 2, 'cells': [1, 2, 3, 4], 'noDataValue': -32768},
+            {'cols': 2, 'rows': 2, 'cells': [5, 6, 7, 8], 'noDataValue': -32768}
+        ]
 
         self.assertEqual(actual_encoded, expected_encoded)
 
@@ -72,33 +65,25 @@ class ShortTileSchemaTest(unittest.TestCase):
             self.assertTrue((actual == expected).all())
 
 
-class UShortTileSchemaTest(unittest.TestCase):
-    def setUp(self):
-        self.pysc = SparkContext(master="local[*]", appName="ushort-tile-test")
-        self.path = "geopyspark.geotrellis.tests.schemas.UShortArrayTileWrapper"
-        java_import(self.pysc._gateway.jvm, self.path)
+class UShortTileSchemaTest(BaseTestClass):
+    path = "geopyspark.geotrellis.tests.schemas.UShortArrayTileWrapper"
+    java_import(BaseTestClass.pysc._gateway.jvm, path)
 
-        self.tiles = [
-                TileArray(np.array([0, 0, 1, 1]).reshape(2, 2), 0),
-                TileArray(np.array([1, 2, 3, 4]).reshape(2, 2), 0),
-                TileArray(np.array([5, 6, 7, 8]).reshape(2, 2), 0)
-                ]
-
-    @pytest.fixture(autouse=True)
-    def tearDown(self):
-        yield
-        self.pysc.stop()
-        self.pysc._gateway.close()
+    tiles = [
+        TileArray(np.array([0, 0, 1, 1]).reshape(2, 2), 0),
+        TileArray(np.array([1, 2, 3, 4]).reshape(2, 2), 0),
+        TileArray(np.array([5, 6, 7, 8]).reshape(2, 2), 0)
+    ]
 
     def get_rdd(self):
-        sc = self.pysc._jsc.sc()
-        tw = self.pysc._gateway.jvm.UShortArrayTileWrapper
+        sc = BaseTestClass.pysc._jsc.sc()
+        tw = BaseTestClass.pysc._gateway.jvm.UShortArrayTileWrapper
 
         tup = tw.testOut(sc)
         (java_rdd, schema) = (tup._1(), tup._2())
 
         ser = AvroSerializer(schema)
-        return (RDD(java_rdd, self.pysc, AutoBatchedSerializer(ser)), schema)
+        return (RDD(java_rdd, BaseTestClass.pysc, AutoBatchedSerializer(ser)), schema)
 
     def get_tiles(self):
         (tiles, schema) = self.get_rdd()
@@ -112,10 +97,10 @@ class UShortTileSchemaTest(unittest.TestCase):
         actual_encoded = encoded.collect()
 
         expected_encoded = [
-                {'cols': 2, 'rows': 2, 'cells': [0, 0, 1, 1], 'noDataValue': 0},
-                {'cols': 2, 'rows': 2, 'cells': [1, 2, 3, 4], 'noDataValue': 0},
-                {'cols': 2, 'rows': 2, 'cells': [5, 6, 7, 8], 'noDataValue': 0}
-                ]
+            {'cols': 2, 'rows': 2, 'cells': [0, 0, 1, 1], 'noDataValue': 0},
+            {'cols': 2, 'rows': 2, 'cells': [1, 2, 3, 4], 'noDataValue': 0},
+            {'cols': 2, 'rows': 2, 'cells': [5, 6, 7, 8], 'noDataValue': 0}
+        ]
 
         self.assertEqual(actual_encoded, expected_encoded)
 
@@ -128,33 +113,25 @@ class UShortTileSchemaTest(unittest.TestCase):
             self.assertTrue((actual == expected).all())
 
 
-class ByteTileSchemaTest(unittest.TestCase):
-    def setUp(self):
-        self.pysc = SparkContext(master="local[*]", appName="byte-tile-test")
-        self.path = "geopyspark.geotrellis.tests.schemas.ByteArrayTileWrapper"
-        java_import(self.pysc._gateway.jvm, self.path)
+class ByteTileSchemaTest(BaseTestClass):
+    path = "geopyspark.geotrellis.tests.schemas.ByteArrayTileWrapper"
+    java_import(BaseTestClass.pysc._gateway.jvm, path)
 
-        self.tiles = [
-                TileArray(np.array(bytearray([0, 0, 1, 1])).reshape(2, 2), -128),
-                TileArray(np.array(bytearray([1, 2, 3, 4])).reshape(2, 2), -128),
-                TileArray(np.array(bytearray([5, 6, 7, 8])).reshape(2, 2), -128)
-                ]
-
-    @pytest.fixture(autouse=True)
-    def tearDown(self):
-        yield
-        self.pysc.stop()
-        self.pysc._gateway.close()
+    tiles = [
+        TileArray(np.array(bytearray([0, 0, 1, 1])).reshape(2, 2), -128),
+        TileArray(np.array(bytearray([1, 2, 3, 4])).reshape(2, 2), -128),
+        TileArray(np.array(bytearray([5, 6, 7, 8])).reshape(2, 2), -128)
+    ]
 
     def get_rdd(self):
-        sc = self.pysc._jsc.sc()
-        tw = self.pysc._gateway.jvm.ByteArrayTileWrapper
+        sc = BaseTestClass.pysc._jsc.sc()
+        tw = BaseTestClass.pysc._gateway.jvm.ByteArrayTileWrapper
 
         tup = tw.testOut(sc)
         (java_rdd, schema) = (tup._1(), tup._2())
 
         ser = AvroSerializer(schema)
-        return (RDD(java_rdd, self.pysc, AutoBatchedSerializer(ser)), schema)
+        return (RDD(java_rdd, BaseTestClass.pysc, AutoBatchedSerializer(ser)), schema)
 
     def get_tiles(self):
         (tiles, schema) = self.get_rdd()
@@ -168,10 +145,10 @@ class ByteTileSchemaTest(unittest.TestCase):
         actual_encoded = encoded.collect()
 
         expected_encoded = [
-                {'cols': 2, 'rows': 2, 'cells': bytearray([0, 0, 1, 1]), 'noDataValue': -128},
-                {'cols': 2, 'rows': 2, 'cells': bytearray([1, 2, 3, 4]), 'noDataValue': -128},
-                {'cols': 2, 'rows': 2, 'cells': bytearray([5, 6, 7, 8]), 'noDataValue': -128}
-                ]
+            {'cols': 2, 'rows': 2, 'cells': bytearray([0, 0, 1, 1]), 'noDataValue': -128},
+            {'cols': 2, 'rows': 2, 'cells': bytearray([1, 2, 3, 4]), 'noDataValue': -128},
+            {'cols': 2, 'rows': 2, 'cells': bytearray([5, 6, 7, 8]), 'noDataValue': -128}
+        ]
 
         self.assertEqual(actual_encoded, expected_encoded)
 
@@ -184,33 +161,25 @@ class ByteTileSchemaTest(unittest.TestCase):
             self.assertTrue((actual == expected).all())
 
 
-class UByteTileSchemaTest(unittest.TestCase):
-    def setUp(self):
-        self.pysc = SparkContext(master="local[*]", appName="ubyte-tile-test")
-        self.path = "geopyspark.geotrellis.tests.schemas.UByteArrayTileWrapper"
-        java_import(self.pysc._gateway.jvm, self.path)
+class UByteTileSchemaTest(BaseTestClass):
+    path = "geopyspark.geotrellis.tests.schemas.UByteArrayTileWrapper"
+    java_import(BaseTestClass.pysc._gateway.jvm, path)
 
-        self.tiles = [
-                TileArray(np.array(bytearray([0, 0, 1, 1])).reshape(2, 2), 0),
-                TileArray(np.array(bytearray([1, 2, 3, 4])).reshape(2, 2), 0),
-                TileArray(np.array(bytearray([5, 6, 7, 8])).reshape(2, 2), 0)
-                ]
-
-    @pytest.fixture(autouse=True)
-    def tearDown(self):
-        yield
-        self.pysc.stop()
-        self.pysc._gateway.close()
+    tiles = [
+        TileArray(np.array(bytearray([0, 0, 1, 1])).reshape(2, 2), 0),
+        TileArray(np.array(bytearray([1, 2, 3, 4])).reshape(2, 2), 0),
+        TileArray(np.array(bytearray([5, 6, 7, 8])).reshape(2, 2), 0)
+    ]
 
     def get_rdd(self):
-        sc = self.pysc._jsc.sc()
-        tw = self.pysc._gateway.jvm.UByteArrayTileWrapper
+        sc = BaseTestClass.pysc._jsc.sc()
+        tw = BaseTestClass.pysc._gateway.jvm.UByteArrayTileWrapper
 
         tup = tw.testOut(sc)
         (java_rdd, schema) = (tup._1(), tup._2())
 
         ser = AvroSerializer(schema)
-        return (RDD(java_rdd, self.pysc, AutoBatchedSerializer(ser)), schema)
+        return (RDD(java_rdd, BaseTestClass.pysc, AutoBatchedSerializer(ser)), schema)
 
     def get_tiles(self):
         (tiles, schema) = self.get_rdd()
@@ -224,10 +193,10 @@ class UByteTileSchemaTest(unittest.TestCase):
         actual_encoded = encoded.collect()
 
         expected_encoded = [
-                {'cols': 2, 'rows': 2, 'cells': bytearray([0, 0, 1, 1]), 'noDataValue': 0},
-                {'cols': 2, 'rows': 2, 'cells': bytearray([1, 2, 3, 4]), 'noDataValue': 0},
-                {'cols': 2, 'rows': 2, 'cells': bytearray([5, 6, 7, 8]), 'noDataValue': 0}
-                ]
+            {'cols': 2, 'rows': 2, 'cells': bytearray([0, 0, 1, 1]), 'noDataValue': 0},
+            {'cols': 2, 'rows': 2, 'cells': bytearray([1, 2, 3, 4]), 'noDataValue': 0},
+            {'cols': 2, 'rows': 2, 'cells': bytearray([5, 6, 7, 8]), 'noDataValue': 0}
+        ]
 
         self.assertEqual(actual_encoded, expected_encoded)
 
@@ -240,33 +209,25 @@ class UByteTileSchemaTest(unittest.TestCase):
             self.assertTrue((actual == expected).all())
 
 
-class IntTileSchemaTest(unittest.TestCase):
-    def setUp(self):
-        self.pysc = SparkContext(master="local[*]", appName="int-tile-test")
-        self.path = "geopyspark.geotrellis.tests.schemas.IntArrayTileWrapper"
-        java_import(self.pysc._gateway.jvm, self.path)
+class IntTileSchemaTest(BaseTestClass):
+    path = "geopyspark.geotrellis.tests.schemas.IntArrayTileWrapper"
+    java_import(BaseTestClass.pysc._gateway.jvm, path)
 
-        self.tiles = [
-                TileArray(np.array([0, 0, 1, 1]).reshape(2, 2), -2147483648),
-                TileArray(np.array([1, 2, 3, 4]).reshape(2, 2), -2147483648),
-                TileArray(np.array([5, 6, 7, 8]).reshape(2, 2), -2147483648)
-                ]
-
-    @pytest.fixture(autouse=True)
-    def tearDown(self):
-        yield
-        self.pysc.stop()
-        self.pysc._gateway.close()
+    tiles = [
+        TileArray(np.array([0, 0, 1, 1]).reshape(2, 2), -2147483648),
+        TileArray(np.array([1, 2, 3, 4]).reshape(2, 2), -2147483648),
+        TileArray(np.array([5, 6, 7, 8]).reshape(2, 2), -2147483648)
+    ]
 
     def get_rdd(self):
-        sc = self.pysc._jsc.sc()
-        tw = self.pysc._gateway.jvm.IntArrayTileWrapper
+        sc = BaseTestClass.pysc._jsc.sc()
+        tw = BaseTestClass.pysc._gateway.jvm.IntArrayTileWrapper
 
         tup = tw.testOut(sc)
         (java_rdd, schema) = (tup._1(), tup._2())
 
         ser = AvroSerializer(schema)
-        return (RDD(java_rdd, self.pysc, AutoBatchedSerializer(ser)), schema)
+        return (RDD(java_rdd, BaseTestClass.pysc, AutoBatchedSerializer(ser)), schema)
 
     def get_tiles(self):
         (tiles, schema) = self.get_rdd()
@@ -280,10 +241,10 @@ class IntTileSchemaTest(unittest.TestCase):
         actual_encoded = encoded.collect()
 
         expected_encoded = [
-                {'cols': 2, 'rows': 2, 'cells': [0, 0, 1, 1], 'noDataValue': -2147483648},
-                {'cols': 2, 'rows': 2, 'cells': [1, 2, 3, 4], 'noDataValue': -2147483648},
-                {'cols': 2, 'rows': 2, 'cells': [5, 6, 7, 8], 'noDataValue': -2147483648}
-                ]
+            {'cols': 2, 'rows': 2, 'cells': [0, 0, 1, 1], 'noDataValue': -2147483648},
+            {'cols': 2, 'rows': 2, 'cells': [1, 2, 3, 4], 'noDataValue': -2147483648},
+            {'cols': 2, 'rows': 2, 'cells': [5, 6, 7, 8], 'noDataValue': -2147483648}
+        ]
 
         self.assertEqual(actual_encoded, expected_encoded)
 
@@ -296,33 +257,25 @@ class IntTileSchemaTest(unittest.TestCase):
             self.assertTrue((actual == expected).all())
 
 
-class DoubleTileSchemaTest(unittest.TestCase):
-    def setUp(self):
-        self.pysc = SparkContext(master="local[*]", appName="double-tile-test")
-        self.path = "geopyspark.geotrellis.tests.schemas.DoubleArrayTileWrapper"
-        java_import(self.pysc._gateway.jvm, self.path)
+class DoubleTileSchemaTest(BaseTestClass):
+    path = "geopyspark.geotrellis.tests.schemas.DoubleArrayTileWrapper"
+    java_import(BaseTestClass.pysc._gateway.jvm, path)
 
-        self.tiles = [
-                TileArray(np.array([0, 0, 1, 1]).reshape(2, 2), True),
-                TileArray(np.array([1, 2, 3, 4]).reshape(2, 2), True),
-                TileArray(np.array([5, 6, 7, 8]).reshape(2, 2), True)
-                ]
-
-    @pytest.fixture(autouse=True)
-    def tearDown(self):
-        yield
-        self.pysc.stop()
-        self.pysc._gateway.close()
+    tiles = [
+        TileArray(np.array([0, 0, 1, 1]).reshape(2, 2), True),
+        TileArray(np.array([1, 2, 3, 4]).reshape(2, 2), True),
+        TileArray(np.array([5, 6, 7, 8]).reshape(2, 2), True)
+    ]
 
     def get_rdd(self):
-        sc = self.pysc._jsc.sc()
-        tw = self.pysc._gateway.jvm.DoubleArrayTileWrapper
+        sc = BaseTestClass.pysc._jsc.sc()
+        tw = BaseTestClass.pysc._gateway.jvm.DoubleArrayTileWrapper
 
         tup = tw.testOut(sc)
         (java_rdd, schema) = (tup._1(), tup._2())
 
         ser = AvroSerializer(schema)
-        return (RDD(java_rdd, self.pysc, AutoBatchedSerializer(ser)), schema)
+        return (RDD(java_rdd, BaseTestClass.pysc, AutoBatchedSerializer(ser)), schema)
 
     def get_tiles(self):
         (tiles, schema) = self.get_rdd()
@@ -336,10 +289,10 @@ class DoubleTileSchemaTest(unittest.TestCase):
         actual_encoded = encoded.collect()
 
         expected_encoded = [
-                {'cols': 2, 'rows': 2, 'cells': [0, 0, 1, 1], 'noDataValue': True},
-                {'cols': 2, 'rows': 2, 'cells': [1, 2, 3, 4], 'noDataValue': True},
-                {'cols': 2, 'rows': 2, 'cells': [5, 6, 7, 8], 'noDataValue': True}
-                ]
+            {'cols': 2, 'rows': 2, 'cells': [0, 0, 1, 1], 'noDataValue': True},
+            {'cols': 2, 'rows': 2, 'cells': [1, 2, 3, 4], 'noDataValue': True},
+            {'cols': 2, 'rows': 2, 'cells': [5, 6, 7, 8], 'noDataValue': True}
+        ]
 
         self.assertEqual(actual_encoded, expected_encoded)
 
@@ -352,33 +305,25 @@ class DoubleTileSchemaTest(unittest.TestCase):
             self.assertTrue((actual == expected).all())
 
 
-class FloatTileSchemaTest(unittest.TestCase):
-    def setUp(self):
-        self.pysc = SparkContext(master="local[*]", appName="float-tile-test")
-        self.path = "geopyspark.geotrellis.tests.schemas.FloatArrayTileWrapper"
-        java_import(self.pysc._gateway.jvm, self.path)
+class FloatTileSchemaTest(BaseTestClass):
+    path = "geopyspark.geotrellis.tests.schemas.FloatArrayTileWrapper"
+    java_import(BaseTestClass.pysc._gateway.jvm, path)
 
-        self.tiles = [
-                TileArray(np.array([0, 0, 1, 1]).reshape(2, 2), True),
-                TileArray(np.array([1, 2, 3, 4]).reshape(2, 2), True),
-                TileArray(np.array([5, 6, 7, 8]).reshape(2, 2), True)
-                ]
-
-    @pytest.fixture(autouse=True)
-    def tearDown(self):
-        yield
-        self.pysc.stop()
-        self.pysc._gateway.close()
+    tiles = [
+        TileArray(np.array([0, 0, 1, 1]).reshape(2, 2), True),
+        TileArray(np.array([1, 2, 3, 4]).reshape(2, 2), True),
+        TileArray(np.array([5, 6, 7, 8]).reshape(2, 2), True)
+    ]
 
     def get_rdd(self):
-        sc = self.pysc._jsc.sc()
-        tw = self.pysc._gateway.jvm.FloatArrayTileWrapper
+        sc = BaseTestClass.pysc._jsc.sc()
+        tw = BaseTestClass.pysc._gateway.jvm.FloatArrayTileWrapper
 
         tup = tw.testOut(sc)
         (java_rdd, schema) = (tup._1(), tup._2())
 
         ser = AvroSerializer(schema)
-        return (RDD(java_rdd, self.pysc, AutoBatchedSerializer(ser)), schema)
+        return (RDD(java_rdd, BaseTestClass.pysc, AutoBatchedSerializer(ser)), schema)
 
     def get_tiles(self):
         (tiles, schema) = self.get_rdd()
@@ -392,10 +337,10 @@ class FloatTileSchemaTest(unittest.TestCase):
         actual_encoded = encoded.collect()
 
         expected_encoded = [
-                {'cols': 2, 'rows': 2, 'cells': [0, 0, 1, 1], 'noDataValue': True},
-                {'cols': 2, 'rows': 2, 'cells': [1, 2, 3, 4], 'noDataValue': True},
-                {'cols': 2, 'rows': 2, 'cells': [5, 6, 7, 8], 'noDataValue': True}
-                ]
+            {'cols': 2, 'rows': 2, 'cells': [0, 0, 1, 1], 'noDataValue': True},
+            {'cols': 2, 'rows': 2, 'cells': [1, 2, 3, 4], 'noDataValue': True},
+            {'cols': 2, 'rows': 2, 'cells': [5, 6, 7, 8], 'noDataValue': True}
+        ]
 
         self.assertEqual(actual_encoded, expected_encoded)
 

--- a/geopyspark/tests/tuple_test.py
+++ b/geopyspark/tests/tuple_test.py
@@ -8,41 +8,33 @@ from geopyspark.avroserializer import AvroSerializer
 from geopyspark.geotrellis.extent import Extent
 from geopyspark.geotrellis.tile import TileArray
 from geopyspark.avroregistry import AvroRegistry
+from geopyspark.tests.base_test_class import BaseTestClass
 
 import numpy as np
 import unittest
 import pytest
 
 
-class TupleSchemaTest(unittest.TestCase):
+class TupleSchemaTest(BaseTestClass):
+    path = "geopyspark.geotrellis.tests.schemas.TupleWrapper"
+    java_import(BaseTestClass.pysc._gateway.jvm, path)
 
-    def setUp(self):
-        self.pysc = SparkContext(master="local[*]", appName="tuple-test")
-        self.path = "geopyspark.geotrellis.tests.schemas.TupleWrapper"
-        java_import(self.pysc._gateway.jvm, self.path)
-
-        self.extents = [Extent(0, 0, 1, 1), Extent(1, 2, 3, 4), Extent(5, 6, 7, 8)]
-        self.arrs = [
-                TileArray(np.array([0, 1, 2, 3, 4, 5]).reshape(3, 2), -2147483648),
-                TileArray(np.array([0, 1, 2, 3, 4, 5]).reshape(2, 3), -2147483648),
-                TileArray(np.array([0, 1, 2, 3, 4, 5]).reshape(6, 1), -2147483648)
-                ]
-
-    @pytest.fixture(autouse=True)
-    def tearDown(self):
-        yield
-        self.pysc.stop()
-        self.pysc._gateway.close()
+    extents = [Extent(0, 0, 1, 1), Extent(1, 2, 3, 4), Extent(5, 6, 7, 8)]
+    arrs = [
+            TileArray(np.array([0, 1, 2, 3, 4, 5]).reshape(3, 2), -2147483648),
+            TileArray(np.array([0, 1, 2, 3, 4, 5]).reshape(2, 3), -2147483648),
+            TileArray(np.array([0, 1, 2, 3, 4, 5]).reshape(6, 1), -2147483648)
+            ]
 
     def get_rdd(self):
-        sc = self.pysc._jsc.sc()
-        ew = self.pysc._gateway.jvm.TupleWrapper
+        sc = BaseTestClass.pysc._jsc.sc()
+        ew = BaseTestClass.pysc._gateway.jvm.TupleWrapper
 
         tup = ew.testOut(sc)
         (java_rdd, schema) = (tup._1(), tup._2())
 
         ser = AvroSerializer(schema)
-        return (RDD(java_rdd, self.pysc, AutoBatchedSerializer(ser)), schema)
+        return (RDD(java_rdd, BaseTestClass.pysc, AutoBatchedSerializer(ser)), schema)
 
     def get_tuples(self):
         (tuples, schema) = self.get_rdd()


### PR DESCRIPTION
This PR fixes the various unit tests by having only one `SparkContext` for all of the tests. By doing this, all tests can now be ran as one batch instead of some of them being run separately.