### PR TITLE
Tile Encoder/Decoder Update

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SchemaProducer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SchemaProducer.scala
@@ -7,24 +7,16 @@ import geotrellis.spark.io.avro._
 
 
 object SchemaProducer {
-  def getSchema(keyType: String, valueType: String): String =
-    (keyType, valueType) match {
-      case ("ProjectedExtent", "Tile") =>
-        implicitly[AvroRecordCodec[(ProjectedExtent, Tile)]].schema.toString
-      case ("ProjectedExtent", "MultibandTile") =>
+  def getSchema(keyType: String): String =
+    keyType match {
+      case "ProjectedExtent" =>
         implicitly[AvroRecordCodec[(ProjectedExtent, MultibandTile)]].schema.toString
-      case ("TemporalProjectedExtent", "Tile") =>
-        implicitly[AvroRecordCodec[(TemporalProjectedExtent, Tile)]].schema.toString
-      case ("TemporalProjectedExtent", "MultibandTile") =>
+      case "TemporalProjectedExtent" =>
         implicitly[AvroRecordCodec[(TemporalProjectedExtent, MultibandTile)]].schema.toString
 
-      case ("SpatialKey", "Tile") =>
-        implicitly[AvroRecordCodec[(SpatialKey, Tile)]].schema.toString
-      case ("SpatialKey", "MultibandTile") =>
+      case "SpatialKey" =>
         implicitly[AvroRecordCodec[(SpatialKey, MultibandTile)]].schema.toString
-      case ("SpaceTimeKey", "Tile") =>
-        implicitly[AvroRecordCodec[(SpaceTimeKey, Tile)]].schema.toString
-      case ("SpaceTimeKey", "MultibandTile") =>
+      case "SpaceTimeKey" =>
         implicitly[AvroRecordCodec[(SpaceTimeKey, MultibandTile)]].schema.toString
     }
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerWriterFactory.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerWriterFactory.scala
@@ -68,7 +68,6 @@ abstract class LayerWriterWrapper {
 
   def write(
     keyType: String,
-    valueType: String,
     layerName: String,
     zoom: Int,
     jrdd: JavaRDD[Array[Byte]],
@@ -80,26 +79,14 @@ abstract class LayerWriterWrapper {
     val id = LayerId(layerName, zoom)
     val metadataAST = returnedMetadata.parseJson
 
-    (keyType, valueType) match {
-      case ("SpatialKey", "Tile") => {
-        val indexMethod = getSpatialIndexMethod(indexStrategy)
-        val rawRdd = PythonTranslator.fromPython[(SpatialKey, Tile)](jrdd, Some(schema))
-        val rdd = ContextRDD(rawRdd, metadataAST.convertTo[TileLayerMetadata[SpatialKey]])
-        layerWriter.write(id, rdd, indexMethod)
-      }
-      case ("SpatialKey", "MultibandTile") => {
+    keyType match {
+      case "SpatialKey" => {
         val indexMethod = getSpatialIndexMethod(indexStrategy)
         val rawRdd = PythonTranslator.fromPython[(SpatialKey, MultibandTile)](jrdd, Some(schema))
         val rdd = ContextRDD(rawRdd, metadataAST.convertTo[TileLayerMetadata[SpatialKey]])
         layerWriter.write(id, rdd, indexMethod)
       }
-      case ("SpaceTimeKey", "Tile") => {
-        val indexMethod = getTemporalIndexMethod(timeString, indexStrategy)
-        val rawRdd = PythonTranslator.fromPython[(SpaceTimeKey, Tile)](jrdd, Some(schema))
-        val rdd = ContextRDD(rawRdd, metadataAST.convertTo[TileLayerMetadata[SpaceTimeKey]])
-        layerWriter.write(id, rdd, indexMethod)
-      }
-      case ("SpaceTimeKey", "MultibandTile") => {
+      case "SpaceTimeKey" => {
         val indexMethod = getTemporalIndexMethod(timeString, indexStrategy)
         val rawRdd = PythonTranslator.fromPython[(SpaceTimeKey, MultibandTile)](jrdd, Some(schema))
         val rdd = ContextRDD(rawRdd, metadataAST.convertTo[TileLayerMetadata[SpaceTimeKey]])

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/ValueReaderFactory.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/ValueReaderFactory.scala
@@ -33,7 +33,6 @@ abstract class ValueReaderWrapper() {
 
   def readTile(
     keyType: String,
-    valueType: String,
     layerName: String,
     zoom: Int,
     col: Int,
@@ -42,31 +41,18 @@ abstract class ValueReaderWrapper() {
   ): (Array[Byte], String) = {
     val id = LayerId(layerName, zoom)
 
-    if (keyType == "SpatialKey") {
-      val spatialKey = SpatialKey(col, row)
-
-      valueType match {
-        case "Tile" =>
-          PythonTranslator
-            .toPython(valueReader
-            .reader[SpatialKey, Tile](id).read(spatialKey))
-        case "MultibandTile" =>
-          PythonTranslator
-            .toPython(valueReader
-            .reader[SpatialKey, MultibandTile](id).read(spatialKey))
-      }
-    } else {
+    keyType match {
+      case "SpatialKey" => {
+        val spatialKey = SpatialKey(col, row)
+        PythonTranslator
+          .toPython(valueReader.reader[SpatialKey, MultibandTile](id)
+          .read(spatialKey))
+        }
+      case "SpaceTimeKey" => {
       val spaceKey = SpaceTimeKey(col, row, ZonedDateTime.parse(zdt))
-
-      valueType match {
-        case "Tile" =>
-          PythonTranslator
-            .toPython(valueReader
-            .reader[SpaceTimeKey, Tile](id).read(spaceKey))
-        case "MultibandTile" =>
-          PythonTranslator
-            .toPython(valueReader
-            .reader[SpaceTimeKey, MultibandTile](id).read(spaceKey))
+      PythonTranslator
+        .toPython(valueReader.reader[SpaceTimeKey, MultibandTile](id)
+        .read(spaceKey))
       }
     }
   }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/hadoop/HadoopGeoTiffRDDWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/hadoop/HadoopGeoTiffRDDWrapper.scala
@@ -46,36 +46,25 @@ object HadoopGeoTiffRDDOptions {
 object HadoopGeoTiffRDDWrapper {
   def getRDD(
     keyType: String,
-    valueType: String,
     path: String,
     sc: SparkContext): (JavaRDD[Array[Byte]], String) =
-    (keyType, valueType) match {
-      case ("ProjectedExtent", "Tile") =>
-        PythonTranslator.toPython(HadoopGeoTiffRDD.spatial(path)(sc))
-      case ("ProjectedExtent", "MultibandTile") =>
+    keyType match {
+      case "ProjectedExtent" =>
         PythonTranslator.toPython(HadoopGeoTiffRDD.spatialMultiband(path)(sc))
-      case ("TemporalProjectedExtent", "Tile") =>
-        PythonTranslator.toPython(HadoopGeoTiffRDD.temporal(path)(sc))
-      case ("TemporalProjectedExtent", "MultibandTile") =>
+      case "TemporalProjectedExtent" =>
         PythonTranslator.toPython(HadoopGeoTiffRDD.temporalMultiband(path)(sc))
     }
 
   def getRDD(
     keyType: String,
-    valueType: String,
     path: String,
     options: java.util.Map[String, Any],
     sc: SparkContext): (JavaRDD[Array[Byte]], String) = {
     val hadoopOptions = HadoopGeoTiffRDDOptions.setValues(options)
-
-    (keyType, valueType) match {
-      case ("ProjectedExtent", "Tile") =>
-        PythonTranslator.toPython(HadoopGeoTiffRDD.spatial(path, hadoopOptions)(sc))
-      case ("ProjectedExtent", "MultibandTile") =>
+    keyType match {
+      case "ProjectedExtent" =>
         PythonTranslator.toPython(HadoopGeoTiffRDD.spatialMultiband(path, hadoopOptions)(sc))
-      case ("TemporalProjectedExtent", "Tile") =>
-        PythonTranslator.toPython(HadoopGeoTiffRDD.temporal(path, hadoopOptions)(sc))
-      case ("TemporalProjectedExtent", "MultibandTile") =>
+      case "TemporalProjectedExtent" =>
         PythonTranslator.toPython(HadoopGeoTiffRDD.temporalMultiband(path, hadoopOptions)(sc))
     }
   }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/s3/S3GeoTiffRDDWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/s3/S3GeoTiffRDDWrapper.scala
@@ -56,38 +56,28 @@ object S3GeoTiffRDDOptions {
 object S3GeoTiffRDDWrapper {
   def getRDD(
     keyType: String,
-    valueType: String,
     bucket: String,
     prefix: String,
     sc: SparkContext): (JavaRDD[Array[Byte]], String) =
-    (keyType, valueType) match {
-      case ("ProjectedExtent", "Tile") =>
-        PythonTranslator.toPython(S3GeoTiffRDD.spatial(bucket, prefix)(sc))
-      case ("ProjectedExtent", "MultibandTile") =>
+    keyType match {
+      case "ProjectedExtent" =>
         PythonTranslator.toPython(S3GeoTiffRDD.spatialMultiband(bucket, prefix)(sc))
-      case ("TemporalProjectedExtent", "Tile") =>
-        PythonTranslator.toPython(S3GeoTiffRDD.temporal(bucket, prefix)(sc))
-      case ("TemporalProjectedExtent", "MultibandTile") =>
+      case "TemporalProjectedExtent" =>
         PythonTranslator.toPython(S3GeoTiffRDD.temporalMultiband(bucket, prefix)(sc))
     }
 
   def getRDD(
     keyType: String,
-    valueType: String,
     bucket: String,
     prefix: String,
     options: java.util.Map[String, Any],
     sc: SparkContext): (JavaRDD[Array[Byte]], String) = {
     val s3Options = S3GeoTiffRDDOptions.setValues(options)
 
-    (keyType, valueType) match {
-      case ("ProjectedExtent", "Tile") =>
-        PythonTranslator.toPython(S3GeoTiffRDD.spatial(bucket, prefix, s3Options)(sc))
-      case ("ProjectedExtent", "MultibandTile") =>
+    keyType match {
+      case "ProjectedExtent" =>
         PythonTranslator.toPython(S3GeoTiffRDD.spatialMultiband(bucket, prefix, s3Options)(sc))
-      case ("TemporalProjectedExtent", "Tile") =>
-        PythonTranslator.toPython(S3GeoTiffRDD.temporal(bucket, prefix, s3Options)(sc))
-      case ("TemporalProjectedExtent", "MultibandTile") =>
+      case "TemporalProjectedExtent" =>
         PythonTranslator.toPython(S3GeoTiffRDD.temporalMultiband(bucket, prefix, s3Options)(sc))
     }
   }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/TileLayerMetadataCollector.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/TileLayerMetadataCollector.scala
@@ -56,7 +56,6 @@ object TileLayerMetadataCollector {
   }
 
   def collectPythonMetadata(
-    valueType: String,
     keyType: String,
     returnedRdd: RDD[Array[Byte]],
     schemaJson: String,
@@ -64,29 +63,15 @@ object TileLayerMetadataCollector {
     pythonTileLayout: java.util.Map[String, Int],
     crsJavaMap: java.util.Map[String, String]
   ): String =
-    (valueType, keyType) match {
-      case ("spatial", "singleband") =>
-        createCollection[ProjectedExtent, Tile, SpatialKey](
-          returnedRdd,
-          schemaJson,
-          pythonExtent,
-          pythonTileLayout,
-          crsJavaMap)
-      case ("spatial", "multiband") =>
+    keyType match {
+      case "ProjectedExtent" =>
         createCollection[ProjectedExtent, MultibandTile, SpatialKey](
           returnedRdd,
           schemaJson,
           pythonExtent,
           pythonTileLayout,
           crsJavaMap)
-      case ("spacetime", "singleband") =>
-        createCollection[TemporalProjectedExtent, Tile, SpaceTimeKey](
-          returnedRdd,
-          schemaJson,
-          pythonExtent,
-          pythonTileLayout,
-          crsJavaMap)
-      case ("spacetime", "multiband") =>
+      case "TemporalProjectedExtent" =>
         createCollection[TemporalProjectedExtent, MultibandTile, SpaceTimeKey](
           returnedRdd,
           schemaJson,

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/merge/MergeMethodsWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/merge/MergeMethodsWrapper.scala
@@ -37,32 +37,19 @@ object MergeMethodsWrapper {
 
   def merge(
     keyType: String,
-    valueType: String,
     self: RDD[Array[Byte]],
     selfSchema: String,
     other: RDD[Array[Byte]],
     otherSchema: String
   ): (JavaRDD[Array[Byte]], String) =
-    (keyType, valueType) match {
-      case ("spatial", "singleband") =>
-        mergeRDDs[ProjectedExtent, Tile](
-          self,
-          selfSchema,
-          other,
-          otherSchema)
-      case ("spatial", "multiband") =>
+    keyType match {
+      case "ProjectedExtent" =>
         mergeRDDs[ProjectedExtent, MultibandTile](
           self,
           selfSchema,
           other,
           otherSchema)
-      case ("spacetime", "singleband") =>
-        mergeRDDs[TemporalProjectedExtent, Tile](
-          self,
-          selfSchema,
-          other,
-          otherSchema)
-      case ("spacetime", "multiband") =>
+      case "TemporalProjectedExtent" =>
         mergeRDDs[TemporalProjectedExtent, MultibandTile](
           self,
           selfSchema,

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/tiling/TilerMethodsWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/tiling/TilerMethodsWrapper.scala
@@ -61,32 +61,19 @@ object TilerMethodsWrapper {
 
   def cutTiles(
     keyType: String,
-    valueType: String,
     returnedRdd: RDD[Array[Byte]],
     schema: String,
     returnedMetadata: String,
     resampleMap: java.util.Map[String, String]
   ): (JavaRDD[Array[Byte]], String) =
-    (keyType, valueType) match {
-      case ("spatial", "singleband") =>
-        cutRDDTiles[ProjectedExtent, Tile, SpatialKey](
-          returnedRdd,
-          schema,
-          returnedMetadata,
-          resampleMap)
-      case ("spatial", "multiband") =>
+    keyType match {
+      case "ProjectedExtent" =>
         cutRDDTiles[ProjectedExtent, MultibandTile, SpatialKey](
           returnedRdd,
           schema,
           returnedMetadata,
           resampleMap)
-      case ("spacetime", "singleband") =>
-        cutRDDTiles[TemporalProjectedExtent, Tile, SpaceTimeKey](
-          returnedRdd,
-          schema,
-          returnedMetadata,
-          resampleMap)
-      case ("spacetime", "multiband") =>
+      case "TemporalProjectedExtent" =>
         cutRDDTiles[TemporalProjectedExtent, MultibandTile, SpaceTimeKey](
           returnedRdd,
           schema,
@@ -122,32 +109,19 @@ object TilerMethodsWrapper {
 
   def tileToLayout(
     keyType: String,
-    valueType: String,
     returnedRdd: RDD[Array[Byte]],
     schema: String,
     returnedMetadata: String,
     options: java.util.Map[String, Any]
   ): (JavaRDD[Array[Byte]], String) =
-    (keyType, valueType) match {
-      case ("spatial", "singleband") =>
-        toLayout[ProjectedExtent, Tile, SpatialKey](
-          returnedRdd,
-          schema,
-          returnedMetadata,
-          options)
-      case ("spatial", "multiband") =>
+    keyType match {
+      case "ProjectedExtent" =>
         toLayout[ProjectedExtent, MultibandTile, SpatialKey](
           returnedRdd,
           schema,
           returnedMetadata,
           options)
-      case ("spacetime", "singleband") =>
-        toLayout[TemporalProjectedExtent, Tile, SpaceTimeKey](
-          returnedRdd,
-          schema,
-          returnedMetadata,
-          options)
-      case ("spacetime", "multiband") =>
+      case "TemporalProjectedExtent" =>
         toLayout[TemporalProjectedExtent, MultibandTile, SpaceTimeKey](
           returnedRdd,
           schema,

--- a/geopyspark/avroregistry.py
+++ b/geopyspark/avroregistry.py
@@ -101,6 +101,9 @@ class AvroRegistry(object):
 
     @classmethod
     def tile_encoder(cls, obj):
+        if obj['data'].ndim == 2:
+            obj['data'] = np.expand_dims(obj['data'], 0)
+
         band_count = obj['data'].shape[0]
 
         def create_dict(index):

--- a/geopyspark/avroregistry.py
+++ b/geopyspark/avroregistry.py
@@ -7,7 +7,7 @@ class AvroRegistry(object):
     # DECODERS
 
     @staticmethod
-    def tile_decoder(schema_dict):
+    def _tile_decoder(schema_dict):
         cells = schema_dict['cells']
 
         if isinstance(cells, bytes):
@@ -16,22 +16,21 @@ class AvroRegistry(object):
         # cols and rows are opposte for GeoTrellis ArrayTiles and Numpy Arrays
         arr = np.array(cells).reshape(schema_dict['rows'], schema_dict['cols'])
 
-        if 'noDataValue' in schema_dict:
-            tile_dict = {'data': arr, 'no_data_value': schema_dict['noDataValue']}
-        else:
-            tile_dict = {'data': arr}
-
-        return tile_dict
+        return arr
 
     @classmethod
-    def multiband_decoder(cls, schema_dict):
-        bands = schema_dict['bands']
-        tile_dicts = [cls.tile_decoder(band) for band in bands]
+    def tile_decoder(cls, schema_dict):
+        if 'bands' not in schema_dict:
+            arr = [cls._tile_decoder(schema_dict)]
+            no_data = schema_dict.get('noNoDataValue')
+            tile = np.array(arr)
+        else:
+            bands = schema_dict['bands']
+            arrs = [cls._tile_decoder(band) for band in bands]
+            no_data = bands[0].get('NoDataValue')
+            tile = np.array(arrs)
 
-        tiles = [tile['data'] for tile in tile_dicts]
-        no_data = tile_dicts[0]['no_data_value']
-
-        return {'data': np.array(tiles), 'no_data_value': no_data}
+        return {'data': tile, 'no_data_value': no_data}
 
     @staticmethod
     def tuple_decoder(schema_dict, key_decoder=None, value_decoder=None):
@@ -51,8 +50,6 @@ class AvroRegistry(object):
     def get_decoder(cls, name):
         if name == "Tile":
             return cls.tile_decoder
-        elif name == "MultibandTile":
-            return cls.multiband_decoder
         else:
             raise Exception("Could not find value type that matches", name)
 
@@ -75,20 +72,17 @@ class AvroRegistry(object):
     # ENCODERS
 
     @staticmethod
-    def tile_encoder(obj):
+    def _tile_encoder(obj):
         arr = obj['data']
 
-        if len(arr.shape) > 2:
-            (rows, cols) = (arr.shape[1], arr.shape[2])
-        else:
-            (rows, cols) = arr.shape
+        (rows, cols) = arr.shape
 
         if arr.dtype.name == 'int8' or arr.dtype.name == 'uint8':
             values = array.array('B', arr.flatten()).tostring()
         else:
             values = arr.flatten().tolist()
 
-        if 'no_data_value' in obj:
+        if obj['no_data_value'] is not None:
             datum = {
                 'cols': cols,
                 'rows': rows,
@@ -106,19 +100,15 @@ class AvroRegistry(object):
         return datum
 
     @classmethod
-    def multiband_encoder(cls, obj):
+    def tile_encoder(cls, obj):
+        band_count = obj['data'].shape[0]
 
         def create_dict(index):
             return {'data': obj['data'][index, :, :], 'no_data_value': obj['no_data_value']}
 
-        bands = obj['data'].shape[0]
-        tile_datums = [cls.tile_encoder(create_dict(x)) for x in range(bands)]
+        tile_datums = [cls._tile_encoder(create_dict(x)) for x in range(band_count)]
 
-        datum = {
-            'bands': tile_datums
-        }
-
-        return datum
+        return {'bands': tile_datums}
 
     @staticmethod
     def tuple_encoder(obj, key_encoder=None, value_encoder=None):
@@ -159,7 +149,5 @@ class AvroRegistry(object):
     def get_encoder(cls, name):
         if name == "Tile":
             return cls.tile_encoder
-        elif name == "MultibandTile":
-            return cls.multiband_encoder
         else:
             raise Exception("Could not find value type that matches", name)

--- a/geopyspark/avroregistry.py
+++ b/geopyspark/avroregistry.py
@@ -27,7 +27,7 @@ class AvroRegistry(object):
         else:
             bands = schema_dict['bands']
             arrs = [cls._tile_decoder(band) for band in bands]
-            no_data = bands[0].get('NoDataValue')
+            no_data = bands[0].get('noDataValue')
             tile = np.array(arrs)
 
         return {'data': tile, 'no_data_value': no_data}

--- a/geopyspark/avroregistry.py
+++ b/geopyspark/avroregistry.py
@@ -22,7 +22,7 @@ class AvroRegistry(object):
     def tile_decoder(cls, schema_dict):
         if 'bands' not in schema_dict:
             arr = [cls._tile_decoder(schema_dict)]
-            no_data = schema_dict.get('noNoDataValue')
+            no_data = schema_dict.get('noDataValue')
             tile = np.array(arr)
         else:
             bands = schema_dict['bands']

--- a/geopyspark/geopycontext.py
+++ b/geopyspark/geopycontext.py
@@ -78,15 +78,6 @@ class GeoPyContext(object):
             else:
                 raise Exception("Could not find key type that matches", key_type)
 
-    @staticmethod
-    def map_value_input(value_type):
-        if value_type == "singleband":
-            return "Tile"
-        elif value_type == "multiband":
-            return "MultibandTile"
-        else:
-            raise Exception("Could not find value type that matches", value_type)
-
     def create_schema(self, key_type, value_type):
         return self.schema_producer.getSchema(key_type, value_type)
 

--- a/geopyspark/geotrellis/geotiff_rdd.py
+++ b/geopyspark/geotrellis/geotiff_rdd.py
@@ -6,16 +6,17 @@ class HadoopGeoTiffRDD(object):
         self.geopysc = geopysc
         self._hadoop_wrapper = self.geopysc.hadoop_geotiff_rdd
 
-    def get_rdd(self, key_type, value_type, path, options=None):
+    def get_rdd(self, key_type, path, options=None):
         key = self.geopysc.map_key_input(key_type, False)
-        value = self.geopysc.map_value_input(value_type)
 
         if options is None:
-            result = self._hadoop_wrapper.getRDD(key, value, path, self.geopysc.sc)
+            result = self._hadoop_wrapper.getRDD(key, path, self.geopysc.sc)
         else:
-            result = self._hadoop_wrapper.getRDD(key, value, path, options, self.geopysc.sc)
+            result = self._hadoop_wrapper.getRDD(key, path, options, self.geopysc.sc)
 
-        return self.geopysc.avro_tuple_rdd_to_python(key, value, result._1(), result._2())
+        ser = self.geopysc.create_tuple_serializer(result._2(), value_type="Tile")
+
+        return self.geopysc.create_python_rdd(result._1(), ser)
 
 
 class S3GeoTiffRDD(object):
@@ -23,13 +24,14 @@ class S3GeoTiffRDD(object):
         self.geopysc = geopysc
         self._s3_wrapper = self.geopysc.s3_geotiff_rdd
 
-    def get_rdd(self, key_type, value_type, bucket, prefix, options=None):
+    def get_rdd(self, key_type, bucket, prefix, options=None):
         key = self.geopysc.map_key_input(key_type, False)
-        value = self.geopysc.map_value_input(value_type)
 
         if options is None:
-            result = self._s3_wrapper.getRDD(key, value, bucket, prefix, self.geopysc.sc)
+            result = self._s3_wrapper.getRDD(key, bucket, prefix, self.geopysc.sc)
         else:
-            result = self._s3_wrapper.getRDD(key, value, bucket, prefix, options, self.geopysc.sc)
+            result = self._s3_wrapper.getRDD(key, bucket, prefix, options, self.geopysc.sc)
 
-        return self.geopysc.avro_tuple_rdd_to_python(key, value, result._1(), result._2())
+        ser = self.geopysc.create_tuple_serializer(result._2(), value_type="Tile")
+
+        return self.geopysc.create_python_rdd(result._1(), ser)

--- a/geopyspark/geotrellis/tile_layer_methods.py
+++ b/geopyspark/geotrellis/tile_layer_methods.py
@@ -12,37 +12,31 @@ class TileLayerMethods(object):
         self._merge_wrapper = self.geopysc.tile_layer_merge
 
     @staticmethod
-    def _map_outputs(key_type, value_type):
+    def _map_outputs(key_type):
         if key_type == "spatial":
             key = "SpatialKey"
         else:
             key = "SpaceTimeKey"
 
-        if value_type == "singleband":
-            value = "Tile"
-        else:
-            value = "MultibandTile"
+        return key
 
-        return (key, value)
-
-    def _convert_to_java_rdd(self, key_type, value_type, rdd):
+    def _convert_to_java_rdd(self, key_type, rdd):
         if isinstance(rdd._jrdd_deserializer.serializer, AvroSerializer):
             ser = rdd._jrdd_deserializer.serializer
             dumped = rdd.map(lambda value: ser.dumps(value))
             schema = rdd._jrdd_deserializer.serializer.schema_string
         else:
-            ser = self.geopysc.create_tuple_serializer(key_type, value_type)
+            schema = self.geopysc.create_schema(key_type)
+            ser = self.geopysc.create_tuple_serializer(schema, value_type="Tile")
             reserialized_rdd = rdd._reserialize(ser)
-            avro_ser = reserialized_rdd._jrdd_deserializer.serializer
 
+            avro_ser = reserialized_rdd._jrdd_deserializer.serializer
             dumped = reserialized_rdd.map(lambda x: avro_ser.dumps(x))
-            schema = reserialized_rdd._jrdd_deserializer.serializer.schema_string
 
         return (dumped._to_java_object_rdd(), schema)
 
     def collect_metadata(self,
                          key_type,
-                         value_type,
                          rdd,
                          extent,
                          tile_layout,
@@ -51,9 +45,8 @@ class TileLayerMethods(object):
                          wkt_string=None):
 
         key = self.geopysc.map_key_input(key_type, False)
-        value = self.geopysc.map_value_input(value_type)
 
-        (java_rdd, schema) = self._convert_to_java_rdd(key, value, rdd)
+        (java_rdd, schema) = self._convert_to_java_rdd(key, rdd)
 
         if proj_params:
             output_crs = {"projParams": proj_params}
@@ -61,13 +54,12 @@ class TileLayerMethods(object):
             if isinstance(epsg_code, int):
                 epsg_code = str(epsg_code)
                 output_crs = {"epsg": epsg_code}
-        elif wkt_string:
-            output_crs = {"wktString": wkt_string}
-        else:
-            output_crs = {}
+            elif wkt_string:
+                output_crs = {"wktString": wkt_string}
+            else:
+                output_crs = {}
 
-        metadata = self._metadata_wrapper.collectPythonMetadata(key_type,
-                                                                value_type,
+        metadata = self._metadata_wrapper.collectPythonMetadata(key,
                                                                 java_rdd.rdd(),
                                                                 schema,
                                                                 extent,
@@ -78,86 +70,74 @@ class TileLayerMethods(object):
 
     def cut_tiles(self,
                   key_type,
-                  value_type,
                   rdd,
                   tile_layer_metadata,
                   resample_method=None):
 
         key = self.geopysc.map_key_input(key_type, False)
-        value = self.geopysc.map_value_input(value_type)
 
-        (java_rdd, schema) = self._convert_to_java_rdd(key, value, rdd)
+        (java_rdd, schema) = self._convert_to_java_rdd(key, rdd)
 
         if resample_method is None:
             resample_dict = {}
         else:
             resample_dict = {"resampleMethod": resample_method}
 
-        result = self._tiler_wrapper.cutTiles(key_type,
-                                              value_type,
+        result = self._tiler_wrapper.cutTiles(key,
                                               java_rdd.rdd(),
                                               schema,
                                               json.dumps(tile_layer_metadata),
                                               resample_dict)
 
-        (out_key, out_value) = self._map_outputs(key_type, value_type)
+        out_key = self._map_outputs(key_type)
 
-        return self.geopysc.avro_tuple_rdd_to_python(out_key,
-                                                     out_value,
-                                                     result._1(),
-                                                     result._2())
+        ser = self.geopysc.create_tuple_serializer(result._2(), value_type="Tile")
+
+        return self.geopysc.create_python_rdd(result._1(), ser)
 
     def tile_to_layout(self,
                        key_type,
-                       value_type,
                        rdd,
                        tile_layer_metadata,
                        resample_method=None):
 
         key = self.geopysc.map_key_input(key_type, False)
-        value = self.geopysc.map_value_input(value_type)
 
-        (java_rdd, schema) = self._convert_to_java_rdd(key, value, rdd)
+        (java_rdd, schema) = self._convert_to_java_rdd(key, rdd)
 
         if resample_method is None:
             resample_dict = {}
         else:
             resample_dict = {"resampleMethod": resample_method}
 
-        result = self._tiler_wrapper.tileToLayout(key_type,
-                                                  value_type,
+        result = self._tiler_wrapper.tileToLayout(key,
                                                   java_rdd.rdd(),
                                                   schema,
                                                   json.dumps(tile_layer_metadata),
                                                   resample_dict)
 
-        (out_key, out_value) = self._map_outputs(key_type, value_type)
+        out_key = self._map_outputs(key_type)
 
-        return self.geopysc.avro_tuple_rdd_to_python(out_key,
-                                                     out_value,
-                                                     result._1(),
-                                                     result._2())
+        ser = self.geopysc.create_tuple_serializer(result._2(), value_type="Tile")
+
+        return self.geopysc.create_python_rdd(result._1(), ser)
 
     def merge(self,
               key_type,
-              value_type,
               rdd_1,
               rdd_2):
 
         key = self.geopysc.map_key_input(key_type, False)
-        value = self.geopysc.map_value_input(value_type)
 
-        (java_rdd_1, schema_1) = self._convert_to_java_rdd(key, value, rdd_1)
-        (java_rdd_2, schema_2) = self._convert_to_java_rdd(key, value, rdd_2)
+        (java_rdd_1, schema_1) = self._convert_to_java_rdd(key, rdd_1)
+        (java_rdd_2, schema_2) = self._convert_to_java_rdd(key, rdd_2)
 
-        result = self._merge_wrapper.merge(key_type,
-                                           value_type,
+        result = self._merge_wrapper.merge(key,
                                            java_rdd_1.rdd(),
                                            schema_1,
                                            java_rdd_2.rdd(),
                                            schema_2)
 
-        return self.geopysc.avro_tuple_rdd_to_python(key,
-                                                     value,
-                                                     result._1(),
-                                                     result._2())
+        ser = self.geopysc.create_tuple_serializer(result._2(), value_type="Tile")
+
+        return self.geopysc.create_python_rdd(result._1(), ser)

--- a/geopyspark/geotrellis/value_reader.py
+++ b/geopyspark/geotrellis/value_reader.py
@@ -5,7 +5,6 @@ class _ValueReader(object):
     def __init__(self, geopysc, key_type, value_type):
         self.geopysc = geopysc
         self.key_type = key_type
-        self.value_type = value_type
         self.value_reader = None
         self.ser = None
 
@@ -20,10 +19,8 @@ class _ValueReader(object):
             zdt = ""
 
         key = self.geopysc.map_key_input(self.key_type, True)
-        value = self.geopysc.map_value_input(self.value_type)
 
         tup = self.value_reader.readTile(key,
-                                         value,
                                          layer_name,
                                          zoom_level,
                                          col,
@@ -32,8 +29,8 @@ class _ValueReader(object):
 
         if not self.ser:
             self.ser = \
-                    self.geopysc.create_value_serializer(value,
-                                                         tup._2())
+                    self.geopysc.create_value_serializer(tup._2(),
+                                                        "Tile")
 
         return self.ser.loads(tup._1())[0]
 
@@ -42,14 +39,12 @@ class HadoopValueReader(_ValueReader):
     def __init__(self,
                  geopysc,
                  key_type,
-                 value_type,
                  uri):
 
-        super().__init__(geopysc, key_type, value_type)
+        super().__init__(geopysc, key_type)
 
         self.geopysc = geopysc
         self.key_type = key_type
-        self.value_type = value_type
         self.uri = uri
 
         self.store = self.geopysc.store_factory.buildHadoop(self.uri)
@@ -60,15 +55,13 @@ class S3ValueReader(_ValueReader):
     def __init__(self,
                  geopysc,
                  key_type,
-                 value_type,
                  bucket,
                  prefix):
 
-        super().__init__(geopysc, key_type, value_type)
+        super().__init__(geopysc, key_type)
 
         self.geopysc = geopysc
         self.key_type = key_type
-        self.value_type = value_type
         self.bucket = bucket
         self.prefix = prefix
 
@@ -80,14 +73,12 @@ class FileValueReader(_ValueReader):
     def __init__(self,
                  geopysc,
                  key_type,
-                 value_type,
                  path):
 
-        super().__init__(geopysc, key_type, value_type)
+        super().__init__(geopysc, key_type)
 
         self.geopysc = geopysc
         self.key_type = key_type
-        self.value_type = value_type
         self.path = path
 
         self.store = self.geopysc.store_factory.buildFile(self.path)
@@ -98,7 +89,6 @@ class CassandraValueReader(_ValueReader):
     def __init__(self,
                  geopysc,
                  key_type,
-                 value_type,
                  hosts,
                  username,
                  password,
@@ -110,11 +100,10 @@ class CassandraValueReader(_ValueReader):
                  attribute_key_space,
                  attribute_table):
 
-        super().__init__(geopysc, key_type, value_type)
+        super().__init__(geopysc, key_type)
 
         self.geopysc = geopysc
         self.key_type = key_type
-        self.value_type = value_type
 
         self.hosts = hosts
         self.username = username
@@ -146,17 +135,15 @@ class HBaseValueReader(_ValueReader):
     def __init__(self,
                  geopysc,
                  key_type,
-                 value_type,
                  zookeepers,
                  master,
                  client_port,
                  attribute_table):
 
-        super().__init__(geopysc, key_type, value_type)
+        super().__init__(geopysc, key_type)
 
         self.geopysc = geopysc
         self.key_type = key_type
-        self.value_type = value_type
 
         self.zookeepers = zookeepers
         self.master = master
@@ -177,18 +164,16 @@ class AccumuloValueReader(_ValueReader):
     def __init__(self,
                  geopysc,
                  key_type,
-                 value_type,
                  zookeepers,
                  instance_name,
                  user,
                  password,
                  attribute_table):
 
-        super().__init__(geopysc, key_type, value_type)
+        super().__init__(geopysc, key_type)
 
         self.geopysc = geopysc
         self.key_type = key_type
-        self.value_type = value_type
 
         self.zookeepers = zookeepers
         self.instance_name = instance_name

--- a/geopyspark/tests/hadoop_geotiff_rdd_test.py
+++ b/geopyspark/tests/hadoop_geotiff_rdd_test.py
@@ -51,11 +51,9 @@ class Singleband(GeoTiffIOTest, BaseTestClass):
     def read_singleband_geotrellis(self, options=None):
         if options is None:
             result = self.hadoop_geotiff.get_rdd(SPATIAL,
-                                                 "singleband",
                                                  self.dir_path)
         else:
             result = self.hadoop_geotiff.get_rdd(SPATIAL,
-                                                 "singleband",
                                                  self.dir_path,
                                                  options)
 
@@ -95,11 +93,9 @@ class Multiband(GeoTiffIOTest, BaseTestClass):
     def read_multiband_geotrellis(self, options=None):
         if options is None:
             result = self.hadoop_geotiff.get_rdd(SPATIAL,
-                                                 "multiband",
                                                  self.dir_path)
         else:
             result = self.hadoop_geotiff.get_rdd(SPATIAL,
-                                                 "multiband",
                                                  self.dir_path, options)
 
         return [tile[1] for tile in result.collect()]

--- a/geopyspark/tests/key_value_test.py
+++ b/geopyspark/tests/key_value_test.py
@@ -61,10 +61,21 @@ class KeyValueRecordSchemaTest(unittest.TestCase):
         encoded = self.rdd.map(lambda s: encoder(s))
         actual_kvs = encoded.collect()
 
+        encoded_tiles = [
+            {'bands':
+             [{'cells': bytearray([0, 1, 2, 3, 4, 5]), 'rows': 3, 'cols': 2, 'noDataValue': -128}]
+            },
+            {'bands':
+             [{'cells': bytearray([0, 1, 2, 3, 4, 5]), 'rows': 2, 'cols': 3, 'noDataValue': -128}]
+            },
+            {'bands':
+             [{'cells': bytearray([0, 1, 2, 3, 4, 5]), 'rows': 6, 'cols': 1, 'noDataValue': -128}]
+            }
+        ]
         encoded_tuples = [
-            {'_1': AvroRegistry.tile_encoder(self.arrs[0]), '_2': self.extents[0]},
-            {'_1': AvroRegistry.tile_encoder(self.arrs[1]), '_2': self.extents[1]},
-            {'_1': AvroRegistry.tile_encoder(self.arrs[2]), '_2': self.extents[2]}
+            {'_1': encoded_tiles[0], '_2': self.extents[0]},
+            {'_1': encoded_tiles[1], '_2': self.extents[1]},
+            {'_1': encoded_tiles[2], '_2': self.extents[2]}
         ]
 
         expected_kvs = [

--- a/geopyspark/tests/multiband_test.py
+++ b/geopyspark/tests/multiband_test.py
@@ -29,23 +29,19 @@ class MultibandSchemaTest(BaseTestClass):
     java_rdd = tup._1()
 
     ser = AvroSerializer(tup._2(),
-                         AvroRegistry.multiband_decoder,
-                         AvroRegistry.multiband_encoder)
+                         AvroRegistry.tile_decoder,
+                         AvroRegistry.tile_encoder)
 
     rdd = RDD(java_rdd, BaseTestClass.geopysc.pysc, AutoBatchedSerializer(ser))
     collected = rdd.collect()
 
     def test_encoded_multibands(self):
-        encoded = self.rdd.map(lambda s: AvroRegistry.multiband_encoder(s))
-        actual_encoded = encoded.collect()
+        encoded = self.rdd.map(lambda s: AvroRegistry.tile_encoder(s))
 
-        expected_encoded = [
-            {'bands': [AvroRegistry.tile_encoder(x) for x in self.band_dicts]},
-            {'bands': [AvroRegistry.tile_encoder(x) for x in self.band_dicts]},
-            {'bands': [AvroRegistry.tile_encoder(x) for x in self.band_dicts]}
-        ]
+        actual_encoded = encoded.collect()[0]
+        expected_encoded = AvroRegistry.tile_encoder(self.multiband_dict)
 
-        for actual, expected in zip(actual_encoded, expected_encoded):
+        for actual, expected in zip(actual_encoded['bands'], expected_encoded['bands']):
             self.assertEqual(actual, expected)
 
     def test_decoded_multibands(self):

--- a/geopyspark/tests/s3_geotiff_rdd_test.py
+++ b/geopyspark/tests/s3_geotiff_rdd_test.py
@@ -65,7 +65,6 @@ class Singleband(S3GeoTiffIOTest, BaseTestClass):
     def read_singleband_geotrellis(self, opt=options):
         self.client.putObject(self.bucket, self.key, self.data)
         result = self.s3_geotiff.get_rdd(SPATIAL,
-                                         "singleband",
                                          self.bucket,
                                          self.key,
                                          opt)
@@ -116,7 +115,6 @@ class Multiband(S3GeoTiffIOTest, BaseTestClass):
     def read_multiband_geotrellis(self, opt=options):
         self.client.putObject(self.bucket, self.key, self.data)
         result = self.s3_geotiff.get_rdd(SPATIAL,
-                                         "multiband",
                                          self.bucket,
                                          self.key,
                                          opt)

--- a/geopyspark/tests/tile_layer_metadata_test.py
+++ b/geopyspark/tests/tile_layer_metadata_test.py
@@ -19,13 +19,13 @@ class TileLayerMetadataTest(BaseTestClass):
     dir_path = geotiff_test_path("all-ones.tif")
     options = {'maxTileSize': 256}
 
-    rdd = hadoop_geotiff.get_rdd(SPATIAL, "singleband", dir_path)
+    rdd = hadoop_geotiff.get_rdd(SPATIAL, dir_path)
     value = rdd.collect()[0]
 
     projected_extent = value[0]
     extent = projected_extent['extent']
 
-    (rows, cols) = value[1]['data'].shape
+    (_, rows, cols) = value[1]['data'].shape
 
     layout = {
         "layoutCols": 1,
@@ -47,7 +47,6 @@ class TileLayerMetadataTest(BaseTestClass):
 
     def test_collection_avro_rdd(self):
         result = self.metadata.collect_metadata(SPATIAL,
-                                                "singleband",
                                                 self.rdd,
                                                 self.extent,
                                                 self.layout,
@@ -65,7 +64,6 @@ class TileLayerMetadataTest(BaseTestClass):
         rasterio_rdd = self.geopysc.pysc.parallelize([(self.projected_extent, tile_dict)])
 
         result = self.metadata.collect_metadata(SPATIAL,
-                                                "singleband",
                                                 rasterio_rdd,
                                                 self.extent,
                                                 self.layout,

--- a/geopyspark/tests/tile_layer_methods_test.py
+++ b/geopyspark/tests/tile_layer_methods_test.py
@@ -17,11 +17,11 @@ class TileLayerMethodsTest(BaseTestClass):
     hadoop_geotiff = HadoopGeoTiffRDD(BaseTestClass.geopysc)
 
     dir_path = geotiff_test_path("all-ones.tif")
-    hadoop_rdd = hadoop_geotiff.get_rdd(SPATIAL, "singleband", dir_path)
+    hadoop_rdd = hadoop_geotiff.get_rdd(SPATIAL, dir_path)
 
     data = rasterio.open(dir_path)
     no_data = data.nodata
-    tile = data.read(1)
+    tile = data.read()
     tile_dict = {'data': tile, 'no_data_value': no_data}
 
     value = hadoop_rdd.collect()[0]
@@ -30,7 +30,7 @@ class TileLayerMethodsTest(BaseTestClass):
 
     extent = value[0]['extent']
 
-    (_rows, _cols) = value[1]['data'].shape
+    (_, _rows, _cols) = value[1]['data'].shape
 
     layout = {
         "layoutCols": 1,
@@ -40,7 +40,6 @@ class TileLayerMethodsTest(BaseTestClass):
     }
 
     metadata = methods.collect_metadata(SPATIAL,
-                                        "singleband",
                                         hadoop_rdd,
                                         extent,
                                         layout,
@@ -48,7 +47,6 @@ class TileLayerMethodsTest(BaseTestClass):
 
     def test_cut_tiles_hadoop(self):
         result = self.methods.cut_tiles(SPATIAL,
-                                        "singleband",
                                         self.hadoop_rdd,
                                         self.metadata)
 
@@ -59,7 +57,6 @@ class TileLayerMethodsTest(BaseTestClass):
 
     def test_cut_tiles_rasterio(self):
         result = self.methods.cut_tiles(SPATIAL,
-                                        "singleband",
                                         self.rasterio_rdd,
                                         self.metadata)
 
@@ -70,7 +67,6 @@ class TileLayerMethodsTest(BaseTestClass):
 
     def test_tile_to_layout_hadoop(self):
         result = self.methods.tile_to_layout(SPATIAL,
-                                             "singleband",
                                              self.hadoop_rdd,
                                              self.metadata)
 
@@ -81,7 +77,6 @@ class TileLayerMethodsTest(BaseTestClass):
 
     def test_tile_to_layout_rasterio(self):
         result = self.methods.tile_to_layout(SPATIAL,
-                                             "singleband",
                                              self.rasterio_rdd,
                                              self.metadata)
 
@@ -92,7 +87,6 @@ class TileLayerMethodsTest(BaseTestClass):
 
     def test_merge(self):
         result = self.methods.merge(SPATIAL,
-                                    "singleband",
                                     self.rasterio_rdd,
                                     self.hadoop_rdd)
 

--- a/geopyspark/tests/tile_test.py
+++ b/geopyspark/tests/tile_test.py
@@ -34,12 +34,13 @@ class ShortTileSchemaTest(BaseTestClass):
         actual_encoded = encoded.collect()
 
         expected_encoded = [
-            {'cols': 2, 'rows': 2, 'cells': [0, 0, 1, 1], 'noDataValue': -32768},
-            {'cols': 2, 'rows': 2, 'cells': [1, 2, 3, 4], 'noDataValue': -32768},
-            {'cols': 2, 'rows': 2, 'cells': [5, 6, 7, 8], 'noDataValue': -32768}
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': [0, 0, 1, 1], 'noDataValue': -32768}]},
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': [1, 2, 3, 4], 'noDataValue': -32768}]},
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': [5, 6, 7, 8], 'noDataValue': -32768}]}
         ]
 
-        self.assertEqual(actual_encoded, expected_encoded)
+        for actual, expected in zip(actual_encoded, expected_encoded):
+            self.assertEqual(actual, expected)
 
     def test_decoded_tiles(self):
         for actual, expected in zip(self.collected, self.tiles):
@@ -71,12 +72,13 @@ class UShortTileSchemaTest(BaseTestClass):
         actual_encoded = encoded.collect()
 
         expected_encoded = [
-            {'cols': 2, 'rows': 2, 'cells': [0, 0, 1, 1], 'noDataValue': 0},
-            {'cols': 2, 'rows': 2, 'cells': [1, 2, 3, 4], 'noDataValue': 0},
-            {'cols': 2, 'rows': 2, 'cells': [5, 6, 7, 8], 'noDataValue': 0}
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': [0, 0, 1, 1], 'noDataValue': 0}]},
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': [1, 2, 3, 4], 'noDataValue': 0}]},
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': [5, 6, 7, 8], 'noDataValue': 0}]}
         ]
 
-        self.assertEqual(actual_encoded, expected_encoded)
+        for actual, expected in zip(actual_encoded, expected_encoded):
+            self.assertEqual(actual, expected)
 
     def test_decoded_tiles(self):
         for actual, expected in zip(self.collected, self.tiles):
@@ -108,12 +110,13 @@ class ByteTileSchemaTest(BaseTestClass):
         actual_encoded = encoded.collect()
 
         expected_encoded = [
-            {'cols': 2, 'rows': 2, 'cells': bytearray([0, 0, 1, 1]), 'noDataValue': -128},
-            {'cols': 2, 'rows': 2, 'cells': bytearray([1, 2, 3, 4]), 'noDataValue': -128},
-            {'cols': 2, 'rows': 2, 'cells': bytearray([5, 6, 7, 8]), 'noDataValue': -128}
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': bytearray([0, 0, 1, 1]), 'noDataValue': -128}]},
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': bytearray([1, 2, 3, 4]), 'noDataValue': -128}]},
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': bytearray([5, 6, 7, 8]), 'noDataValue': -128}]}
         ]
 
-        self.assertEqual(actual_encoded, expected_encoded)
+        for actual, expected in zip(actual_encoded, expected_encoded):
+            self.assertEqual(actual, expected)
 
     def test_decoded_tiles(self):
         for actual, expected in zip(self.collected, self.tiles):
@@ -125,9 +128,9 @@ class UByteTileSchemaTest(BaseTestClass):
     java_import(BaseTestClass.geopysc.pysc._gateway.jvm, path)
 
     tiles = [
-        {'data': np.array([0, 0, 1, 1]).reshape(2, 2), 'no_data_value': -128},
-        {'data': np.array([1, 2, 3, 4]).reshape(2, 2), 'no_data_value': -128},
-        {'data': np.array([5, 6, 7, 8]).reshape(2, 2), 'no_data_value': -128}
+        {'data': np.array([0, 0, 1, 1]).reshape(2, 2), 'no_data_value': 0},
+        {'data': np.array([1, 2, 3, 4]).reshape(2, 2), 'no_data_value': 0},
+        {'data': np.array([5, 6, 7, 8]).reshape(2, 2), 'no_data_value': 0}
     ]
 
     sc = BaseTestClass.geopysc.pysc._jsc.sc()
@@ -145,12 +148,13 @@ class UByteTileSchemaTest(BaseTestClass):
         actual_encoded = encoded.collect()
 
         expected_encoded = [
-            {'cols': 2, 'rows': 2, 'cells': bytearray([0, 0, 1, 1]), 'noDataValue': 0},
-            {'cols': 2, 'rows': 2, 'cells': bytearray([1, 2, 3, 4]), 'noDataValue': 0},
-            {'cols': 2, 'rows': 2, 'cells': bytearray([5, 6, 7, 8]), 'noDataValue': 0}
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': bytearray([0, 0, 1, 1]), 'noDataValue': 0}]},
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': bytearray([1, 2, 3, 4]), 'noDataValue': 0}]},
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': bytearray([5, 6, 7, 8]), 'noDataValue': 0}]}
         ]
 
-        self.assertEqual(actual_encoded, expected_encoded)
+        for actual, expected in zip(actual_encoded, expected_encoded):
+            self.assertEqual(actual, expected)
 
     def test_decoded_tiles(self):
         for actual, expected in zip(self.collected, self.tiles):
@@ -182,12 +186,13 @@ class IntTileSchemaTest(BaseTestClass):
         actual_encoded = encoded.collect()
 
         expected_encoded = [
-            {'cols': 2, 'rows': 2, 'cells': [0, 0, 1, 1], 'noDataValue': -2147483648},
-            {'cols': 2, 'rows': 2, 'cells': [1, 2, 3, 4], 'noDataValue': -2147483648},
-            {'cols': 2, 'rows': 2, 'cells': [5, 6, 7, 8], 'noDataValue': -2147483648}
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': [0, 0, 1, 1], 'noDataValue': -2147483648}]},
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': [1, 2, 3, 4], 'noDataValue': -2147483648}]},
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': [5, 6, 7, 8], 'noDataValue': -2147483648}]}
         ]
 
-        self.assertEqual(actual_encoded, expected_encoded)
+        for actual, expected in zip(actual_encoded, expected_encoded):
+            self.assertEqual(actual, expected)
 
     def test_decoded_tiles(self):
         for actual, expected in zip(self.collected, self.tiles):
@@ -219,12 +224,13 @@ class DoubleTileSchemaTest(BaseTestClass):
         actual_encoded = encoded.collect()
 
         expected_encoded = [
-            {'cols': 2, 'rows': 2, 'cells': [0, 0, 1, 1], 'noDataValue': True},
-            {'cols': 2, 'rows': 2, 'cells': [1, 2, 3, 4], 'noDataValue': True},
-            {'cols': 2, 'rows': 2, 'cells': [5, 6, 7, 8], 'noDataValue': True}
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': [0, 0, 1, 1], 'noDataValue': True}]},
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': [1, 2, 3, 4], 'noDataValue': True}]},
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': [5, 6, 7, 8], 'noDataValue': True}]}
         ]
 
-        self.assertEqual(actual_encoded, expected_encoded)
+        for actual, expected in zip(actual_encoded, expected_encoded):
+            self.assertEqual(actual, expected)
 
     def test_decoded_tiles(self):
         for actual, expected in zip(self.collected, self.tiles):
@@ -256,12 +262,13 @@ class FloatTileSchemaTest(BaseTestClass):
         actual_encoded = encoded.collect()
 
         expected_encoded = [
-            {'cols': 2, 'rows': 2, 'cells': [0, 0, 1, 1], 'noDataValue': True},
-            {'cols': 2, 'rows': 2, 'cells': [1, 2, 3, 4], 'noDataValue': True},
-            {'cols': 2, 'rows': 2, 'cells': [5, 6, 7, 8], 'noDataValue': True}
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': [0, 0, 1, 1], 'noDataValue': True}]},
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': [1, 2, 3, 4], 'noDataValue': True}]},
+            {'bands': [{'cols': 2, 'rows': 2, 'cells': [5, 6, 7, 8], 'noDataValue': True}]}
         ]
 
-        self.assertEqual(actual_encoded, expected_encoded)
+        for actual, expected in zip(actual_encoded, expected_encoded):
+            self.assertEqual(actual, expected)
 
     def test_decoded_tiles(self):
         for actual, expected in zip(self.collected, self.tiles):

--- a/geopyspark/tests/tuple_test.py
+++ b/geopyspark/tests/tuple_test.py
@@ -35,9 +35,9 @@ class TupleSchemaTest(BaseTestClass):
     ]
 
     arrs = [
-        {'data': np.array([0, 1, 2, 3, 4, 5]).reshape(3, 2), 'no_data_value': -2147483648},
-        {'data': np.array([0, 1, 2, 3, 4, 5]).reshape(2, 3), 'no_data_value': -2147483648},
-        {'data': np.array([0, 1, 2, 3, 4, 5]).reshape(6, 1), 'no_data_value': -2147483648}
+        {'data': np.array([0, 1, 2, 3, 4, 5]).reshape(1, 3, 2), 'no_data_value': -2147483648},
+        {'data': np.array([0, 1, 2, 3, 4, 5]).reshape(1, 2, 3), 'no_data_value': -2147483648},
+        {'data': np.array([0, 1, 2, 3, 4, 5]).reshape(1, 6, 1), 'no_data_value': -2147483648}
     ]
 
     sc = BaseTestClass.geopysc.pysc._jsc.sc()


### PR DESCRIPTION
This Pr merges `Tile` and `MultibandTile` so that they are both treated the same in GeoPySpark. Now, `Tile`s will be read in and sent to scala as `MultibandTile`s regardless of the number of bands they have. This greatly simplifies the code, and makes it easier to work with.

This Pr fixes #60