### PR TITLE
Avoid calls to _to_java_object_rdd during RDD encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ notebooks
 
 # GeoPySpark-backend jar
 geopyspark/jars/*.jar
+
+# Unit test performance results
+prof/

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/TileLayerMetadataCollector.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/TileLayerMetadataCollector.scala
@@ -17,6 +17,7 @@ import spray.json._
 
 import org.apache.spark._
 import org.apache.spark.rdd.RDD
+import org.apache.spark.api.java.JavaRDD
 
 import scala.collection.JavaConverters._
 import collection.JavaConversions._
@@ -31,7 +32,7 @@ object TileLayerMetadataCollector {
   T <: CellGrid: AvroRecordCodec: ClassTag,
   K2: Boundable: SpatialComponent: JsonFormat
   ](
-    returnedRdd: RDD[Array[Byte]],
+    returnedRdd: JavaRDD[Array[Byte]],
     schemaJson: String,
     pythonExtent: java.util.Map[String, Double],
     pythonTileLayout: java.util.Map[String, Int],
@@ -55,7 +56,7 @@ object TileLayerMetadataCollector {
 
   def collectPythonMetadata(
     keyType: String,
-    returnedRdd: RDD[Array[Byte]],
+    returnedRdd: JavaRDD[Array[Byte]],
     schemaJson: String,
     pythonExtent: java.util.Map[String, Double],
     pythonTileLayout: java.util.Map[String, Int],
@@ -83,7 +84,7 @@ object TileLayerMetadataCollector {
     T <: CellGrid: AvroRecordCodec: ClassTag,
     K2: Boundable: SpatialComponent: JsonFormat
   ](
-    returnedRdd: RDD[Array[Byte]],
+    returnedRdd: JavaRDD[Array[Byte]],
     schemaJson: String,
     crs: String,
     tileSize: Int,
@@ -105,7 +106,7 @@ object TileLayerMetadataCollector {
 
   def collectPythonPyramidMetadata(
     keyType: String,
-    returnedRDD: RDD[Array[Byte]],
+    returnedRDD: JavaRDD[Array[Byte]],
     schemaJson: String,
     crs: String,
     tileSize: Int,

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/merge/MergeMethodsWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/merge/MergeMethodsWrapper.scala
@@ -22,9 +22,9 @@ object MergeMethodsWrapper {
     K: AvroRecordCodec: ClassTag,
     V <: CellGrid: AvroRecordCodec: ClassTag: (? => TileMergeMethods[V])
   ](
-    self: RDD[Array[Byte]],
+    self: JavaRDD[Array[Byte]],
     selfSchema: String,
-    other: RDD[Array[Byte]],
+    other: JavaRDD[Array[Byte]],
     otherSchema: String
   ): (JavaRDD[Array[Byte]], String) = {
     val rdd1: RDD[(K, V)] = PythonTranslator.fromPython[(K, V)](self, Some(selfSchema))
@@ -37,9 +37,9 @@ object MergeMethodsWrapper {
 
   def merge(
     keyType: String,
-    self: RDD[Array[Byte]],
+    self: JavaRDD[Array[Byte]],
     selfSchema: String,
-    other: RDD[Array[Byte]],
+    other: JavaRDD[Array[Byte]],
     otherSchema: String
   ): (JavaRDD[Array[Byte]], String) =
     keyType match {

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/pyramid/PyramidWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/pyramid/PyramidWrapper.scala
@@ -34,7 +34,7 @@ object PyramidWrapper {
     K: SpatialComponent: AvroRecordCodec: ClassTag: JsonFormat,
     M: Component[?, LayoutDefinition]: Component[?, Bounds[K]]
   ](
-    returnedRDD: RDD[Array[Byte]],
+    returnedRDD: JavaRDD[Array[Byte]],
     schema: String,
     returnedMetadata: String,
     tileSize: Int,
@@ -70,7 +70,7 @@ object PyramidWrapper {
 
   def buildPythonPyramid(
     keyType: String,
-    returnedRDD: RDD[Array[Byte]],
+    returnedRDD: JavaRDD[Array[Byte]],
     schema: String,
     returnedMetadata: String,
     tileSize: Int,

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/reproject/ReprojectWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/reproject/ReprojectWrapper.scala
@@ -23,7 +23,7 @@ object ReprojectWrapper {
   private def reprojectRDD[
     K: SpatialComponent: ClassTag: Boundable: AvroRecordCodec: JsonFormat
   ](
-    returnedRDD: RDD[Array[Byte]],
+    returnedRDD: JavaRDD[Array[Byte]],
     schema: String,
     metadata: TileLayerMetadata[K],
     destCRS: String,
@@ -44,7 +44,7 @@ object ReprojectWrapper {
 
   def reproject(
     keyType: String,
-    returnedRDD: RDD[Array[Byte]],
+    returnedRDD: JavaRDD[Array[Byte]],
     schema: String,
     returnedMetadata: String,
     destCRS: String,
@@ -69,7 +69,7 @@ object ReprojectWrapper {
 
   def reprojectWithZoom(
     keyType: String,
-    returnedRDD: RDD[Array[Byte]],
+    returnedRDD: JavaRDD[Array[Byte]],
     schema: String,
     returnedMetadata: String,
     destCRS: String,

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/tiling/TilerMethodsWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/tiling/TilerMethodsWrapper.scala
@@ -33,7 +33,7 @@ object TilerMethodsWrapper {
     V <: CellGrid: AvroRecordCodec: ClassTag: (? => TileMergeMethods[V]): (? => TilePrototypeMethods[V]),
     K2: Boundable: SpatialComponent: ClassTag: AvroRecordCodec: JsonFormat
   ](
-    returnedRdd: RDD[Array[Byte]],
+    returnedRdd: JavaRDD[Array[Byte]],
     schema: String,
     returnedMetadata: String,
     returnedResampleMethod: String
@@ -55,7 +55,7 @@ object TilerMethodsWrapper {
 
   def cutTiles(
     keyType: String,
-    returnedRdd: RDD[Array[Byte]],
+    returnedRdd: JavaRDD[Array[Byte]],
     schema: String,
     returnedMetadata: String,
     returnedResampleMethod: String
@@ -80,7 +80,7 @@ object TilerMethodsWrapper {
     V <: CellGrid: AvroRecordCodec: ClassTag: (? => TileMergeMethods[V]): (? => TilePrototypeMethods[V]),
     K2: Boundable: SpatialComponent: ClassTag: AvroRecordCodec: JsonFormat
   ](
-    returnedRdd: RDD[Array[Byte]],
+    returnedRdd: JavaRDD[Array[Byte]],
     schema: String,
     returnedMetadata: String,
     resampleMethod: String
@@ -98,7 +98,7 @@ object TilerMethodsWrapper {
 
   def tileToLayout(
     keyType: String,
-    returnedRdd: RDD[Array[Byte]],
+    returnedRdd: JavaRDD[Array[Byte]],
     schema: String,
     returnedMetadata: String,
     resampleMethod: String

--- a/geopyspark/geotrellis/tile_layer.py
+++ b/geopyspark/geotrellis/tile_layer.py
@@ -21,10 +21,7 @@ def _convert_to_java_rdd(geopysc, rdd_type, raster_rdd):
         ser = geopysc.create_tuple_serializer(schema, key_type=None, value_type=TILE)
         reserialized_rdd = raster_rdd._reserialize(ser)
 
-        avro_ser = reserialized_rdd._jrdd_deserializer.serializer
-        dumped = raster_rdd.map(lambda value: avro_ser.dumps(value))
-
-        return (dumped._to_java_object_rdd(), schema)
+        return (reserialized_rdd._jrdd, schema)
 
 def collect_metadata(geopysc,
                      rdd_type,
@@ -229,8 +226,7 @@ def collect_pyramid_metadata(geopysc,
     metadata_wrapper = geopysc.tile_layer_metadata_collecter
     key = geopysc.map_key_input(rdd_type, False)
 
-    #(java_rdd, schema) = _convert_to_java_rdd(geopysc, key, raster_rdd)
-    schema = raster_rdd._jrdd_deserializer.serializer.schema_string
+    (java_rdd, schema) = _convert_to_java_rdd(geopysc, key, raster_rdd)
 
     if output_crs:
         output_crs = output_crs
@@ -238,7 +234,7 @@ def collect_pyramid_metadata(geopysc,
         output_crs = ""
 
     result = metadata_wrapper.collectPythonPyramidMetadata(key,
-                                                           raster_rdd._jrdd,
+                                                           java_rdd,
                                                            schema,
                                                            crs,
                                                            tile_size,


### PR DESCRIPTION
This Pr is based on another, open Pr #75 . A partial fix to the performance issues with GeoPySpark. Now functions that take a `RDD` that came from Scala and then send it back will be much faster. Depending on the `RDD` and function, there was between a 50%-80% increase in speed. Making times much more manageable.

However, `RDD`s that originated in Python still have performance issues. These have been partially solved in this Pr, but not to the same extent as the scala `RDD`s. Thus, it is still recommended to use GeoPySpark to read in GeoTiffs.