### PR TITLE
Multiband Fix

### DIFF
--- a/geopyspark/geotrellis/tile.py
+++ b/geopyspark/geotrellis/tile.py
@@ -1,9 +1,13 @@
 import numpy as np
 
 class TileArray(np.ndarray):
-    def __new__(cls, input_array, no_data_value):
+    def __new__(cls, input_array, no_data_value=None):
         obj = np.asarray(input_array).view(cls)
-        obj.no_data_value = no_data_value
+
+        if no_data_value:
+            obj.no_data_value = no_data_value
+        else:
+            obj.no_data_value = None
 
         return obj
 

--- a/geopyspark/geotrellis/tile.py
+++ b/geopyspark/geotrellis/tile.py
@@ -4,7 +4,7 @@ class TileArray(np.ndarray):
     def __new__(cls, input_array, no_data_value=None):
         obj = np.asarray(input_array).view(cls)
 
-        if no_data_value:
+        if no_data_value is not None:
             obj.no_data_value = no_data_value
         else:
             obj.no_data_value = None

--- a/geopyspark/tests/multiband_test.py
+++ b/geopyspark/tests/multiband_test.py
@@ -19,7 +19,8 @@ class MultibandSchemaTest(BaseTestClass):
     java_import(BaseTestClass.pysc._gateway.jvm, path)
 
     arr = TileArray(np.array(bytearray([0, 0, 1, 1])).reshape(2, 2), -128)
-    multiband_tile = [arr, arr, arr]
+    bands = [arr, arr, arr]
+    multiband_tile = np.array(bands)
 
     def get_rdd(self):
         sc = BaseTestClass.pysc._jsc.sc()
@@ -43,10 +44,10 @@ class MultibandSchemaTest(BaseTestClass):
         actual_encoded = encoded.collect()
 
         expected_encoded = [
-                {'bands': [AvroRegistry.tile_encoder(x) for x in self.multiband_tile]},
-                {'bands': [AvroRegistry.tile_encoder(x) for x in self.multiband_tile]},
-                {'bands': [AvroRegistry.tile_encoder(x) for x in self.multiband_tile]},
-                ]
+            {'bands': [AvroRegistry.tile_encoder(x) for x in self.bands]},
+            {'bands': [AvroRegistry.tile_encoder(x) for x in self.bands]},
+            {'bands': [AvroRegistry.tile_encoder(x) for x in self.bands]}
+        ]
 
         for actual, expected in zip(actual_encoded, expected_encoded):
             self.assertEqual(actual, expected)
@@ -55,10 +56,10 @@ class MultibandSchemaTest(BaseTestClass):
         actual_multibands = self.get_multibands()
 
         expected_multibands = [
-                self.multiband_tile,
-                self.multiband_tile,
-                self.multiband_tile
-                ]
+            self.multiband_tile,
+            self.multiband_tile,
+            self.multiband_tile
+        ]
 
         for actual_tiles, expected_tiles in zip(actual_multibands, expected_multibands):
             for actual, expected in zip(actual_tiles, expected_tiles):


### PR DESCRIPTION
This PR changes how `Multiband`s are returned in python. Instead of getting back a `[TileArray, TileArray, .., TileArray]`, the use now gets back a single `TileArray` that has a shape `(n, cols, rows)`. Where `n` is the number of bands in that array. The reason for this change was to match what Rasterio returns when it reads in a `Multiband` file.