### PR TITLE
Reproject

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/reproject/ReprojectWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/reproject/ReprojectWrapper.scala
@@ -1,0 +1,96 @@
+package geopyspark.geotrellis.spark.reproject
+
+import geopyspark.geotrellis._
+
+import geotrellis.util._
+import geotrellis.proj4._
+import geotrellis.raster._
+import geotrellis.spark._
+import geotrellis.spark.io._
+import geotrellis.spark.io.avro._
+import geotrellis.spark.reproject._
+import geotrellis.spark.tiling._
+
+import spray.json._
+
+import org.apache.spark._
+import org.apache.spark.rdd._
+import org.apache.spark.api.java.JavaRDD
+
+import scala.reflect.ClassTag
+
+object ReprojectWrapper {
+  private def reprojectRDD[
+    K: SpatialComponent: ClassTag: Boundable: AvroRecordCodec: JsonFormat
+  ](
+    returnedRDD: RDD[Array[Byte]],
+    schema: String,
+    metadata: TileLayerMetadata[K],
+    destCRS: String,
+    layout: Either[LayoutScheme, LayoutDefinition],
+    matchLayerExtent: Boolean
+  ): (Int, (JavaRDD[Array[Byte]], String), String) = {
+    val rdd: RDD[(K, MultibandTile)] =
+      PythonTranslator.fromPython[(K, MultibandTile)](returnedRDD, Some(schema))
+
+    val contextRDD = ContextRDD(rdd, metadata)
+    val crs = CRS.fromName(destCRS)
+    val options = Reproject.Options(matchLayerExtent=matchLayerExtent)
+
+    val (zoom, reprojectedRDD) = TileRDDReproject(contextRDD, crs, layout, options)
+
+    (zoom, PythonTranslator.toPython(reprojectedRDD), metadata.toJson.compactPrint)
+  }
+
+  def reproject(
+    keyType: String,
+    returnedRDD: RDD[Array[Byte]],
+    schema: String,
+    returnedMetadata: String,
+    destCRS: String,
+    matchLayerExtent: Boolean
+  ): (Int, (JavaRDD[Array[Byte]], String), String) =
+    keyType match {
+      case "SpatialKey" => {
+        val metadataAST = returnedMetadata.parseJson
+        val metadata = metadataAST.convertTo[TileLayerMetadata[SpatialKey]]
+        val layout = Right(metadata.layout)
+
+        reprojectRDD[SpatialKey](returnedRDD, schema, metadata, destCRS, layout, matchLayerExtent)
+      }
+      case "SpaceTimeKey" => {
+        val metadataAST = returnedMetadata.parseJson
+        val metadata = metadataAST.convertTo[TileLayerMetadata[SpaceTimeKey]]
+        val layout = Right(metadata.layout)
+
+        reprojectRDD[SpaceTimeKey](returnedRDD, schema, metadata, destCRS, layout, matchLayerExtent)
+      }
+    }
+
+  def reprojectWithZoom(
+    keyType: String,
+    returnedRDD: RDD[Array[Byte]],
+    schema: String,
+    returnedMetadata: String,
+    destCRS: String,
+    matchLayerExtent: Boolean,
+    tileSize: Int,
+    resolutionThreshold: Double
+  ): (Int, (JavaRDD[Array[Byte]], String), String) =
+    keyType match {
+      case "SpatialKey" => {
+        val metadataAST = returnedMetadata.parseJson
+        val metadata = metadataAST.convertTo[TileLayerMetadata[SpatialKey]]
+        val layout = Left(ZoomedLayoutScheme(metadata.crs, tileSize, resolutionThreshold))
+
+        reprojectRDD[SpatialKey](returnedRDD, schema, metadata, destCRS, layout, matchLayerExtent)
+      }
+      case "SpaceTimeKey" => {
+        val metadataAST = returnedMetadata.parseJson
+        val metadata = metadataAST.convertTo[TileLayerMetadata[SpaceTimeKey]]
+        val layout = Left(ZoomedLayoutScheme(metadata.crs, tileSize, resolutionThreshold))
+
+        reprojectRDD[SpaceTimeKey](returnedRDD, schema, metadata, destCRS, layout, matchLayerExtent)
+      }
+    }
+}

--- a/geopyspark/geopycontext.py
+++ b/geopyspark/geopycontext.py
@@ -65,6 +65,10 @@ class GeoPyContext(object):
     def pyramid_builder(self):
         return self._jvm.geopyspark.geotrellis.spark.pyramid.PyramidWrapper
 
+    @property
+    def rdd_reprojector(self):
+        return self._jvm.geopyspark.geotrellis.spark.reproject.ReprojectWrapper
+
     @staticmethod
     def map_key_input(key_type, is_boundable):
         if is_boundable:

--- a/geopyspark/geotrellis/tile_layer.py
+++ b/geopyspark/geotrellis/tile_layer.py
@@ -255,6 +255,119 @@ def reproject(geopysc,
               dest_crs,
               match_layer_extent=False):
 
+    """Reprojects the tiles within a RDD to a new projection.
+
+    The new RDD will have tiles that are laid according to the the layout definition
+    within the metadata. This function is used when the RDD has no corresponding zoom
+    (ie. is not a layer within a pyramid).
+
+    Args:
+        geopysc (GeoPyContext): The GeoPyContext being used this session.
+        rdd_type (str): What the spatial type of the geotiffs are. This is
+            represented by the constants: SPATIAL and SPACETIME. Note: All of the
+            GeoTiffs must have the same saptial type.
+        keyed_rdd(RDD): A RDD that contains tuples of dictionaries, (key, tile).
+            key (dict): The index of the tile within the layer. There are two different types
+                of keys, SpatialKeys and SpaceTimeKeys. SpatialKeys deal with data that have just
+                a spatial component, whereas SpaceTimeKeys are for data with both a spatial and
+                time component.
+
+                Both SpatialKeys and SpaceTimeKeys share these fields:
+                    col (int): The column number of the grid, runs east to west.
+                    row (int): The row number of the grid, runs north to south.
+
+                SpaceTimeKeys also have an additional field:
+                    instant (int): The time stamp of the tile.
+            tile (dict): The data of the tile.
+
+                The fields to represent the tile:
+                    data (np.ndarray): The tile data itself is represented as a 3D, numpy array.
+                        Note, even if the data was originally singleband, it will be reformatted as
+                        a multiband tile and read and saved as such.
+                    no_data_value (optional): The no data value of the tile. Can be a range of
+                        types including None.
+        tile_layer_metadata (dict): The metadata for this tile layer. This provides
+            the information needed to resample the old tiles and create new ones.
+
+            The fields that are used to represent the metadata:
+                cellType (str): The value type of every cell within the rasters.
+                layoutDefinition (dict): Defines the raster layout of the rasters.
+
+                The fields that are used to represent the layoutDefinition:
+                    extent (dict): The area covered by the layout tiles.
+                    tileLayout (dict): The tile layout of the rasters.
+                extent (dict): The extent that covers the tiles.
+                crs (str): The CRS that the rasters are projected in.
+                bounds (dict): Represents the positions of the tile layer tiles within a gird.
+
+                    The fields that are used to represent the bounds:
+                        minKey (dict): Represents where the tile layer begins in the gird.
+                        maxKey (dict): Represents where the tile layer ends in the gird.
+
+                        The fields that are used to represent the minKey and maxKey:
+                            col (int): The column number of the grid, runs east to west.
+                            row (int): The row number of the grid, runs north to south.
+        dest_crs (str): The CRS that the tiles should be reprojected to. Must be in well-known name
+            format. This can be same,or a different than what's in the tile_layer_metadata.
+        match_layer_extent (bool): Should the reprojection attempt to match the total layer's
+            extent. Defualts to False. This should only be used with small extents, as seems can
+            occur if the extent is too large.
+
+    Returns:
+        tuple: A tuple containing (reprojected_rdd, metadata).
+            projected_rdd (RDD): A RDD that contains data only for that layer represented as
+                tuples of dictionaries.
+
+                key (dict): The index of the tile within the layer. There are two different
+                    types of keys, SpatialKeys and SpaceTimeKeys. SpatialKeys deal with data that
+                    have just a spatial component, whereas SpaceTimeKeys are for data with both a
+                    spatial and time component.
+
+                    Both SpatialKeys and SpaceTimeKeys share these fields:
+                        col (int): The column number of the grid, runs east to west.
+                        row (int): The row number of the grid, runs north to south.
+
+                    SpaceTimeKeys also have an additional field:
+                        instant (int): The time stamp of the tile.
+                tile (dict): The data of the tile.
+
+                    The fields to represent the tile:
+                        data (np.ndarray): The tile data itself is represented as a 3D, numpy
+                            array.  Note, even if the data was originally singleband, it will
+                            be reformatted as a multiband tile and read and saved as such.
+                        no_data_value (optional): The no data value of the tile. Can be a range of
+                            types including None.
+            metadata (dict): The metadata for the RDD.
+                dict: The dictionary representation of the RDD's metadata.
+                    The fields that are used to represent the metadata:
+                        cellType (str): The value type of every cell within the rasters.
+                        layoutDefinition (dict): Defines the raster layout of the rasters.
+
+                        The fields that are used to represent the layoutDefinition:
+                            extent (dict): The area covered by the layout tiles.
+                            tileLayout (dict): The tile layout of the rasters.
+                        extent (dict): The extent that covers the tiles.
+                        crs (str): The CRS that the rasters are projected in.
+                        bounds (dict): Represents the positions of the tile layer's tiles within
+                            a gird.  These positions are represented by keys. There are two
+                            different types of keys, SpatialKeys and SpaceTimeKeys. SpatialKeys are
+                            for data that only have a spatial component while SpaceTimeKeys are for
+                            data with both spatial and temporal components.
+
+                            Both SpatialKeys and SpaceTimeKeys share these fields:
+                                The fields that are used to represent the bounds:
+                                    minKey (dict): Represents where the tile layer begins in the
+                                        gird.
+                                    maxKey (dict): Represents where the tile layer ends in the gird.
+
+                                    The fields that are used to represent the minKey and maxKey:
+                                        col (int): The column number of the grid, runs east to west.
+                                        row (int): The row number of the grid, runs north to south.
+
+                            SpaceTimeKeys also have an additional field:
+                                instant (int): The time stamp of the tile.
+    """
+
     reproject_wrapper = geopysc.rdd_reprojector
     key = geopysc.map_key_input(rdd_type, True)
 
@@ -281,6 +394,129 @@ def reproject_pyramid(geopysc,
                       tile_size,
                       resolution_threshold=0.1,
                       match_layer_extent=False):
+
+    """Reprojects a layer to a new projection.
+
+    The new layer will have tiles that are laid according to the the layout definition
+    within the metadata. This function is used when the layer has a corresponding zoom level,
+    and is apart of a larger pyramid. In addition to the new layer, a new zoom level will also
+    be given.
+
+    Args:
+        geopysc (GeoPyContext): The GeoPyContext being used this session.
+        rdd_type (str): What the spatial type of the geotiffs are. This is
+            represented by the constants: SPATIAL and SPACETIME. Note: All of the
+            GeoTiffs must have the same saptial type.
+        keyed_rdd(RDD): A RDD that contains tuples of dictionaries, (key, tile).
+            key (dict): The index of the tile within the layer. There are two different types
+                of keys, SpatialKeys and SpaceTimeKeys. SpatialKeys deal with data that have just
+                a spatial component, whereas SpaceTimeKeys are for data with both a spatial and
+                time component.
+
+                Both SpatialKeys and SpaceTimeKeys share these fields:
+                    col (int): The column number of the grid, runs east to west.
+                    row (int): The row number of the grid, runs north to south.
+
+                SpaceTimeKeys also have an additional field:
+                    instant (int): The time stamp of the tile.
+            tile (dict): The data of the tile.
+
+                The fields to represent the tile:
+                    data (np.ndarray): The tile data itself is represented as a 3D, numpy array.
+                        Note, even if the data was originally singleband, it will be reformatted as
+                        a multiband tile and read and saved as such.
+                    no_data_value (optional): The no data value of the tile. Can be a range of
+                        types including None.
+        tile_layer_metadata (dict): The metadata for this tile layer. This provides
+            the information needed to resample the old tiles and create new ones.
+
+            The fields that are used to represent the metadata:
+                cellType (str): The value type of every cell within the rasters.
+                layoutDefinition (dict): Defines the raster layout of the rasters.
+
+                The fields that are used to represent the layoutDefinition:
+                    extent (dict): The area covered by the layout tiles.
+                    tileLayout (dict): The tile layout of the rasters.
+                extent (dict): The extent that covers the tiles.
+                crs (str): The CRS that the rasters are projected in.
+                bounds (dict): Represents the positions of the tile layer tiles within a gird.
+
+                    The fields that are used to represent the bounds:
+                        minKey (dict): Represents where the tile layer begins in the gird.
+                        maxKey (dict): Represents where the tile layer ends in the gird.
+
+                        The fields that are used to represent the minKey and maxKey:
+                            col (int): The column number of the grid, runs east to west.
+                            row (int): The row number of the grid, runs north to south.
+        dest_crs (str): The CRS that the tiles should be reprojected to. Must be in well-known name
+            format. This can be same,or a different than what's in the tile_layer_metadata.
+        tile_size (int): The size of the each tile in the RDD in terms of
+            pixels. Thus, if each tile within a RDD is 256x256 then the
+            tile_size will be 256. Note: All tiles within the RDD must be of the
+            same size.
+        resolution_threshold (double, optional): The percentage difference between
+            the cell size and zoom level as well as the resolution difference between
+            a given zoom level, and the next that is tolerated to snap to the lower-resolution
+            zoom level. If not specified, the default value is: 0.1.
+        match_layer_extent (bool): Should the reprojection attempt to match the total layer's
+            extent. Defualts to False. This should only be used with small extents, as seems can
+            occur if the extent is too large.
+
+    Returns:
+        tuple: A tuple containing (new_zoom_level, reprojected_rdd, metadata).
+            new_zoom_level (int): The new zoom level for the layer.
+            projected_rdd (RDD): A RDD that contains data only for that layer represented as
+                tuples of dictionaries.
+
+                key (dict): The index of the tile within the layer. There are two different
+                    types of keys, SpatialKeys and SpaceTimeKeys. SpatialKeys deal with data that
+                    have just a spatial component, whereas SpaceTimeKeys are for data with both a
+                    spatial and time component.
+
+                    Both SpatialKeys and SpaceTimeKeys share these fields:
+                        col (int): The column number of the grid, runs east to west.
+                        row (int): The row number of the grid, runs north to south.
+
+                    SpaceTimeKeys also have an additional field:
+                        instant (int): The time stamp of the tile.
+                tile (dict): The data of the tile.
+
+                    The fields to represent the tile:
+                        data (np.ndarray): The tile data itself is represented as a 3D, numpy
+                            array.  Note, even if the data was originally singleband, it will
+                            be reformatted as a multiband tile and read and saved as such.
+                        no_data_value (optional): The no data value of the tile. Can be a range of
+                            types including None.
+            metadata (dict): The metadata for the RDD.
+                dict: The dictionary representation of the RDD's metadata.
+                    The fields that are used to represent the metadata:
+                        cellType (str): The value type of every cell within the rasters.
+                        layoutDefinition (dict): Defines the raster layout of the rasters.
+
+                        The fields that are used to represent the layoutDefinition:
+                            extent (dict): The area covered by the layout tiles.
+                            tileLayout (dict): The tile layout of the rasters.
+                        extent (dict): The extent that covers the tiles.
+                        crs (str): The CRS that the rasters are projected in.
+                        bounds (dict): Represents the positions of the tile layer's tiles within
+                            a gird.  These positions are represented by keys. There are two
+                            different types of keys, SpatialKeys and SpaceTimeKeys. SpatialKeys are
+                            for data that only have a spatial component while SpaceTimeKeys are for
+                            data with both spatial and temporal components.
+
+                            Both SpatialKeys and SpaceTimeKeys share these fields:
+                                The fields that are used to represent the bounds:
+                                    minKey (dict): Represents where the tile layer begins in the
+                                        gird.
+                                    maxKey (dict): Represents where the tile layer ends in the gird.
+
+                                    The fields that are used to represent the minKey and maxKey:
+                                        col (int): The column number of the grid, runs east to west.
+                                        row (int): The row number of the grid, runs north to south.
+
+                            SpaceTimeKeys also have an additional field:
+                                instant (int): The time stamp of the tile.
+    """
 
     reproject_wrapper = geopysc.rdd_reprojector
     key = geopysc.map_key_input(rdd_type, True)
@@ -659,6 +895,7 @@ def pyramid(geopysc,
             resample_method=NEARESTNEIGHBOR):
 
     """Creates a pyramid layout from a tile layer.
+
     Args:
         geopysc (GeoPyContext): The GeoPyContext being used this session.
         rdd_type (str): What the spatial type of the geotiffs are. This is

--- a/geopyspark/tests/reproject_test.py
+++ b/geopyspark/tests/reproject_test.py
@@ -1,0 +1,65 @@
+import os
+import unittest
+
+from geopyspark.tests.python_test_utils import check_directory, geotiff_test_path
+from geopyspark.geotrellis.tile_layer import reproject, collect_metadata, tile_to_layout
+from geopyspark.geotrellis.geotiff_rdd import geotiff_rdd
+from geopyspark.tests.base_test_class import BaseTestClass
+from geopyspark.geotrellis.constants import SPATIAL
+
+
+check_directory()
+
+
+class ReprojectTest(BaseTestClass):
+    dir_path = geotiff_test_path("all-ones.tif")
+
+    rdd = geotiff_rdd(BaseTestClass.geopysc, SPATIAL, dir_path)
+    value = rdd.collect()[0]
+
+    extent = value[0]['extent']
+
+    (_, _rows, _cols) = value[1]['data'].shape
+
+    layout = {
+        "layoutCols": 1,
+        "layoutRows": 1,
+        "tileCols": _cols,
+        "tileRows": _rows
+    }
+
+    metadata = collect_metadata(BaseTestClass.geopysc,
+                                SPATIAL,
+                                rdd,
+                                extent,
+                                layout)
+    crs = metadata['crs']
+
+    laid_out_rdd = tile_to_layout(BaseTestClass.geopysc,
+                                  SPATIAL,
+                                  rdd,
+                                  metadata)
+
+    def test_same_crs(self):
+        (_, new_metadata) = reproject(BaseTestClass.geopysc,
+                                      SPATIAL,
+                                      self.laid_out_rdd,
+                                      self.metadata,
+                                      "EPSG:4326")
+
+        self.assertEqual(self.crs, new_metadata['crs'])
+
+    def test_different_crs(self):
+        (_, new_metadata) = reproject(BaseTestClass.geopysc,
+                                      SPATIAL,
+                                      self.laid_out_rdd,
+                                      self.metadata,
+                                      "EPSG:4324")
+
+        actual = '+proj=longlat +datum=WGS84 +no_defs '
+
+        self.assertEqual(actual, new_metadata['crs'])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This Pr is based on another, open Pr #74 . Two new reprojection functions have been added to `tile_layer` that can reproject either a `RDD` or a layer called, `reproject` and `reproject_pyramid`, respectively. This will make it possible to pyramid more types of tiles since pyramiding is only possible for certain types.