### PR TITLE
Geotiff Rdd Refactor

### DIFF
--- a/geopyspark/geotrellis/geotiff_rdd.py
+++ b/geopyspark/geotrellis/geotiff_rdd.py
@@ -1,37 +1,43 @@
 from geopyspark.geopycontext import GeoPyContext
 
 
-class HadoopGeoTiffRDD(object):
-    def __init__(self, geopysc):
-        self.geopysc = geopysc
-        self._hadoop_wrapper = self.geopysc.hadoop_geotiff_rdd
+def geotiff_rdd(geopysc,
+                rdd_type,
+                uri,
+                options=None,
+                **kwargs):
 
-    def get_rdd(self, key_type, path, options=None):
-        key = self.geopysc.map_key_input(key_type, False)
+    key = geopysc.map_key_input(rdd_type, False)
 
-        if options is None:
-            result = self._hadoop_wrapper.getRDD(key, path, self.geopysc.sc)
+    if kwargs and not options:
+        options = kwargs
+
+    if 's3' in uri:
+        key_and_bucket_uri = uri.split("s3://")[1]
+        (bucket, prefix) = key_and_bucket_uri.split("/", 1)
+
+        if not options:
+            result = geopysc.s3_geotiff_rdd.getRDD(key,
+                                                   bucket,
+                                                   prefix,
+                                                   geopysc.sc)
         else:
-            result = self._hadoop_wrapper.getRDD(key, path, options, self.geopysc.sc)
+            result = geopysc.s3_geotiff_rdd.getRDD(key,
+                                                   bucket,
+                                                   prefix,
+                                                   options,
+                                                   geopysc.sc)
 
-        ser = self.geopysc.create_tuple_serializer(result._2(), value_type="Tile")
-
-        return self.geopysc.create_python_rdd(result._1(), ser)
-
-
-class S3GeoTiffRDD(object):
-    def __init__(self, geopysc):
-        self.geopysc = geopysc
-        self._s3_wrapper = self.geopysc.s3_geotiff_rdd
-
-    def get_rdd(self, key_type, bucket, prefix, options=None):
-        key = self.geopysc.map_key_input(key_type, False)
-
-        if options is None:
-            result = self._s3_wrapper.getRDD(key, bucket, prefix, self.geopysc.sc)
+    else:
+        if not options:
+            result = geopysc.hadoop_geotiff_rdd.getRDD(key,
+                                                       uri,
+                                                       geopysc.sc)
         else:
-            result = self._s3_wrapper.getRDD(key, bucket, prefix, options, self.geopysc.sc)
+            result = geopysc.hadoop_geotiff_rdd.getRDD(key,
+                                                       uri,
+                                                       options,
+                                                       geopysc.sc)
 
-        ser = self.geopysc.create_tuple_serializer(result._2(), value_type="Tile")
-
-        return self.geopysc.create_python_rdd(result._1(), ser)
+    ser = geopysc.create_tuple_serializer(result._2(), value_type="Tile")
+    return geopysc.create_python_rdd(result._1(), ser)

--- a/geopyspark/geotrellis/geotiff_rdd.py
+++ b/geopyspark/geotrellis/geotiff_rdd.py
@@ -19,10 +19,38 @@ def geotiff_rdd(geopysc,
             GeoTiffs must have the same saptial type.
         uri (str): The path to a given file/directory.
         options (dict, optional): A dictionary of different options that are used
-            when creating the RDD. This defaults to the None. If None, then the
+            when creating the RDD. This defaults to None. If None, then the
             RDD will be created using the default options for the given backend
             in GeoTrellis. Note: key values should be in camel case, as this is
             the style that is used in Scala.
+
+            These are the options when using the local file system or HDFS:
+                crs (str, optional): The CRS that the output tiles should be
+                    in. The CRS must be in the well-known name format. If None,
+                    then the CRS that the tiles were originally in will be used.
+                timeTag (str, optional): The name of the tiff tag that contains
+                    the time stamp for the tile. If None, then the default value
+                    is: 'TIFFTAG_DATETIME'.
+                timeFormat (str, optional): The pattern of the time stamp for
+                    java.time.format.DateTimeFormatter to parse. If None,
+                    then the default value is: 'yyyy:MM:dd HH:mm:ss".
+                maxTileSize (int, optional): The max size of each tile in the
+                    resulting RDD. If the size is smaller than a read in tile,
+                    then that tile will be broken into tiles of the specified
+                    size. If None, then the whole tile will be read in.
+                numPartitions (int, optional): The number of repartitions Spark
+                    will make when the data is repartitioned. If None, then the
+                    data will not be repartitioned.
+                chunkSize (int, optional): How many bytes of the file should be
+                    read in at a time. If None, then files will be read in 65536
+                    byte chunks.
+
+            S3 has the above options in addition to this:
+                s3Client (st, optional): Which S3Cleint to use when reading
+                    GeoTiffs. There are currently two options: 'default' and
+                    'mock'. If None, 'defualt' is used. Note: 'mock' should
+                    only be used in unit tests.
+
         **kwargs: Option parameters can also be entered as keyword arguements.
             Note: Defining both options and keyword arguements will cause the
             keyword arguements to be ignored in favor of options.

--- a/geopyspark/geotrellis/geotiff_rdd.py
+++ b/geopyspark/geotrellis/geotiff_rdd.py
@@ -1,4 +1,7 @@
-from geopyspark.geopycontext import GeoPyContext
+""""This module contains functions that create RDDs from files.
+
+There is only one function found within this module at this time, geotiff_rdd.
+"""
 
 
 def geotiff_rdd(geopysc,
@@ -6,6 +9,46 @@ def geotiff_rdd(geopysc,
                 uri,
                 options=None,
                 **kwargs):
+
+    """Creates a RDD from GeoTiffs that are located on the local file system, HDFS, or S3.
+
+    Args:
+        geopysc (GeoPyContext): The GeoPyContext being used this session.
+        rdd_type (str): What the spatial type of the geotiffs are. This is
+            represented by the constants: SPATIAL and SPACETIME. Note: All of the
+            GeoTiffs must have the same saptial type.
+        uri (str): The path to a given file/directory.
+        options (dict, optional): A dictionary of different options that are used
+            when creating the RDD. This defaults to the None. If None, then the
+            RDD will be created using the default options for the given backend
+            in GeoTrellis. Note: key values should be in camel case, as this is
+            the style that is used in Scala.
+        **kwargs: Option parameters can also be entered as keyword arguements.
+            Note: Defining both options and keyword arguements will cause the
+            keyword arguements to be ignored in favor of options.
+
+    Returns:
+        RDD: A RDD that contains tuples of dictionaries, (K, V).
+            K (dict): The projected extent information of the GeoTiff.
+                Which is the pyhiscal extent and the CRS of the GeoTiff.
+            V (dict): The raster tile information of the GeoTiff.
+                Which is the Tile data itself represented as a numpy array,
+                and the no_data_value of the Tile, if any.
+
+    Examples:
+        Reading a local GeoTiff that does not have a time component with the
+        default options.
+
+        >>> geotiff_rdd(geopysc, SPATIAL, 'file://path/to/my/geotiff.tif')
+        RDD
+
+        Reading a GeoTiff from S3 that does have a time component. An option
+        parameter is also passed in which specifies that each GeoTiff should
+        be cut up into 256x256 tiles.
+
+        >>> geotiff_rdd(geopysc, SPACETIME, 's3://bucket/data/september_images/', maxTileSize=256)
+        RDD
+    """
 
     key = geopysc.map_key_input(rdd_type, False)
 

--- a/geopyspark/geotrellis/geotiff_rdd.py
+++ b/geopyspark/geotrellis/geotiff_rdd.py
@@ -83,7 +83,7 @@ def geotiff_rdd(geopysc,
     if kwargs and not options:
         options = kwargs
 
-    if 's3' in uri:
+    if uri.startswith("s3://"):
         key_and_bucket_uri = uri.split("s3://")[1]
         (bucket, prefix) = key_and_bucket_uri.split("/", 1)
 

--- a/geopyspark/tests/hadoop_geotiff_rdd_test.py
+++ b/geopyspark/tests/hadoop_geotiff_rdd_test.py
@@ -3,7 +3,7 @@ from os import walk, path
 import rasterio
 
 from geopyspark.tests.python_test_utils import check_directory, geotiff_test_path
-from geopyspark.geotrellis.geotiff_rdd import HadoopGeoTiffRDD
+from geopyspark.geotrellis.geotiff_rdd import geotiff_rdd
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis.constants import SPATIAL
 
@@ -43,19 +43,18 @@ class GeoTiffIOTest(object):
 
 
 class Singleband(GeoTiffIOTest, BaseTestClass):
-    hadoop_geotiff = HadoopGeoTiffRDD(BaseTestClass.geopysc)
-
     dir_path = geotiff_test_path("one-month-tiles/")
-    options = {'maxTileSize': 256}
 
     def read_singleband_geotrellis(self, options=None):
         if options is None:
-            result = self.hadoop_geotiff.get_rdd(SPATIAL,
-                                                 self.dir_path)
+            result = geotiff_rdd(BaseTestClass.geopysc,
+                                 SPATIAL,
+                                 self.dir_path)
         else:
-            result = self.hadoop_geotiff.get_rdd(SPATIAL,
-                                                 self.dir_path,
-                                                 options)
+            result = geotiff_rdd(BaseTestClass.geopysc,
+                                 SPATIAL,
+                                 self.dir_path,
+                                 maxTileSize=256)
 
         return [tile[1] for tile in result.collect()]
 
@@ -73,7 +72,7 @@ class Singleband(GeoTiffIOTest, BaseTestClass):
         self.assertEqual(len(windowed_tiles), 24)
 
     def test_windowed_tiles(self):
-        geotrellis_tiles = self.read_singleband_geotrellis(self.options)
+        geotrellis_tiles = self.read_singleband_geotrellis(True)
 
         file_paths = self.get_filepaths(self.dir_path)
         rasterio_tiles = self.read_geotiff_rasterio(file_paths, True)
@@ -86,17 +85,19 @@ class Singleband(GeoTiffIOTest, BaseTestClass):
 
 
 class Multiband(GeoTiffIOTest, BaseTestClass):
-    hadoop_geotiff = HadoopGeoTiffRDD(BaseTestClass.geopysc)
     dir_path = geotiff_test_path("one-month-tiles-multiband/")
     options = {'maxTileSize': 256}
 
     def read_multiband_geotrellis(self, options=None):
         if options is None:
-            result = self.hadoop_geotiff.get_rdd(SPATIAL,
-                                                 self.dir_path)
+            result = geotiff_rdd(BaseTestClass.geopysc,
+                                 SPATIAL,
+                                 self.dir_path)
         else:
-            result = self.hadoop_geotiff.get_rdd(SPATIAL,
-                                                 self.dir_path, options)
+            result = geotiff_rdd(BaseTestClass.geopysc,
+                                 SPATIAL,
+                                 self.dir_path,
+                                 options)
 
         return [tile[1] for tile in result.collect()]
 

--- a/geopyspark/tests/s3_geotiff_rdd_test.py
+++ b/geopyspark/tests/s3_geotiff_rdd_test.py
@@ -3,7 +3,7 @@ import unittest
 import rasterio
 
 from geopyspark.tests.python_test_utils import check_directory, geotiff_test_path
-from geopyspark.geotrellis.geotiff_rdd import S3GeoTiffRDD
+from geopyspark.geotrellis.geotiff_rdd import geotiff_rdd
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis.constants import SPATIAL
 from py4j.java_gateway import java_import
@@ -50,10 +50,10 @@ class Singleband(S3GeoTiffIOTest, BaseTestClass):
     mock_wrapper = BaseTestClass.geopysc._jvm.MockS3ClientWrapper
     client = mock_wrapper.mockClient()
 
-    s3_geotiff = S3GeoTiffRDD(BaseTestClass.geopysc)
-
     key = "one-month-tiles/test-200506000000_0_0.tif"
     bucket = "test"
+
+    uri = "s3://test/one-month-tiles/test-200506000000_0_0.tif"
     file_path = geotiff_test_path(key)
 
     in_file = open(file_path, "rb")
@@ -64,10 +64,7 @@ class Singleband(S3GeoTiffIOTest, BaseTestClass):
 
     def read_singleband_geotrellis(self, opt=options):
         self.client.putObject(self.bucket, self.key, self.data)
-        result = self.s3_geotiff.get_rdd(SPATIAL,
-                                         self.bucket,
-                                         self.key,
-                                         opt)
+        result = geotiff_rdd(BaseTestClass.geopysc, SPATIAL, self.uri, opt)
 
         return [tile[1] for tile in result.collect()]
 
@@ -96,15 +93,15 @@ class Singleband(S3GeoTiffIOTest, BaseTestClass):
 
 class Multiband(S3GeoTiffIOTest, BaseTestClass):
     java_import(BaseTestClass.geopysc._jvm,
-                "geopyspark.geotrellis.testkit.MockS3ClientWrapper")
+    "geopyspark.geotrellis.testkit.MockS3ClientWrapper")
 
     mock_wrapper = BaseTestClass.geopysc._jvm.MockS3ClientWrapper
     client = mock_wrapper.mockClient()
 
-    s3_geotiff = S3GeoTiffRDD(BaseTestClass.geopysc)
-
     key = "one-month-tiles-multiband/result.tif"
     bucket = "test"
+
+    uri = "s3://test/one-month-tiles-multiband/result.tif"
     file_path = geotiff_test_path(key)
     options = {"s3Client": "mock"}
 
@@ -114,10 +111,10 @@ class Multiband(S3GeoTiffIOTest, BaseTestClass):
 
     def read_multiband_geotrellis(self, opt=options):
         self.client.putObject(self.bucket, self.key, self.data)
-        result = self.s3_geotiff.get_rdd(SPATIAL,
-                                         self.bucket,
-                                         self.key,
-                                         opt)
+        result = geotiff_rdd(BaseTestClass.geopysc,
+                             SPATIAL,
+                             self.uri,
+                             opt)
 
         return [tile[1] for tile in result.collect()]
 

--- a/geopyspark/tests/tile_layer_metadata_test.py
+++ b/geopyspark/tests/tile_layer_metadata_test.py
@@ -4,7 +4,7 @@ import rasterio
 
 from geopyspark.tests.python_test_utils import check_directory, geotiff_test_path
 from geopyspark.geotrellis.tile_layer_methods import TileLayerMethods
-from geopyspark.geotrellis.geotiff_rdd import HadoopGeoTiffRDD
+from geopyspark.geotrellis.geotiff_rdd import geotiff_rdd
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis.constants import SPATIAL
 
@@ -14,12 +14,10 @@ check_directory()
 
 class TileLayerMetadataTest(BaseTestClass):
     metadata = TileLayerMethods(BaseTestClass.geopysc)
-    hadoop_geotiff = HadoopGeoTiffRDD(BaseTestClass.geopysc)
 
     dir_path = geotiff_test_path("all-ones.tif")
-    options = {'maxTileSize': 256}
 
-    rdd = hadoop_geotiff.get_rdd(SPATIAL, dir_path)
+    rdd = geotiff_rdd(BaseTestClass.geopysc, SPATIAL, dir_path)
     value = rdd.collect()[0]
 
     projected_extent = value[0]

--- a/geopyspark/tests/tile_layer_methods_test.py
+++ b/geopyspark/tests/tile_layer_methods_test.py
@@ -4,7 +4,7 @@ import rasterio
 
 from geopyspark.tests.python_test_utils import check_directory, geotiff_test_path
 from geopyspark.geotrellis.tile_layer_methods import TileLayerMethods
-from geopyspark.geotrellis.geotiff_rdd import HadoopGeoTiffRDD
+from geopyspark.geotrellis.geotiff_rdd import geotiff_rdd
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis.constants import SPATIAL
 
@@ -14,10 +14,9 @@ check_directory()
 
 class TileLayerMethodsTest(BaseTestClass):
     methods = TileLayerMethods(BaseTestClass.geopysc)
-    hadoop_geotiff = HadoopGeoTiffRDD(BaseTestClass.geopysc)
 
     dir_path = geotiff_test_path("all-ones.tif")
-    hadoop_rdd = hadoop_geotiff.get_rdd(SPATIAL, dir_path)
+    hadoop_rdd = geotiff_rdd(BaseTestClass.geopysc, SPATIAL, dir_path)
 
     data = rasterio.open(dir_path)
     no_data = data.nodata


### PR DESCRIPTION
This is Pr is based on another, open Pr #65 . `HadoopGeoTiffRDD` and `S3GeoTiffRDD` have been removed in favor of just a single method, `geotiff_rdd`. By taking a `uri`, this function will be able to determine which backend to read from.

This Pr fixes #63 