### PR TITLE
Yet Another Catalog Refactor

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerWriterFactory.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerWriterFactory.scala
@@ -48,7 +48,7 @@ abstract class LayerWriterWrapper {
       case ("zorder", "millis") => ZCurveKeyIndexMethod.byMilliseconds(1)
       case ("zorder", "seconds") => ZCurveKeyIndexMethod.bySecond
       case ("zorder", "minutes") => ZCurveKeyIndexMethod.byMinute
-      case ("zorder", "hour") => ZCurveKeyIndexMethod.byHour
+      case ("zorder", "hours") => ZCurveKeyIndexMethod.byHour
       case ("zorder", "days") => ZCurveKeyIndexMethod.byDay
       case ("zorder", "months") => ZCurveKeyIndexMethod.byMonth
       case ("zorder", "years") => ZCurveKeyIndexMethod.byYear

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -1,232 +1,222 @@
 import json
-import re
 
 from shapely.geometry import Polygon
 from shapely.wkt import dumps
 from urllib.parse import urlparse
 
 
-class Catalog(object):
-    def __init__(self, geopysc, options=None, **kwargs):
-        self.geopysc = geopysc
+_mapped_builds = {}
 
-        self.uri = None
 
-        self.store = None
-        self.reader = None
-        self.writer = None
+def _construct_catalog(geopysc, new_uri, options):
+    if new_uri not in _mapped_builds:
 
-        if options:
-            self.options = options
-        elif kwargs:
-            self.options = kwargs
+        parsed_uri = urlparse(new_uri)
+        backend = parsed_uri.scheme
+
+        if backend == 'hdfs':
+            store = geopysc.store_factory.buildHadoop(new_uri)
+            reader = geopysc.reader_factory.buildHadoop(store, geopysc.sc)
+            writer = geopysc.writer_factory.buildHadoop(store)
+
+        elif backend == 'file':
+            store = geopysc.store_factory.buildFile(new_uri)
+            reader = geopysc.reader_factory.buildFile(store, geopysc.sc)
+            writer = geopysc.writer_factory.buildFile(store)
+
+        elif backend == 's3':
+            store = geopysc.store_factory.buildS3(parsed_uri.netloc, parsed_uri.path[1:])
+            reader = geopysc.reader_factory.buildS3(store, geopysc.sc)
+            writer = geopysc.writer_factory.buildS3(store)
+
+        elif backend == 'cassandra':
+            parameters = parsed_uri.query.split('&')
+            parameter_dict = {}
+
+            for param in parameters:
+                split_param = param.split('=', 1)
+                parameter_dict[split_param[0]] = split_param[1]
+
+            store = geopysc.store_factory.buildCassandra(
+                parameter_dict['host'],
+                parameter_dict['username'],
+                parameter_dict['password'],
+                parameter_dict['keyspace'],
+                parameter_dict['table'],
+                options)
+
+            reader = geopysc.reader_factory.buildCassandra(store, geopysc.sc)
+            writer = geopysc.writer_factory.buildCassandra(store,
+                                                           parameter_dict['keyspace'],
+                                                           parameter_dict['table'])
+
+        elif backend == 'hbase':
+
+            # The assumed uri looks like: hbase://zoo1, zoo2, ..., zooN: port/table
+            (zookeepers, port) = parsed_uri.netloc.split(':')
+            table = parsed_uri.path
+
+            if 'master' in options:
+                master = options['master']
+            else:
+                master = ""
+
+            store = geopysc.store_factory.buildHBase(zookeepers, master, port, table)
+            reader = geopysc.reader_factory.buildHBase(store, geopysc.sc)
+            writer = geopysc.writer_factory.buildHBase(store, table)
+
+        elif backend == 'accumulo':
+
+            # The assumed uri looks like: accumulo//username:password/zoo1, zoo2/instance/table
+            (user, password) = parsed_uri.netloc.split(':')
+            split_parameters = parsed_uri.path.split('/')[1:]
+
+            store = geopysc.store_factory.buildAccumulo(split_parameters[0],
+                                                        split_parameters[1],
+                                                        user,
+                                                        password,
+                                                        split_parameters[2])
+
+            reader = geopysc.reader_factory.buildAccumulo(split_parameters[1],
+                                                          store,
+                                                          geopysc.sc)
+
+            writer = geopysc.writer_factory.buildAccumulo(split_parameters[1],
+                                                          store,
+                                                          split_parameters[2])
+
         else:
-            self.options = {}
+            raise Exception("Cannot find Attribute Store for, {}".format(backend))
 
-    def _construct_catalog(self, new_uri):
-        if new_uri != self.uri and new_uri is not None:
-            self.uri = new_uri
+        _mapped_builds[new_uri] = (store, reader, writer)
 
-            parsed_uri = urlparse(self.uri)
-            backend = parsed_uri.scheme
+def read(geopysc,
+         rdd_type,
+         uri,
+         layer_name,
+         layer_zoom,
+         options=None,
+         **kwargs):
 
-            if backend == 'hdfs':
-                self.store = self.geopysc.store_factory.buildHadoop(self.uri)
+    if options:
+        options = options
+    elif kwargs:
+        options = kwargs
+    else:
+        options = {}
 
-                self.reader = \
-                        self.geopysc.reader_factory.buildHadoop(self.store,
-                                                                self.geopysc.sc)
-                self.writer = \
-                        self.geopysc.writer_factory.buildHadoop(self.store)
+    _construct_catalog(geopysc, uri, options)
 
-            elif backend == 'file':
-                self.store = self.geopysc.store_factory.buildFile(self.uri)
+    (store, reader, _) = _mapped_builds[uri]
 
-                self.reader = \
-                        self.geopysc.reader_factory.buildFile(self.store,
-                                                              self.geopysc.sc)
-                self.writer = \
-                        self.geopysc.writer_factory.buildFile(self.store)
+    key = geopysc.map_key_input(rdd_type, True)
 
-            elif backend == 's3':
-                self.store = self.geopysc.store_factory.buildS3(parsed_uri.netloc,
-                                                                parsed_uri.path[1:])
+    tup = reader.read(key, layer_name, layer_zoom)
+    schema = tup._2()
 
-                self.reader = \
-                        self.geopysc.reader_factory.buildS3(self.store,
-                                                            self.geopysc.sc)
+    if rdd_type == "spatial":
+        jmetadata = store.metadataSpatial(layer_name, layer_zoom)
+    else:
+        jmetadata = store.metadataSpaceTime(layer_name, layer_zoom)
 
-                self.writer = self.geopysc.writer_factory.buildS3(self.store)
+    metadata = json.loads(jmetadata)
+    ser = geopysc.create_tuple_serializer(schema, value_type="Tile")
 
-            elif backend == 'cassandra':
-                parameters = parsed_uri.query.split('&')
-                parameter_dict = {}
+    rdd = geopysc.create_python_rdd(tup._1(), ser)
 
-                for param in parameters:
-                    split_param = param.split('=', 1)
-                    parameter_dict[split_param[0]] = split_param[1]
+    return (rdd, schema, metadata)
 
-                self.store = self.geopysc.store_factory.buildCassandra(
-                    parameter_dict['host'],
-                    parameter_dict['username'],
-                    parameter_dict['password'],
-                    parameter_dict['keyspace'],
-                    parameter_dict['table'],
-                    self.options)
+def query(geopysc,
+          rdd_type,
+          uri,
+          layer_name,
+          layer_zoom,
+          intersects,
+          time_intervals=None,
+          options=None,
+          **kwargs):
 
-                self.reader = \
-                        self.geopysc.reader_factory.buildCassandra(self.store,
-                                                                   self.geopysc.sc)
+    if options:
+        options = options
+    elif kwargs:
+        options = kwargs
+    else:
+        options = {}
 
-                self.writer = \
-                        self.geopysc.writer_factory.buildCassandra(self.store,
-                                                                   parameter_dict['keyspace'],
-                                                                   parameter_dict['table'])
+    _construct_catalog(geopysc, uri, options)
 
-            elif backend == 'hbase':
+    (store, reader, _) = _mapped_builds[uri]
 
-                # The assumed uri looks like: hbase://zoo1, zoo2, ..., zooN: port/table
-                (zookeepers, port) = parsed_uri.netloc.split(':')
-                table = parsed_uri.path
+    key = geopysc.map_key_input(rdd_type, True)
 
-                if 'master' in self.options:
-                    master = self.options['master']
-                else:
-                    master = ""
+    if time_intervals is None:
+        time_intervals = []
 
+    if isinstance(intersects, Polygon):
+        tup = reader.query(key,
+                           layer_name,
+                           layer_zoom,
+                           dumps(intersects),
+                           time_intervals)
 
-                self.store = \
-                        self.geopysc.store_factory.buildHBase(zookeepers,
-                                                              master,
-                                                              port,
-                                                              table)
-                self.reader = \
-                        self.geopysc.reader_factory.buildHBase(self.store,
-                                                               self.geopysc.sc)
+    elif isinstance(intersects, str):
+        tup = reader.query(key,
+                           layer_name,
+                           layer_zoom,
+                           intersects,
+                           time_intervals)
+    else:
+        raise Exception("Could not query intersection", intersects)
 
-                self.writer = \
-                        self.geopysc.writer_factory.buildHBase(self.store,
-                                                               table)
+    schema = tup._2()
 
-            elif backend == 'accumulo':
+    if rdd_type == "spatial":
+        jmetadata = store.metadataSpatial(layer_name, layer_zoom)
+    else:
+        jmetadata = store.metadataSpaceTime(layer_name, layer_zoom)
 
-                # The assumed uri looks like: accumulo//username:password/zoo1, zoo2/instance/table
-                (user, password) = parsed_uri.netloc.split(':')
-                split_parameters = parsed_uri.path.split('/')[1:]
+    metadata = json.loads(jmetadata)
+    ser = geopysc.create_tuple_serializer(schema, value_type="Tile")
 
-                self.store = \
-                        self.geopysc.store_factory.buildAccumulo(split_parameters[0],
-                                                                 split_parameters[1],
-                                                                 user,
-                                                                 password,
-                                                                 split_parameters[2])
-                self.reader = \
-                        self.geopysc.reader_factory.buildAccumulo(split_parameters[1],
-                                                                  self.store,
-                                                                  self.geopysc.sc)
-                self.writer = \
-                        self.geopysc.writer_factory.buildAccumulo(split_parameters[1],
-                                                                  self.store,
-                                                                  split_parameters[2])
+    rdd = geopysc.create_python_rdd(tup._1(), ser)
 
-            else:
-                raise Exception("Cannot find Attribute Store for, {}".format(backend))
+    return (rdd, schema, metadata)
 
-        def read(self,
-                 rdd_type,
-                 uri,
+def write(geopysc,
+          rdd_type,
+          uri,
+          layer_name,
+          layer_zoom,
+          rdd,
+          metadata,
+          index_strategy="zorder",
+          time_unit=None,
+          options=None,
+          **kwargs):
+
+    if options:
+        options = options
+    elif kwargs:
+        options = kwargs
+    else:
+        options = {}
+
+    _construct_catalog(geopysc, uri, options)
+
+    (_, _, writer) = _mapped_builds[uri]
+
+    key = geopysc.map_key_input(rdd_type, True)
+
+    schema = metadata.schema
+
+    if not time_unit:
+        time_unit = ""
+
+    writer.write(key,
                  layer_name,
-                 layer_zoom):
-
-            self._construct_catalog(uri)
-
-            key = self.geopysc.map_key_input(rdd_type, True)
-
-            tup = self.reader.read(key, layer_name, layer_zoom)
-            schema = tup._2()
-
-            if rdd_type == "spatial":
-                jmetadata = self.store.metadataSpatial(layer_name, layer_zoom)
-            else:
-                jmetadata = self.store.metadataSpaceTime(layer_name, layer_zoom)
-
-            metadata = json.loads(jmetadata)
-            ser = self.geopysc.create_tuple_serializer(schema, value_type="Tile")
-
-            rdd = self.geopysc.create_python_rdd(tup._1(), ser)
-
-            return (rdd, schema, metadata)
-
-        def query(self,
-                  rdd_type,
-                  uri,
-                  layer_name,
-                  layer_zoom,
-                  intersects,
-                  time_intervals=None):
-
-            self._construct_catalog(uri)
-
-            key = self.geopysc.map_key_input(rdd_type, True)
-
-            if time_intervals is None:
-                time_intervals = []
-
-            if isinstance(intersects, Polygon):
-                tup = self.reader.query(key,
-                                        layer_name,
-                                        layer_zoom,
-                                        dumps(intersects),
-                                        time_intervals)
-
-            elif isinstance(intersects, str):
-                tup = self.reader.query(key,
-                                        layer_name,
-                                        layer_zoom,
-                                        intersects,
-                                        time_intervals)
-            else:
-                raise Exception("Could not query intersection", intersects)
-
-            schema = tup._2()
-
-            if rdd_type == "spatial":
-                jmetadata = self.store.metadataSpatial(layer_name, layer_zoom)
-            else:
-                jmetadata = self.store.metadataSpaceTime(layer_name, layer_zoom)
-
-            metadata = json.loads(jmetadata)
-            ser = self.geopysc.create_tuple_serializer(schema, value_type="Tile")
-
-            rdd = self.geopysc.create_python_rdd(tup._1(), ser)
-
-            return (rdd, schema, metadata)
-
-        def write(self,
-                  rdd_type,
-                  layer_name,
-                  layer_zoom,
-                  rdd,
-                  metadata,
-                  index_strategy="zorder",
-                  time_unit=None,
-                  uri=None):
-
-            if uri is not None:
-                self._construct_catalog(uri)
-
-            key = self.geopysc.map_key_input(rdd_type, True)
-
-            schema = metadata.schema
-
-            if not time_unit:
-                time_unit = ""
-
-            self.writer.write(key,
-                              layer_name,
-                              layer_zoom,
-                              rdd._jrdd,
-                              json.dumps(metadata),
-                              schema,
-                              time_unit,
-                              index_strategy)
+                 layer_zoom,
+                 rdd._jrdd,
+                 json.dumps(metadata),
+                 schema,
+                 time_unit,
+                 index_strategy)

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -483,7 +483,7 @@ def write(geopysc,
 
     key = geopysc.map_key_input(rdd_type, True)
 
-    schema = metadata.schema
+    schema = geopysc.create_schema(key)
 
     if not time_unit:
         time_unit = ""
@@ -492,7 +492,7 @@ def write(geopysc,
                  layer_name,
                  layer_zoom,
                  rdd._jrdd,
-                 json.dumps(metadata),
                  schema,
+                 json.dumps(metadata),
                  time_unit,
                  index_strategy)

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -1,3 +1,9 @@
+"""Methods for reading, querying, and saving tile layers to and from Geotrellis Catalogs.
+
+Because GeoPySpark represents all raster data as 3D numpy arrays, data that is read/written out
+will be in a multiband format; regardless of how the data was originally formatted.
+"""
+
 import json
 
 from geopyspark.geotrellis.constants import SPATIAL, TILE, ZORDER
@@ -68,7 +74,7 @@ def _construct_catalog(geopysc, new_uri, options):
 
         elif backend == 'accumulo':
 
-            # The assumed uri looks like: accumulo//username:password/zoo1, zoo2/instance/table
+            # The assumed uri looks like: accumulo://username:password/zoo1, zoo2/instance/table
             (user, password) = parsed_uri.netloc.split(':')
             split_parameters = parsed_uri.path.split('/')[1:]
 
@@ -98,6 +104,78 @@ def read(geopysc,
          layer_zoom,
          options=None,
          **kwargs):
+
+    """Reads a single, zoom layer from a GeoTrellis catalog.
+    Note, this will read the entire layer. If only part of the layer is needed, consider using
+    query instead.
+
+    A layer can be read from various backends. These are the ones that are currently supported:
+        Local Filesystem
+        HDFS
+        S3
+        Cassandra
+        HBase
+        Accumulo
+
+    Args:
+        geopysc (GeoPyContext): The GeoPyContext being used this session.
+        rdd_type (str): What the spatial type of the geotiffs are. This is
+            represented by the constants: SPATIAL and SPACETIME. Note: All of the
+            GeoTiffs must have the same saptial type.
+        uri (str): The Uniform Resource Identifier used to point towards the desired GeoTrellis
+        catalog to be read from. The shape of this string varies depending on backend.
+
+            Example uris for each backend:
+                Local Filesystem: file://my_folder/my_catalog/
+                HDFS: hdfs://my_folder/my_catalog/
+                S3: s3://my_bucket/my_catalog/
+                Cassandra: cassandra:name?username=user&password=pass&host=host1&keyspace=key&table=table
+                HBase: hbase://zoo1, zoo2: port/table
+                Accumulo: accumulo://username:password/zoo1, zoo2/instance/table
+        layer_name (str): The name of the GeoTrellis catalog to be read from.
+        layer_zoom (int): The zoom level of the layer that is to be read.
+        options (dict, optional): Additional parameters for reading the tile for specific backends.
+            The dictioanry is only used for Cassandra and HBase, no other backend requires this
+            to be set.
+
+            Fields that can be set for Cassandra:
+                replicationStrategy (str, optional): If not specified, then 'SimpleStrategy' will
+                    be used.
+                replicationFactor (int, optional): If not specified, then 1 will be used.
+                localDc (str, optional): If not specified, then 'datacenter1' will be used.
+                usedHostsPerRemoteDc (int, optional): If not specified, then 0 will be used.
+                allowRemoteDCsForLocalConsistencyLevel (int, optional): If you'd like this feature,
+                    then the value would be 1, Otherwise, the value should be 0. If not specified,
+                    then 0 will be used.
+
+            Fields that can be set for HBase:
+                master (str, optional): If not specified, then 'null' will be used.
+        **kwargs: The optional parameters can also be set as keywords arguements. The keywords must
+            be in camel case. If both options and keywords are set, then the options will be used.
+
+    Returns:
+        RDD: A RDD that contains tuples of dictionaries, (key, tile).
+            key (dict): The index of the tile within the layer. There are two different types
+                of keys, SpatialKeys and SpaceTimeKeys. SpatialKeys deal with data that have just
+                a spatial component, whereas SpaceTimeKeys are for data with both a spatial and
+                time component.
+
+                Both SpatialKeys and SpaceTimeKeys share these fields:
+                    col (int): The column number of the grid, runs east to west.
+                    row (int): The row number of the grid, runs north to south.
+
+                SpaceTimeKeys also have an additional field:
+                    instant (int): The time stamp of the tile.
+            tile (dict): The data of the tile.
+
+                The fields to represent the tile:
+                    data (np.ndarray): The tile data itself is represented as a 3D, numpy array.
+                        Note, even if the data was originally singleband, it will be reformatted as
+                        a multiband tile and read and saved as such.
+                    no_data_value (optional): The no data value of the tile. Can be a range of
+                        types including None.
+
+    """
 
     if options:
         options = options
@@ -136,6 +214,93 @@ def query(geopysc,
           time_intervals=None,
           options=None,
           **kwargs):
+
+    """Queries a single, zoom layer from a GeoTrellis catalog given spatial and/or time parameters.
+    Unlike read, this method will only return part of the layer that intersects the specified
+    region. However, the whole layer could still be read in if no area/time has been set, or
+    if the querried region contains the entire layer.
+
+    A layer can be queried from various backends. These are the ones that are currently supported:
+        Local Filesystem
+        HDFS
+        S3
+        Cassandra
+        HBase
+        Accumulo
+
+    Args:
+        geopysc (GeoPyContext): The GeoPyContext being used this session.
+        rdd_type (str): What the spatial type of the geotiffs are. This is
+            represented by the constants: SPATIAL and SPACETIME. Note: All of the
+            GeoTiffs must have the same saptial type.
+        uri (str): The Uniform Resource Identifier used to point towards the desired GeoTrellis
+            catalog to be read from. The shape of this string varies depending on backend.
+
+            Example uris for each backend:
+                Local Filesystem: file://my_folder/my_catalog/
+                HDFS: hdfs://my_folder/my_catalog/
+                S3: s3://my_bucket/my_catalog/
+                Cassandra: cassandra:name?username=user&password=pass&host=host1&keyspace=key&table=table
+                HBase: hbase://zoo1, zoo2: port/table
+                Accumulo: accumulo://username:password/zoo1, zoo2/instance/table
+        layer_name (str): The name of the GeoTrellis catalog to be querried.
+        layer_zoom (int): The zoom level of the layer that is to be querried.
+        intersects (str, Polygon): The desired spatial area to be returned. Can either be a string
+            or a shapely Polygon. If the value is a string, it must be the WKT string, geometry
+            format.
+
+            The types of Polygons supported:
+                Point
+                Polygon
+                MultiPolygon
+
+            Note, only layers that were made from spatial, singleband GeoTiffs can query a Point.
+            All other types are restricted to Polygon and MulitPolygon.
+        time_intervals (list, optional): A list of strings that time intervals to query.
+            The strings must be in a valid date-time format. This parameter is only used when
+            querying spatial-temporal data. The default value is, None. If None, then only the
+            spatial area will be querried.
+        options (dict, optional): Additional parameters for reading the tile for specific backends.
+            The dictioanry is only used for Cassandra and HBase, no other backend requires this
+            to be set.
+
+            Fields that can be set for Cassandra:
+                replicationStrategy (str, optional): If not specified, then 'SimpleStrategy' will
+                    be used.
+                replicationFactor (int, optional): If not specified, then 1 will be used.
+                localDc (str, optional): If not specified, then 'datacenter1' will be used.
+                usedHostsPerRemoteDc (int, optional): If not specified, then 0 will be used.
+                allowRemoteDCsForLocalConsistencyLevel (int, optional): If you'd like this feature,
+                    then the value would be 1, Otherwise, the value should be 0. If not specified,
+                    then 0 will be used.
+
+            Fields that can be set for HBase:
+                master (str, optional): If not specified, then 'null' will be used.
+        **kwargs: The optional parameters can also be set as keywords arguements. The keywords must
+            be in camel case. If both options and keywords are set, then the options will be used.
+    Returns:
+        RDD: A RDD that contains tuples of dictionaries, (key, tile).
+            key (dict): The index of the tile within the layer. There are two different types
+                of keys, SpatialKeys and SpaceTimeKeys. SpatialKeys deal with data that have just
+                a spatial component, whereas SpaceTimeKeys are for data with both a spatial and
+                time component.
+
+                Both SpatialKeys and SpaceTimeKeys share these fields:
+                    col (int): The column number of the grid, runs east to west.
+                    row (int): The row number of the grid, runs north to south.
+
+                SpaceTimeKeys also have an additional field:
+                    instant (int): The time stamp of the tile.
+            tile (dict): The data of the tile.
+
+                The fields to represent the tile:
+                    data (np.ndarray): The tile data itself is represented as a 3D, numpy array.
+                        Note, even if the data was originally singleband, it will be reformatted as
+                        a multiband tile and read and saved as such.
+                    no_data_value (optional): The no data value of the tile. Can be a range of
+                        types including None.
+
+    """
 
     if options:
         options = options
@@ -194,6 +359,116 @@ def write(geopysc,
           time_unit=None,
           options=None,
           **kwargs):
+
+    """Writes a tile layer to a specified destination.
+
+    Args:
+        geopysc (GeoPyContext): The GeoPyContext being used this session.
+        rdd_type (str): What the spatial type of the geotiffs are. This is
+            represented by the constants: SPATIAL and SPACETIME. Note: All of the
+            GeoTiffs must have the same saptial type.
+        uri (str): The Uniform Resource Identifier used to point towards the desired location for
+        the tile layer to written to. The shape of this string varies depending on backend.
+
+            Example uris for each backend:
+                Local Filesystem: file://my_folder/my_catalog/
+                HDFS: hdfs://my_folder/my_catalog/
+                S3: s3://my_bucket/my_catalog/
+                Cassandra: cassandra:name?username=user&password=pass&host=host1&keyspace=key&table=table
+                HBase: hbase://zoo1, zoo2: port/table
+                Accumulo: accumulo://username:password/zoo1, zoo2/instance/table
+        layer_name (str): The name of the new, tile layer.
+        layer_zoom (int): The zoom level the layer should be saved at.
+        rdd (RDD): A RDD that contains tuples of dictionaries, (key, tile).
+            key (dict): The index of the tile within the layer. There are two different types
+                of keys, SpatialKeys and SpaceTimeKeys. SpatialKeys deal with data that have just
+                a spatial component, whereas SpaceTimeKeys are for data with both a spatial and
+                time component.
+
+                Both SpatialKeys and SpaceTimeKeys share these fields:
+                    col (int): The column number of the grid, runs east to west.
+                    row (int): The row number of the grid, runs north to south.
+
+                SpaceTimeKeys also have an additional field:
+                    instant (int): The time stamp of the tile.
+            tile (dict): The data of the tile.
+
+                The fields to represent the tile:
+                    data (np.ndarray): The tile data itself is represented as a 3D, numpy array.
+                        Note, even if the data was originally singleband, it will be reformatted as
+                        a multiband tile and read and saved as such.
+                    no_data_value (optional): The no data value of the tile. Can be a range of
+                        types including None.
+        tile_layer_metadata (dict): The metadata for this tile layer. This provides
+            the layout definition that the tiles will be cut to.
+
+            The fields that are used to represent the metadata:
+                cellType (str): The value type of every cell within the rasters.
+                layoutDefinition (dict): Defines the raster layout of the rasters.
+
+                The fields that are used to represent the layoutDefinition:
+                    extent (dict): The area covered by the layout tiles.
+                    tileLayout (dict): The tile layout of the rasters.
+                extent (dict): The extent that covers the tiles.
+                crs (str): The CRS that the rasters are projected in.
+                bounds (dict): Represents the positions of the tile layer tiles within a gird.
+
+                    The fields that are used to represent the bounds:
+                        minKey (dict): Represents where the tile layer begins in the gird.
+                        maxKey (dict): Represents where the tile layer ends in the gird.
+
+                        The fields that are used to represent the minKey and maxKey:
+                            col (int): The column number of the grid, runs east to west.
+                            row (int): The row number of the grid, runs north to south.
+        index_strategy (str): The method used to orginize the saved data. Depending on the type of
+            data within the layer, only certain methods are available. The default method used is,
+            ZORDER.
+
+            The different indexing methods:
+                ZORDER: Works for both spatial and spatial-temporal data.
+                HILBERT: Works for both spatial and spatial-temporal data. Currently has a size
+                    limitation where the combined resolutions for each index cannot be greater
+                    than 64 bits.
+                ROWMAJOR: Works only for spatial data. Is the fastest of the three methods,
+                    but can provide unreliable locality results.
+        time_unit (str, optional): Horallllllllllllllll data should be indexed when saved.
+            While this is set to None as default, it must be set if saving spatial-temporal data.
+            Depending on the indexing method chosen, different time units are used.
+
+            Time units for ZORDER:
+                MILLIS: Index data by milliseconds.
+                SECONDS: Index data by seconds.
+                MINUTES: Index data by minutes.
+                HOURS: Index data by hours.
+                DAYS: Index data by days.
+                MONTHS: Index data by months.
+                YEARS: Index data by years.
+
+            Time unit for HILBERT:
+                The time unit must be in this format: 'min_date, max_date, resolution'.
+                Where 'min_date' is the starting date, 'max_date' is the ending date,
+                and 'resolution' is the temporal resolution. Both 'min_date' and 'max_date'
+                must be in a valid date-time format.
+
+        options (dict, optional): Additional parameters for writing the tile layer for specific
+            backends. The dictioanry is only used for Cassandra and HBase, no other backend
+            requires this to be set.
+
+            Fields that can be set for Cassandra:
+                replicationStrategy (str, optional): If not specified, then 'SimpleStrategy' will
+                    be used.
+                replicationFactor (int, optional): If not specified, then 1 will be used.
+                localDc (str, optional): If not specified, then 'datacenter1' will be used.
+                usedHostsPerRemoteDc (int, optional): If not specified, then 0 will be used.
+                allowRemoteDCsForLocalConsistencyLevel (int, optional): If you'd like this feature,
+                    then the value would be 1, Otherwise, the value should be 0. If not specified,
+                    then 0 will be used.
+
+            Fields that can be set for HBase:
+                master (str, optional): If not specified, then 'null' will be used.
+        **kwargs: The optional parameters can also be set as keywords arguements. The keywords must
+            be in camel case. If both options and keywords are set, then the options will be used.
+    """
 
     if options:
         options = options

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -1,5 +1,6 @@
 import json
 
+from geopyspark.geotrellis.constants import SPATIAL, TILE, ZORDER
 from shapely.geometry import Polygon
 from shapely.wkt import dumps
 from urllib.parse import urlparse
@@ -114,13 +115,13 @@ def read(geopysc,
     tup = reader.read(key, layer_name, layer_zoom)
     schema = tup._2()
 
-    if rdd_type == "spatial":
+    if rdd_type == SPATIAL:
         jmetadata = store.metadataSpatial(layer_name, layer_zoom)
     else:
         jmetadata = store.metadataSpaceTime(layer_name, layer_zoom)
 
     metadata = json.loads(jmetadata)
-    ser = geopysc.create_tuple_serializer(schema, value_type="Tile")
+    ser = geopysc.create_tuple_serializer(schema, value_type=TILE)
 
     rdd = geopysc.create_python_rdd(tup._1(), ser)
 
@@ -170,13 +171,13 @@ def query(geopysc,
 
     schema = tup._2()
 
-    if rdd_type == "spatial":
+    if rdd_type == SPATIAL:
         jmetadata = store.metadataSpatial(layer_name, layer_zoom)
     else:
         jmetadata = store.metadataSpaceTime(layer_name, layer_zoom)
 
     metadata = json.loads(jmetadata)
-    ser = geopysc.create_tuple_serializer(schema, value_type="Tile")
+    ser = geopysc.create_tuple_serializer(schema, value_type=TILE)
 
     rdd = geopysc.create_python_rdd(tup._1(), ser)
 
@@ -189,7 +190,7 @@ def write(geopysc,
           layer_zoom,
           rdd,
           metadata,
-          index_strategy="zorder",
+          index_strategy=ZORDER,
           time_unit=None,
           options=None,
           **kwargs):

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -12,41 +12,44 @@ of this type of K.
 """
 SPACETIME = 'spacetime'
 
+
 """
 Indicates the type value that needs to be serialized/deserialized. Both singleband
 and multiband GeoTiffs are reffered to as this.
 """
 TILE = 'Tile'
 
-"""A resampling method"""
+
+"""A resampling method."""
 NEARESTNEIGHBOR = 'NearestNeighbor'
 
-"""A resampling method"""
+"""A resampling method."""
 BILINEAR = 'Bilinear'
 
-"""A resampling method"""
+"""A resampling method."""
 CUBICCONVOLUTION = 'CubicConvolution'
 
-"""A resampling method"""
+"""A resampling method."""
 CUBICSPLINE = 'CubicSpline'
 
-"""A resampling method"""
+"""A resampling method."""
 LANCZOS = 'Lanczos'
 
-"""A resampling method"""
+"""A resampling method."""
 AVERAGE = 'Average'
 
-"""A resampling method"""
+"""A resampling method."""
 MODE = 'Mode'
 
-"""A resampling method"""
+"""A resampling method."""
 MEDIAN = 'Median'
 
-"""A resampling method"""
+"""A resampling method."""
 MAX = 'Max'
 
-"""A resampling method"""
+"""A resampling method."""
 MIN = 'Min'
+
 
 """A key indexing method. Works for RDDs that contain both SpatialKeys and SpacetimeKeys."""
 ZORDER = 'zorder'
@@ -65,3 +68,25 @@ good locality guarntees. It is reccomended then that this method should only be 
 is not important for your analysis.
 """
 ROWMAJOR = 'rowmajor'
+
+
+"""A time unit used with ZORDER."""
+MILLISECONDS = 'millis'
+
+"""A time unit used with ZORDER."""
+SECONDS = 'seconds'
+
+"""A time unit used with ZORDER."""
+MINUTES = 'minutes'
+
+"""A time unit used with ZORDER."""
+HOURS = 'hours'
+
+"""A time unit used with ZORDER."""
+DAYS = 'days'
+
+"""A time unit used with ZORDER."""
+MONTHS = 'months'
+
+"""A time unit used with ZORDER."""
+YEARS = 'years'

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -47,3 +47,21 @@ MAX = 'Max'
 
 """A resampling method"""
 MIN = 'Min'
+
+"""A key indexing method. Works for RDDs that contain both SpatialKeys and SpacetimeKeys."""
+ZORDER = 'zorder'
+
+"""
+A key indexing method. Works for RDDs that contain both SpatialKeys and SpacetimeKeys.
+Note, indexes are determined by the x, y, and if SPACETIME, the temporal resolutions of
+a point. This is expressed in bits, and has a max value of 62. Thus if the sum of those
+resolutions are greate than 62, then the indexing will fail
+"""
+HILBERT = 'hilbert'
+
+"""A key indexing method. Works only for RDDs that contain SpatialKeys.
+This method provides the fastest lookup of all the key indexing method, however, it does not give
+good locality guarntees. It is reccomended then that this method should only be used when locality
+is not important for your analysis.
+"""
+ROWMAJOR = 'rowmajor'


### PR DESCRIPTION
This Pr is based off another, open Pr #68 . This Pr removed the various classes from `catalog`, leaving just the `read`, `query`, and `write` functions. This was done by requiring all paths to be in a `uri` format. By having just these three methods, the code has become much more simplified and is easier to use, read, and understand. In addition to the refactor, docs have been added to `catalog`.

This Pr fixes #69 .