### PR TITLE
Jar Distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,4 +96,4 @@ geopyspark/tests/data_files/geotiff_test_files/
 notebooks
 
 # GeoPySpark-backend jar
-geopyspark/jar/*.jar
+geopyspark/jars/*.jar

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ ENV/
 # GeoTiff Test Files
 geopyspark/tests/data_files/geotiff_test_files/
 notebooks
+
+# GeoPySpark-backend jar
+geopyspark/jar/*.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,11 @@ addons:
       - gfortran
       - oracle-java8-set-default
 
+before_install:
+  - cd geopyspark-backend && ./sbt "project geotrellis-backend" assembly
+  - cp geotrellis/target/scala-2.11/geotrellis-backend-assembly-0.1.0.jar ../geopyspark/jars
+  - cd ..
+
 install:
   - pip3 install -r requirements.txt
   - pip3 install .
@@ -37,5 +42,4 @@ script:
   - "tar -xvf spark-2.1.0-bin-hadoop2.7.tgz"
   - "export SPARK_HOME=./spark-2.1.0-bin-hadoop2.7/"
   - "export JAVA_HOME=/usr/lib/jvm/java-8-oracle"
-  - cd geopyspark-backend && ./sbt "project geotrellis-backend" assembly
-  - cd .. && pytest
+  - pytest

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export IMG := jupyter-geopyspark
 
 ASSEMBLY := geopyspark-backend/geotrellis/target/scala-2.11/geotrellis-backend-assembly-0.1.0.jar
 WHEEL := dist/geopyspark-0.1.0-py3-none-any.whl
-JAR-PATH := geopyspark/jar/
+JAR-PATH := geopyspark/jars/
 rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
 
 install: ${ASSEMBLY} ${JAR-PATH}

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,11 @@ export IMG := jupyter-geopyspark
 
 ASSEMBLY := geopyspark-backend/geotrellis/target/scala-2.11/geotrellis-backend-assembly-0.1.0.jar
 WHEEL := dist/geopyspark-0.1.0-py3-none-any.whl
+JAR_PATH := geopyspark/jar/
 rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
 
 install:
-	${PYTHON} setup.py install --user --force --prefix=
+	cp $(ASSEMBLY) $(JAR_PATH) && ${PYTHON} setup.py install --user --force --prefix=
 
 ${ASSEMBLY}: $(call rwildcard, geopyspark-backend/src, *.scala) geopyspark-backend/build.sbt
 	(cd geopyspark-backend && ./sbt "project geotrellis-backend" assembly)

--- a/Makefile
+++ b/Makefile
@@ -4,21 +4,24 @@ export IMG := jupyter-geopyspark
 
 ASSEMBLY := geopyspark-backend/geotrellis/target/scala-2.11/geotrellis-backend-assembly-0.1.0.jar
 WHEEL := dist/geopyspark-0.1.0-py3-none-any.whl
-JAR_PATH := geopyspark/jar/
+JAR-PATH := geopyspark/jar/
 rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
 
-install:
-	cp $(ASSEMBLY) $(JAR_PATH) && ${PYTHON} setup.py install --user --force --prefix=
+install: ${ASSEMBLY} ${JAR-PATH}
+	${PYTHON} setup.py install --user --force --prefix=
 
 ${ASSEMBLY}: $(call rwildcard, geopyspark-backend/src, *.scala) geopyspark-backend/build.sbt
 	(cd geopyspark-backend && ./sbt "project geotrellis-backend" assembly)
 
+${JAR-PATH}: $(call rwildcard, geopyspark-backend/, *.jar) $(ASSEMBLY)
+	cp $(ASSEMBLY) $(JAR-PATH)
+
 ${WHEEL}: $(call rwildcard, geopyspark, *.py) setup.py
 	${PYTHON} setup.py bdist_wheel
 
-wheel: ${WHEEL}
+wheel: ${ASSEMBLY} ${JAR-PATH} ${WHEEL}
 
-pyspark: ${ASSEMBLY}
+pyspark:
 	pyspark --jars ${ASSEMBLY}
 
 docker-build: ${WHEEL}

--- a/geopyspark/__init__.py
+++ b/geopyspark/__init__.py
@@ -1,0 +1,6 @@
+import os
+
+
+if 'JARS' not in os.environ:
+    from geopyspark.geopyspark_utils import setup_environment
+    setup_environment()

--- a/geopyspark/geopyspark_utils.py
+++ b/geopyspark/geopyspark_utils.py
@@ -18,7 +18,7 @@ def setup_environment():
     ]
 
     possible_jars = [path.join(prefix, '*.jar') for prefix in local_prefixes]
-    possible_jars.append(path.abspath(resource_filename('geopyspark.jar',
+    possible_jars.append(path.abspath(resource_filename('geopyspark.jars',
                                                         JAR_FILE)))
 
     returned = [glob.glob(jar_files) for jar_files in possible_jars]

--- a/geopyspark/geopyspark_utils.py
+++ b/geopyspark/geopyspark_utils.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import glob
 
 from os import path
 from pkg_resources import resource_filename
@@ -9,7 +10,7 @@ VERSION = '0.1.0'
 JAR_FILE = 'geotrellis-backend-assembly-' + VERSION + '.jar'
 
 
-def add_jar():
+def setup_environment():
     current_location = path.dirname(path.realpath(__file__))
 
     local_prefixes = [
@@ -17,13 +18,29 @@ def add_jar():
         path.join(os.getcwd(), 'jar/')
     ]
 
-    possible_jars = [path.join(prefix, JAR_FILE) for prefix in local_prefixes]
+    possible_jars = [path.join(prefix, '*.jar') for prefix in local_prefixes]
     possible_jars.append(path.abspath(resource_filename('geopyspark.jar',
                                                         JAR_FILE)))
 
+    returned = [glob.glob(jar_files) for jar_files in possible_jars]
+    jars = [jar for sublist in returned for jar in sublist]
+
+    if len(jars) == 0:
+        raise IOError("Failed to find any jars. Looked at these paths {}".format(possible_jars))
+
+    jar_string = ','.join(jars)
+
     try:
-        jar = [jar_path for jar_path in possible_jars if path.exists(jar_path)][0]
-    except IndexError:
-        raise IOError("Failed to find geotrellis-backend jar. \
-                      Looked at paths {}".format(possible_jars))
-    os.environ['JARS'] = jar
+        backend_jar = [backend for backend in jars if JAR_FILE in backend][0]
+    except:
+        raise IOError("Failed to find driver jar, {}. Looked at these paths {}"
+                      .format(JAR_FILE, possible_jars))
+
+    os.environ['JARS'] = jar_string
+    os.environ["PYSPARK_PYTHON"] = "python3"
+    os.environ["PYSPARK_DRIVER_PYTHON"] = "python3"
+    os.environ["PYSPARK_SUBMIT_ARGS"] = "--jars {} \
+            --driver-class-path {} \
+            --driver-memory 4G \
+            --executor-memory 4G \
+            pyspark-shell".format(jar_string, backend_jar)

--- a/geopyspark/geopyspark_utils.py
+++ b/geopyspark/geopyspark_utils.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+from os import path
+from pkg_resources import resource_filename
+
+
+VERSION = '0.1.0'
+JAR_FILE = 'geotrellis-backend-assembly-' + VERSION + '.jar'
+
+
+def add_jar():
+    current_location = path.dirname(path.realpath(__file__))
+
+    local_prefixes = [
+        path.join(current_location, 'jar/'),
+        path.join(os.getcwd(), 'jar/')
+    ]
+
+    possible_jars = [path.join(prefix, JAR_FILE) for prefix in local_prefixes]
+    possible_jars.append(path.abspath(resource_filename('geopyspark.jar',
+                                                        JAR_FILE)))
+
+    try:
+        jar = [jar_path for jar_path in possible_jars if path.exists(jar_path)][0]
+    except IndexError:
+        raise IOError("Failed to find geotrellis-backend jar. \
+                      Looked at paths {}".format(possible_jars))
+    os.environ['JARS'] = jar

--- a/geopyspark/geopyspark_utils.py
+++ b/geopyspark/geopyspark_utils.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import glob
 
 from os import path

--- a/geopyspark/geopyspark_utils.py
+++ b/geopyspark/geopyspark_utils.py
@@ -14,8 +14,8 @@ def setup_environment():
     current_location = path.dirname(path.realpath(__file__))
 
     local_prefixes = [
-        path.join(current_location, 'jar/'),
-        path.join(os.getcwd(), 'jar/')
+        path.join(current_location, 'jars/'),
+        path.join(os.getcwd(), 'jars/')
     ]
 
     possible_jars = [path.join(prefix, '*.jar') for prefix in local_prefixes]

--- a/geopyspark/tests/__init__.py
+++ b/geopyspark/tests/__init__.py
@@ -1,9 +1,11 @@
 import os
 
-jar_path = "geopyspark-backend/geotrellis/target/scala-2.11/geotrellis-backend-assembly-0.1.0.jar"
+from geopyspark.geopyspark_utils import add_jar
 
-if not os.path.isfile(jar_path):
-    raise Exception("Could not locate assembly jar file at {}".format(jar_path))
+
+add_jar()
+
+jar_path = os.environ['JARS']
 
 os.environ["PYSPARK_PYTHON"] = "python3"
 os.environ["PYSPARK_DRIVER_PYTHON"] = "python3"

--- a/geopyspark/tests/__init__.py
+++ b/geopyspark/tests/__init__.py
@@ -1,16 +1,6 @@
 import os
 
-from geopyspark.geopyspark_utils import add_jar
 
-
-add_jar()
-
-jar_path = os.environ['JARS']
-
-os.environ["PYSPARK_PYTHON"] = "python3"
-os.environ["PYSPARK_DRIVER_PYTHON"] = "python3"
-os.environ["PYSPARK_SUBMIT_ARGS"] = "--jars {} \
-        --driver-class-path {} \
-        --driver-memory 4G \
-        --executor-memory 4G \
-        pyspark-shell".format(jar_path, jar_path)
+if 'JARS' not in os.environ:
+    from geopyspark.geopyspark_utils import setup_environment
+    setup_environment()

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ setup(
         'shapely>=1.6b3'
     ],
     include_package_data=True,
-    data_files=[('jar', ['geopyspark/jars/geotrellis-backend-assembly-0.1.0.jar'])],
-    packages=['geopyspark', 'geopyspark.geotrellis', 'geopyspark.tests'],
+    data_files=[('jars', ['geopyspark/jars/geotrellis-backend-assembly-0.1.0.jar'])],
+    packages=['geopyspark', 'geopyspark.geotrellis', 'geopyspark.tests', 'geopyspark.jars'],
     scripts=[],
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'shapely>=1.6b3'
     ],
     include_package_data=True,
-    data_files=[('jar', ['geopyspark/jar/geotrellis-backend-assembly-0.1.0.jar'])],
+    data_files=[('jar', ['geopyspark/jars/geotrellis-backend-assembly-0.1.0.jar'])],
     packages=['geopyspark', 'geopyspark.geotrellis', 'geopyspark.tests'],
     scripts=[],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ setup(
         'numpy>=1.8',
         'shapely>=1.6b3'
     ],
+    include_package_data=True,
+    data_files=[('jar', ['geopyspark/jar/geotrellis-backend-assembly-0.1.0.jar'])],
     packages=['geopyspark', 'geopyspark.geotrellis', 'geopyspark.tests'],
     scripts=[],
     classifiers=[


### PR DESCRIPTION
This PR is based on another PR that is still in review, #41 . The main feature added is that the `jar` file that is needed to drive GeoPySpark will now be distributed in the wheel. In addition, PySpark environment variables have now been set in a new way.