### PR TITLE
Serialization Refactor - Catalog Metadata

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/AttributeStoreFactory.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/AttributeStoreFactory.scala
@@ -7,7 +7,10 @@ import geotrellis.spark.io.cassandra._
 import geotrellis.spark.io.file._
 import geotrellis.spark.io.hadoop._
 import geotrellis.spark.io.hbase._
+import geotrellis.spark.io.json._
 import geotrellis.spark.io.s3._
+
+import spray.json._
 
 import org.apache.accumulo.core.client.security.tokens.PasswordToken
 import org.apache.spark._
@@ -21,16 +24,16 @@ abstract class AttributeStoreWrapper {
 
   def header(name: String, zoom: Int): Array[String]
 
-  def metadataSpatial(name: String, zoom: Int): TileLayerMetadataWrapper[SpatialKey] = {
+  def metadataSpatial(name: String, zoom: Int): String = {
     val id = LayerId(name, zoom)
     val md = attributeStore.readMetadata[TileLayerMetadata[SpatialKey]](id)
-    new TileLayerMetadataWrapper(md)
+    md.toJson.compactPrint
   }
 
-  def metadataSpaceTime(name: String, zoom: Int): TileLayerMetadataWrapper[SpaceTimeKey] = {
+  def metadataSpaceTime(name: String, zoom: Int): String = {
     val id = LayerId(name, zoom)
     val md = attributeStore.readMetadata[TileLayerMetadata[SpaceTimeKey]](id)
-    new TileLayerMetadataWrapper(md)
+    md.toJson.compactPrint
   }
 }
 


### PR DESCRIPTION
This PR is based on another, open Pr, #52 . When reading or querying data with one of the catalogs, the return is now `(RDD, schema, metadata)` as opposed to `(RDD, Metadata)`. This will make working with the various catalogs easier.

While the refactor is still continuing, this Pr is stable, and can be merged in without issue.

This Pr resoles #48 