### PR TITLE
Reproject Methods Refactor and Expansion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,27 +2,28 @@ export PYTHON := python3
 export PYSPARK_PYTHON := ipython
 export IMG := jupyter-geopyspark
 
-ASSEMBLY := geopyspark-backend/geotrellis/target/scala-2.11/geotrellis-backend-assembly-0.1.0.jar
-WHEEL := dist/geopyspark-0.1.0-py3-none-any.whl
 JAR-PATH := geopyspark/jars/
+ASSEMBLYNAME := geotrellis-backend-assembly-0.1.0.jar
+BUILD-ASSEMBLY := geopyspark-backend/geotrellis/target/scala-2.11/${ASSEMBLYNAME}
+DIST-ASSEMBLY := ${JAR-PATH}/${ASSEMBLYNAME}
+WHEELNAME := geopyspark-0.1.0-py3-none-any.whl
+WHEEL := dist/${WHEELNAME}
 rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
 
-install: assembly ${JAR-PATH}
+install: ${DIST-ASSEMBLY} ${WHEEL}
 	${PYTHON} setup.py install --user --force --prefix=
 
-assembly:
+${DIST-ASSEMBLY}: ${BUILD-ASSEMBLY}
+	mv -f ${BUILD-ASSEMBLY} ${JAR-PATH}
+
+${BUILD-ASSEMBLY}: $(call rwildcard, geopyspark-backend/, *.jar)
 	(cd geopyspark-backend && ./sbt "project geotrellis-backend" assembly)
 
-${JAR-PATH}: $(call rwildcard, geopyspark-backend/, *.jar) $(ASSEMBLY)
-	mv $(ASSEMBLY) $(JAR-PATH)
-
-${WHEEL}: $(call rwildcard, geopyspark, *.py) setup.py
+${WHEEL}: $(call rwildcard, geopyspark, *.py) setup.py ${DIST-ASSEMBLY}
 	${PYTHON} setup.py bdist_wheel
 
-wheel: assembly ${JAR-PATH} ${WHEEL}
-
-pyspark:
-	pyspark --jars $(ASSEMBLY)
+pyspark: ${DIST-ASSEMBLY}
+	pyspark --jars ${DIST-ASSEMBLY}
 
 docker-build: ${WHEEL}
 	docker build -t ${IMG}:latest .
@@ -32,3 +33,12 @@ docker-run:
 
 docker-exec:
 	docker exec -it -u root geopyspark bash
+
+clean:
+	(cd geopyspark-backend && ./sbt "project geotrellis-backend" clean)
+	rm -f ${WHEEL} ${DIST-ASSEMBLY}
+
+cleaner: clean
+	rm -f `find ./build ./geopyspark | grep "\.pyc"`
+
+cleanest: cleaner

--- a/Makefile
+++ b/Makefile
@@ -7,22 +7,22 @@ WHEEL := dist/geopyspark-0.1.0-py3-none-any.whl
 JAR-PATH := geopyspark/jars/
 rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
 
-install: ${ASSEMBLY} ${JAR-PATH}
+install: assembly ${JAR-PATH}
 	${PYTHON} setup.py install --user --force --prefix=
 
-${ASSEMBLY}: $(call rwildcard, geopyspark-backend/src, *.scala) geopyspark-backend/build.sbt
+assembly:
 	(cd geopyspark-backend && ./sbt "project geotrellis-backend" assembly)
 
 ${JAR-PATH}: $(call rwildcard, geopyspark-backend/, *.jar) $(ASSEMBLY)
-	cp $(ASSEMBLY) $(JAR-PATH)
+	mv $(ASSEMBLY) $(JAR-PATH)
 
 ${WHEEL}: $(call rwildcard, geopyspark, *.py) setup.py
 	${PYTHON} setup.py bdist_wheel
 
-wheel: ${ASSEMBLY} ${JAR-PATH} ${WHEEL}
+wheel: assembly ${JAR-PATH} ${WHEEL}
 
 pyspark:
-	pyspark --jars ${ASSEMBLY}
+	pyspark --jars $(ASSEMBLY)
 
 docker-build: ${WHEEL}
 	docker build -t ${IMG}:latest .

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/reproject/ReprojectWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/reproject/ReprojectWrapper.scala
@@ -109,6 +109,34 @@ object ReprojectWrapper {
     }
 
   def reproject(
+    keyType: String,
+    returnedRDD: JavaRDD[Array[Byte]],
+    schema: String,
+    returnedMetadata: String,
+    destCRS: String,
+    tileCols: Int,
+    tileRows: Int,
+    returnedResampleMethod: String,
+    matchLayerExtent: Boolean
+  ): (Int, (JavaRDD[Array[Byte]], String), String) =
+    keyType match {
+      case "SpatialKey" => {
+        val metadataAST = returnedMetadata.parseJson
+        val metadata = metadataAST.convertTo[TileLayerMetadata[SpatialKey]]
+        val layout = Left(FloatingLayoutScheme(tileCols, tileRows))
+
+        reprojectRDD[SpatialKey](returnedRDD, schema, metadata, destCRS, layout, matchLayerExtent, returnedResampleMethod)
+      }
+      case "SpaceTimeKey" => {
+        val metadataAST = returnedMetadata.parseJson
+        val metadata = metadataAST.convertTo[TileLayerMetadata[SpaceTimeKey]]
+        val layout = Left(FloatingLayoutScheme(tileCols, tileRows))
+
+        reprojectRDD[SpaceTimeKey](returnedRDD, schema, metadata, destCRS, layout, matchLayerExtent, returnedResampleMethod)
+      }
+    }
+
+  def reproject(
     returnedRDD: JavaRDD[Array[Byte]],
     schema: String,
     destCRS: String,

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/reproject/ReprojectWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/reproject/ReprojectWrapper.scala
@@ -32,7 +32,7 @@ object ReprojectWrapper {
     destCRS: String,
     layout: Either[LayoutScheme, LayoutDefinition],
     matchLayerExtent: Boolean,
-    returnedResampleMethod: String
+    resampleMethod: String
   ): (Int, (JavaRDD[Array[Byte]], String), String) = {
     val rdd: RDD[(K, MultibandTile)] =
       PythonTranslator.fromPython[(K, MultibandTile)](returnedRDD, Some(schema))
@@ -41,9 +41,9 @@ object ReprojectWrapper {
     val crs = CRS.fromName(destCRS)
 
     val options = {
-      val resampleMethod = TilerOptions.getResampleMethod(returnedResampleMethod)
+      val method = TilerOptions.getResampleMethod(resampleMethod)
 
-      Reproject.Options(geotrellis.raster.reproject.Reproject.Options(method=resampleMethod),
+      Reproject.Options(geotrellis.raster.reproject.Reproject.Options(method=method),
         matchLayerExtent=matchLayerExtent)
     }
 
@@ -64,7 +64,7 @@ object ReprojectWrapper {
     destCRS: String,
     layoutExtent: java.util.Map[String, Double],
     tileLayout: java.util.Map[String, Int],
-    returnedResampleMethod: String,
+    resampleMethod: String,
     matchLayerExtent: Boolean
   ): (Int, (JavaRDD[Array[Byte]], String), String) =
     keyType match {
@@ -73,14 +73,14 @@ object ReprojectWrapper {
         val metadata = metadataAST.convertTo[TileLayerMetadata[SpatialKey]]
         val layout = Right(LayoutDefinition(layoutExtent.toExtent, tileLayout.toTileLayout))
 
-        reprojectRDD[SpatialKey](returnedRDD, schema, metadata, destCRS, layout, matchLayerExtent, returnedResampleMethod)
+        reprojectRDD[SpatialKey](returnedRDD, schema, metadata, destCRS, layout, matchLayerExtent, resampleMethod)
       }
       case "SpaceTimeKey" => {
         val metadataAST = returnedMetadata.parseJson
         val metadata = metadataAST.convertTo[TileLayerMetadata[SpaceTimeKey]]
         val layout = Right(LayoutDefinition(layoutExtent.toExtent, tileLayout.toTileLayout))
 
-        reprojectRDD[SpaceTimeKey](returnedRDD, schema, metadata, destCRS, layout, matchLayerExtent, returnedResampleMethod)
+        reprojectRDD[SpaceTimeKey](returnedRDD, schema, metadata, destCRS, layout, matchLayerExtent, resampleMethod)
       }
     }
 
@@ -92,7 +92,7 @@ object ReprojectWrapper {
     destCRS: String,
     tileSize: Int,
     resolutionThreshold: Double,
-    returnedResampleMethod: String,
+    resampleMethod: String,
     matchLayerExtent: Boolean
   ): (Int, (JavaRDD[Array[Byte]], String), String) =
     keyType match {
@@ -101,14 +101,14 @@ object ReprojectWrapper {
         val metadata = metadataAST.convertTo[TileLayerMetadata[SpatialKey]]
         val layout = Left(ZoomedLayoutScheme(CRS.fromName(destCRS), tileSize, resolutionThreshold))
 
-        reprojectRDD[SpatialKey](returnedRDD, schema, metadata, destCRS, layout, matchLayerExtent, returnedResampleMethod)
+        reprojectRDD[SpatialKey](returnedRDD, schema, metadata, destCRS, layout, matchLayerExtent, resampleMethod)
       }
       case "SpaceTimeKey" => {
         val metadataAST = returnedMetadata.parseJson
         val metadata = metadataAST.convertTo[TileLayerMetadata[SpaceTimeKey]]
         val layout = Left(ZoomedLayoutScheme(CRS.fromName(destCRS), tileSize, resolutionThreshold))
 
-        reprojectRDD[SpaceTimeKey](returnedRDD, schema, metadata, destCRS, layout, matchLayerExtent, returnedResampleMethod)
+        reprojectRDD[SpaceTimeKey](returnedRDD, schema, metadata, destCRS, layout, matchLayerExtent, resampleMethod)
       }
     }
 
@@ -119,7 +119,7 @@ object ReprojectWrapper {
     returnedMetadata: String,
     destCRS: String,
     tileSize: Int,
-    returnedResampleMethod: String,
+    resampleMethod: String,
     matchLayerExtent: Boolean
   ): (Int, (JavaRDD[Array[Byte]], String), String) =
     keyType match {
@@ -128,14 +128,14 @@ object ReprojectWrapper {
         val metadata = metadataAST.convertTo[TileLayerMetadata[SpatialKey]]
         val layout = Left(FloatingLayoutScheme(tileSize))
 
-        reprojectRDD[SpatialKey](returnedRDD, schema, metadata, destCRS, layout, matchLayerExtent, returnedResampleMethod)
+        reprojectRDD[SpatialKey](returnedRDD, schema, metadata, destCRS, layout, matchLayerExtent, resampleMethod)
       }
       case "SpaceTimeKey" => {
         val metadataAST = returnedMetadata.parseJson
         val metadata = metadataAST.convertTo[TileLayerMetadata[SpaceTimeKey]]
         val layout = Left(FloatingLayoutScheme(tileSize))
 
-        reprojectRDD[SpaceTimeKey](returnedRDD, schema, metadata, destCRS, layout, matchLayerExtent, returnedResampleMethod)
+        reprojectRDD[SpaceTimeKey](returnedRDD, schema, metadata, destCRS, layout, matchLayerExtent, resampleMethod)
       }
     }
 
@@ -143,7 +143,7 @@ object ReprojectWrapper {
     returnedRDD: JavaRDD[Array[Byte]],
     schema: String,
     destCRS: String,
-    returnedResampleMethod: String,
+    resampleMethod: String,
     errorThreshold: Double
   ): (JavaRDD[Array[Byte]], String) = {
     val rdd =
@@ -152,10 +152,9 @@ object ReprojectWrapper {
     val crs = CRS.fromName(destCRS)
 
     val options = {
-      val resampleMethod = TilerOptions.getResampleMethod(returnedResampleMethod)
+      val method = TilerOptions.getResampleMethod(resampleMethod)
 
-      geotrellis.raster.reproject.Reproject.Options(method=resampleMethod,
-        errorThreshold=errorThreshold)
+      geotrellis.raster.reproject.Reproject.Options(method=method, errorThreshold=errorThreshold)
     }
 
     val result = ProjectedExtentComponentReproject(rdd, crs, options)

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/reproject/ReprojectWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/reproject/ReprojectWrapper.scala
@@ -52,7 +52,7 @@ object ReprojectWrapper {
     (zoom, PythonTranslator.toPython(reprojectedRDD), metadata.toJson.compactPrint)
   }
 
-  def reprojectWithLayout(
+  def reproject(
     keyType: String,
     returnedRDD: JavaRDD[Array[Byte]],
     schema: String,
@@ -80,16 +80,16 @@ object ReprojectWrapper {
       }
     }
 
-  def reprojectWithZoom(
+  def reproject(
     keyType: String,
     returnedRDD: JavaRDD[Array[Byte]],
     schema: String,
     returnedMetadata: String,
     destCRS: String,
-    matchLayerExtent: Boolean,
     tileSize: Int,
+    resolutionThreshold: Double,
     returnedResampleMethod: String,
-    resolutionThreshold: Double
+    matchLayerExtent: Boolean
   ): (Int, (JavaRDD[Array[Byte]], String), String) =
     keyType match {
       case "SpatialKey" => {

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/reproject/ReprojectWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/reproject/ReprojectWrapper.scala
@@ -118,8 +118,7 @@ object ReprojectWrapper {
     schema: String,
     returnedMetadata: String,
     destCRS: String,
-    tileCols: Int,
-    tileRows: Int,
+    tileSize: Int,
     returnedResampleMethod: String,
     matchLayerExtent: Boolean
   ): (Int, (JavaRDD[Array[Byte]], String), String) =
@@ -127,14 +126,14 @@ object ReprojectWrapper {
       case "SpatialKey" => {
         val metadataAST = returnedMetadata.parseJson
         val metadata = metadataAST.convertTo[TileLayerMetadata[SpatialKey]]
-        val layout = Left(FloatingLayoutScheme(tileCols, tileRows))
+        val layout = Left(FloatingLayoutScheme(tileSize))
 
         reprojectRDD[SpatialKey](returnedRDD, schema, metadata, destCRS, layout, matchLayerExtent, returnedResampleMethod)
       }
       case "SpaceTimeKey" => {
         val metadataAST = returnedMetadata.parseJson
         val metadata = metadataAST.convertTo[TileLayerMetadata[SpaceTimeKey]]
-        val layout = Left(FloatingLayoutScheme(tileCols, tileRows))
+        val layout = Left(FloatingLayoutScheme(tileSize))
 
         reprojectRDD[SpaceTimeKey](returnedRDD, schema, metadata, destCRS, layout, matchLayerExtent, returnedResampleMethod)
       }

--- a/geopyspark/geotrellis/tile_layer.py
+++ b/geopyspark/geotrellis/tile_layer.py
@@ -508,15 +508,15 @@ def reproject_pyramid_layout(geopysc,
 
     (java_rdd, schema) = _convert_to_java_rdd(geopysc, key, keyed_rdd)
 
-    result = reproject_wrapper.reprojectWithLayout(key,
-                                                   java_rdd,
-                                                   schema,
-                                                   json.dumps(tile_layer_metadata),
-                                                   dest_crs,
-                                                   layout_extent,
-                                                   tile_layout,
-                                                   resample_method,
-                                                   match_layer_extent)
+    result = reproject_wrapper.reproject(key,
+                                         java_rdd,
+                                         schema,
+                                         json.dumps(tile_layer_metadata),
+                                         dest_crs,
+                                         layout_extent,
+                                         tile_layout,
+                                         resample_method,
+                                         match_layer_extent)
 
     (rdd, returned_schema) = (result._2()._1(), result._2()._2())
     ser = geopysc.create_tuple_serializer(returned_schema, value_type=TILE)
@@ -662,15 +662,15 @@ def reproject_pyramid_zoom(geopysc,
 
     (java_rdd, schema) = _convert_to_java_rdd(geopysc, key, keyed_rdd)
 
-    result = reproject_wrapper.reprojectWithZoom(key,
-                                                 java_rdd,
-                                                 schema,
-                                                 json.dumps(tile_layer_metadata),
-                                                 dest_crs,
-                                                 match_layer_extent,
-                                                 tile_size,
-                                                 resample_method,
-                                                 resolution_threshold)
+    result = reproject_wrapper.reproject(key,
+                                         java_rdd,
+                                         schema,
+                                         json.dumps(tile_layer_metadata),
+                                         dest_crs,
+                                         tile_size,
+                                         resolution_threshold,
+                                         resample_method,
+                                         match_layer_extent)
 
     (rdd, returned_schema) = (result._2()._1(), result._2()._2())
     ser = geopysc.create_tuple_serializer(returned_schema, value_type=TILE)

--- a/geopyspark/geotrellis/tile_layer.py
+++ b/geopyspark/geotrellis/tile_layer.py
@@ -252,115 +252,8 @@ def reproject(geopysc,
 
     """Reprojects the tiles within a RDD to a new projection.
 
-    The new RDD will have tiles that are laid according to the the layout definition
-    within the metadata. This function is used when the RDD has no corresponding zoom
-    (ie. is not a layer within a pyramid).
+    TODO: Write the remaining docs.
 
-    Args:
-        geopysc (GeoPyContext): The GeoPyContext being used this session.
-        rdd_type (str): What the spatial type of the geotiffs are. This is
-            represented by the constants: SPATIAL and SPACETIME. Note: All of the
-            GeoTiffs must have the same saptial type.
-        keyed_rdd(RDD): A RDD that contains tuples of dictionaries, (key, tile).
-            key (dict): The index of the tile within the layer. There are two different types
-                of keys, SpatialKeys and SpaceTimeKeys. SpatialKeys deal with data that have just
-                a spatial component, whereas SpaceTimeKeys are for data with both a spatial and
-                time component.
-
-                Both SpatialKeys and SpaceTimeKeys share these fields:
-                    col (int): The column number of the grid, runs east to west.
-                    row (int): The row number of the grid, runs north to south.
-
-                SpaceTimeKeys also have an additional field:
-                    instant (int): The time stamp of the tile.
-            tile (dict): The data of the tile.
-
-                The fields to represent the tile:
-                    data (np.ndarray): The tile data itself is represented as a 3D, numpy array.
-                        Note, even if the data was originally singleband, it will be reformatted as
-                        a multiband tile and read and saved as such.
-                    no_data_value (optional): The no data value of the tile. Can be a range of
-                        types including None.
-        tile_layer_metadata (dict): The metadata for this tile layer. This provides
-            the information needed to resample the old tiles and create new ones.
-
-            The fields that are used to represent the metadata:
-                cellType (str): The value type of every cell within the rasters.
-                layoutDefinition (dict): Defines the raster layout of the rasters.
-
-                The fields that are used to represent the layoutDefinition:
-                    extent (dict): The area covered by the layout tiles.
-                    tileLayout (dict): The tile layout of the rasters.
-                extent (dict): The extent that covers the tiles.
-                crs (str): The CRS that the rasters are projected in.
-                bounds (dict): Represents the positions of the tile layer tiles within a gird.
-
-                    The fields that are used to represent the bounds:
-                        minKey (dict): Represents where the tile layer begins in the gird.
-                        maxKey (dict): Represents where the tile layer ends in the gird.
-
-                        The fields that are used to represent the minKey and maxKey:
-                            col (int): The column number of the grid, runs east to west.
-                            row (int): The row number of the grid, runs north to south.
-        dest_crs (str): The CRS that the tiles should be reprojected to. Must be in well-known name
-            format. This can be same,or a different than what's in the tile_layer_metadata.
-        match_layer_extent (bool): Should the reprojection attempt to match the total layer's
-            extent. Defualts to False. This should only be used with small extents, as seems can
-            occur if the extent is too large.
-
-    Returns:
-        tuple: A tuple containing (reprojected_rdd, metadata).
-            projected_rdd (RDD): A RDD that contains data only for that layer represented as
-                tuples of dictionaries.
-
-                key (dict): The index of the tile within the layer. There are two different
-                    types of keys, SpatialKeys and SpaceTimeKeys. SpatialKeys deal with data that
-                    have just a spatial component, whereas SpaceTimeKeys are for data with both a
-                    spatial and time component.
-
-                    Both SpatialKeys and SpaceTimeKeys share these fields:
-                        col (int): The column number of the grid, runs east to west.
-                        row (int): The row number of the grid, runs north to south.
-
-                    SpaceTimeKeys also have an additional field:
-                        instant (int): The time stamp of the tile.
-                tile (dict): The data of the tile.
-
-                    The fields to represent the tile:
-                        data (np.ndarray): The tile data itself is represented as a 3D, numpy
-                            array.  Note, even if the data was originally singleband, it will
-                            be reformatted as a multiband tile and read and saved as such.
-                        no_data_value (optional): The no data value of the tile. Can be a range of
-                            types including None.
-            metadata (dict): The metadata for the RDD.
-                dict: The dictionary representation of the RDD's metadata.
-                    The fields that are used to represent the metadata:
-                        cellType (str): The value type of every cell within the rasters.
-                        layoutDefinition (dict): Defines the raster layout of the rasters.
-
-                        The fields that are used to represent the layoutDefinition:
-                            extent (dict): The area covered by the layout tiles.
-                            tileLayout (dict): The tile layout of the rasters.
-                        extent (dict): The extent that covers the tiles.
-                        crs (str): The CRS that the rasters are projected in.
-                        bounds (dict): Represents the positions of the tile layer's tiles within
-                            a gird.  These positions are represented by keys. There are two
-                            different types of keys, SpatialKeys and SpaceTimeKeys. SpatialKeys are
-                            for data that only have a spatial component while SpaceTimeKeys are for
-                            data with both spatial and temporal components.
-
-                            Both SpatialKeys and SpaceTimeKeys share these fields:
-                                The fields that are used to represent the bounds:
-                                    minKey (dict): Represents where the tile layer begins in the
-                                        gird.
-                                    maxKey (dict): Represents where the tile layer ends in the gird.
-
-                                    The fields that are used to represent the minKey and maxKey:
-                                        col (int): The column number of the grid, runs east to west.
-                                        row (int): The row number of the grid, runs north to south.
-
-                            SpaceTimeKeys also have an additional field:
-                                instant (int): The time stamp of the tile.
     """
 
     reproject_wrapper = geopysc.rdd_reprojector
@@ -380,15 +273,15 @@ def reproject(geopysc,
 
     return (returned_rdd, json.loads(result._3()))
 
-def reproject_pyramid_layout(geopysc,
-                             rdd_type,
-                             keyed_rdd,
-                             tile_layer_metadata,
-                             dest_crs,
-                             layout_extent,
-                             tile_layout,
-                             resample_method=NEARESTNEIGHBOR,
-                             match_layer_extent=False):
+def reproject_with_tile_layout(geopysc,
+                               rdd_type,
+                               keyed_rdd,
+                               tile_layer_metadata,
+                               dest_crs,
+                               layout_extent,
+                               tile_layout,
+                               resample_method=NEARESTNEIGHBOR,
+                               match_layer_extent=False):
 
     """Reprojects the tiles within a RDD to a new projection.
 
@@ -522,17 +415,54 @@ def reproject_pyramid_layout(geopysc,
     ser = geopysc.create_tuple_serializer(returned_schema, value_type=TILE)
     returned_rdd = geopysc.create_python_rdd(rdd, ser)
 
-    return (returned_rdd, json.loads(result._3()))
+    return (result._1(), returned_rdd, json.loads(result._3()))
 
-def reproject_pyramid_zoom(geopysc,
-                           rdd_type,
-                           keyed_rdd,
-                           tile_layer_metadata,
-                           dest_crs,
-                           tile_size,
-                           resolution_threshold=0.1,
-                           resample_method=NEARESTNEIGHBOR,
-                           match_layer_extent=False):
+def reproject_with_floating_layout(geopysc,
+                                   rdd_type,
+                                   keyed_rdd,
+                                   tile_layer_metadata,
+                                   dest_crs,
+                                   tile_cols,
+                                   tile_rows,
+                                   resample_method=NEARESTNEIGHBOR,
+                                   match_layer_extent=False):
+
+    """Reprojects a layer to a new projection.
+
+    TODO: Write the remaining docs.
+
+    """
+
+    reproject_wrapper = geopysc.rdd_reprojector
+    key = geopysc.map_key_input(rdd_type, True)
+
+    (java_rdd, schema) = _convert_to_java_rdd(geopysc, key, keyed_rdd)
+
+    result = reproject_wrapper.reproject(key,
+                                         java_rdd,
+                                         schema,
+                                         json.dumps(tile_layer_metadata),
+                                         dest_crs,
+                                         tile_cols,
+                                         tile_rows,
+                                         resample_method,
+                                         match_layer_extent)
+
+    (rdd, returned_schema) = (result._2()._1(), result._2()._2())
+    ser = geopysc.create_tuple_serializer(returned_schema, value_type=TILE)
+    returned_rdd = geopysc.create_python_rdd(rdd, ser)
+
+    return (result._1(), returned_rdd, json.loads(result._3()))
+
+def reproject_with_zoomed_layout(geopysc,
+                                 rdd_type,
+                                 keyed_rdd,
+                                 tile_layer_metadata,
+                                 dest_crs,
+                                 tile_size,
+                                 resolution_threshold=0.1,
+                                 resample_method=NEARESTNEIGHBOR,
+                                 match_layer_extent=False):
 
     """Reprojects a layer to a new projection.
 

--- a/geopyspark/geotrellis/tile_layer.py
+++ b/geopyspark/geotrellis/tile_layer.py
@@ -250,12 +250,6 @@ def reproject(geopysc,
               resample_method=NEARESTNEIGHBOR,
               error_threshold=0.125):
 
-    """Reprojects the tiles within a RDD to a new projection.
-
-    TODO: Write the remaining docs.
-
-    """
-
     reproject_wrapper = geopysc.rdd_reprojector
     key = geopysc.map_key_input(SPATIAL, False)
 
@@ -267,21 +261,21 @@ def reproject(geopysc,
                                          resample_method,
                                          error_threshold)
 
-    (rdd, returned_schema) = (result._2()._1(), result._2()._2())
+    (rdd, returned_schema) = (result._1()._1(), result._1()._2())
     ser = geopysc.create_tuple_serializer(returned_schema, value_type=TILE)
     returned_rdd = geopysc.create_python_rdd(rdd, ser)
 
-    return (returned_rdd, json.loads(result._3()))
+    return (returned_rdd, json.loads(result._2()))
 
-def reproject_with_tile_layout(geopysc,
-                               rdd_type,
-                               keyed_rdd,
-                               tile_layer_metadata,
-                               dest_crs,
-                               layout_extent,
-                               tile_layout,
-                               resample_method=NEARESTNEIGHBOR,
-                               match_layer_extent=False):
+def reproject_to_layout(geopysc,
+                        rdd_type,
+                        keyed_rdd,
+                        tile_layer_metadata,
+                        dest_crs,
+                        layer_layout=None,
+                        match_layer_extent=False,
+                        resample_method=NEARESTNEIGHBOR,
+                        **kwargs):
 
     """Reprojects the tiles within a RDD to a new projection.
 
@@ -294,26 +288,6 @@ def reproject_with_tile_layout(geopysc,
         rdd_type (str): What the spatial type of the geotiffs are. This is
             represented by the constants: SPATIAL and SPACETIME. Note: All of the
             GeoTiffs must have the same saptial type.
-        keyed_rdd(RDD): A RDD that contains tuples of dictionaries, (key, tile).
-            key (dict): The index of the tile within the layer. There are two different types
-                of keys, SpatialKeys and SpaceTimeKeys. SpatialKeys deal with data that have just
-                a spatial component, whereas SpaceTimeKeys are for data with both a spatial and
-                time component.
-
-                Both SpatialKeys and SpaceTimeKeys share these fields:
-                    col (int): The column number of the grid, runs east to west.
-                    row (int): The row number of the grid, runs north to south.
-
-                SpaceTimeKeys also have an additional field:
-                    instant (int): The time stamp of the tile.
-            tile (dict): The data of the tile.
-
-                The fields to represent the tile:
-                    data (np.ndarray): The tile data itself is represented as a 3D, numpy array.
-                        Note, even if the data was originally singleband, it will be reformatted as
-                        a multiband tile and read and saved as such.
-                    no_data_value (optional): The no data value of the tile. Can be a range of
-                        types including None.
         tile_layer_metadata (dict): The metadata for this tile layer. This provides
             the information needed to resample the old tiles and create new ones.
 
@@ -396,211 +370,47 @@ def reproject_with_tile_layout(geopysc,
                                 instant (int): The time stamp of the tile.
     """
 
-    reproject_wrapper = geopysc.rdd_reprojector
-    key = geopysc.map_key_input(rdd_type, True)
+    if not layer_layout and not kwargs:
+        raise Exception("layer_formation needs to be set in order to reproject the RDD")
 
-    (java_rdd, schema) = _convert_to_java_rdd(geopysc, key, keyed_rdd)
-
-    result = reproject_wrapper.reproject(key,
-                                         java_rdd,
-                                         schema,
-                                         json.dumps(tile_layer_metadata),
-                                         dest_crs,
-                                         layout_extent,
-                                         tile_layout,
-                                         resample_method,
-                                         match_layer_extent)
-
-    (rdd, returned_schema) = (result._2()._1(), result._2()._2())
-    ser = geopysc.create_tuple_serializer(returned_schema, value_type=TILE)
-    returned_rdd = geopysc.create_python_rdd(rdd, ser)
-
-    return (result._1(), returned_rdd, json.loads(result._3()))
-
-def reproject_with_floating_layout(geopysc,
-                                   rdd_type,
-                                   keyed_rdd,
-                                   tile_layer_metadata,
-                                   dest_crs,
-                                   tile_cols,
-                                   tile_rows,
-                                   resample_method=NEARESTNEIGHBOR,
-                                   match_layer_extent=False):
-
-    """Reprojects a layer to a new projection.
-
-    TODO: Write the remaining docs.
-
-    """
+    if kwargs and not layer_layout:
+        layer_layout = kwargs
 
     reproject_wrapper = geopysc.rdd_reprojector
     key = geopysc.map_key_input(rdd_type, True)
 
     (java_rdd, schema) = _convert_to_java_rdd(geopysc, key, keyed_rdd)
 
-    result = reproject_wrapper.reproject(key,
-                                         java_rdd,
-                                         schema,
-                                         json.dumps(tile_layer_metadata),
-                                         dest_crs,
-                                         tile_cols,
-                                         tile_rows,
-                                         resample_method,
-                                         match_layer_extent)
+    if 'tile_layout' and 'layout_extent' in layer_layout:
+        result = reproject_wrapper.reproject(key,
+                                             java_rdd,
+                                             schema,
+                                             json.dumps(tile_layer_metadata),
+                                             dest_crs,
+                                             layer_layout['layout_extent'],
+                                             layer_layout['tile_layout'],
+                                             resample_method,
+                                             match_layer_extent)
 
-    (rdd, returned_schema) = (result._2()._1(), result._2()._2())
-    ser = geopysc.create_tuple_serializer(returned_schema, value_type=TILE)
-    returned_rdd = geopysc.create_python_rdd(rdd, ser)
-
-    return (result._1(), returned_rdd, json.loads(result._3()))
-
-def reproject_with_zoomed_layout(geopysc,
-                                 rdd_type,
-                                 keyed_rdd,
-                                 tile_layer_metadata,
-                                 dest_crs,
-                                 tile_size,
-                                 resolution_threshold=0.1,
-                                 resample_method=NEARESTNEIGHBOR,
-                                 match_layer_extent=False):
-
-    """Reprojects a layer to a new projection.
-
-    The new layer will have tiles that are laid according to the the layout definition
-    within the metadata. This function is used when the layer has a corresponding zoom level,
-    and is apart of a larger pyramid. In addition to the new layer, a new zoom level will also
-    be given.
-
-    Args:
-        geopysc (GeoPyContext): The GeoPyContext being used this session.
-        rdd_type (str): What the spatial type of the geotiffs are. This is
-            represented by the constants: SPATIAL and SPACETIME. Note: All of the
-            GeoTiffs must have the same saptial type.
-        keyed_rdd(RDD): A RDD that contains tuples of dictionaries, (key, tile).
-            key (dict): The index of the tile within the layer. There are two different types
-                of keys, SpatialKeys and SpaceTimeKeys. SpatialKeys deal with data that have just
-                a spatial component, whereas SpaceTimeKeys are for data with both a spatial and
-                time component.
-
-                Both SpatialKeys and SpaceTimeKeys share these fields:
-                    col (int): The column number of the grid, runs east to west.
-                    row (int): The row number of the grid, runs north to south.
-
-                SpaceTimeKeys also have an additional field:
-                    instant (int): The time stamp of the tile.
-            tile (dict): The data of the tile.
-
-                The fields to represent the tile:
-                    data (np.ndarray): The tile data itself is represented as a 3D, numpy array.
-                        Note, even if the data was originally singleband, it will be reformatted as
-                        a multiband tile and read and saved as such.
-                    no_data_value (optional): The no data value of the tile. Can be a range of
-                        types including None.
-        tile_layer_metadata (dict): The metadata for this tile layer. This provides
-            the information needed to resample the old tiles and create new ones.
-
-            The fields that are used to represent the metadata:
-                cellType (str): The value type of every cell within the rasters.
-                layoutDefinition (dict): Defines the raster layout of the rasters.
-
-                The fields that are used to represent the layoutDefinition:
-                    extent (dict): The area covered by the layout tiles.
-                    tileLayout (dict): The tile layout of the rasters.
-                extent (dict): The extent that covers the tiles.
-                crs (str): The CRS that the rasters are projected in.
-                bounds (dict): Represents the positions of the tile layer tiles within a gird.
-
-                    The fields that are used to represent the bounds:
-                        minKey (dict): Represents where the tile layer begins in the gird.
-                        maxKey (dict): Represents where the tile layer ends in the gird.
-
-                        The fields that are used to represent the minKey and maxKey:
-                            col (int): The column number of the grid, runs east to west.
-                            row (int): The row number of the grid, runs north to south.
-        dest_crs (str): The CRS that the tiles should be reprojected to. Must be in well-known name
-            format. This can be same,or a different than what's in the tile_layer_metadata.
-        tile_size (int): The size of the each tile in the RDD in terms of
-            pixels. Thus, if each tile within a RDD is 256x256 then the
-            tile_size will be 256. Note: All tiles within the RDD must be of the
-            same size.
-        resolution_threshold (double, optional): The percentage difference between
-            the cell size and zoom level as well as the resolution difference between
-            a given zoom level, and the next that is tolerated to snap to the lower-resolution
-            zoom level. If not specified, the default value is: 0.1.
-        match_layer_extent (bool): Should the reprojection attempt to match the total layer's
-            extent. Defualts to False. This should only be used with small extents, as seems can
-            occur if the extent is too large.
-
-    Returns:
-        tuple: A tuple containing (new_zoom_level, reprojected_rdd, metadata).
-            new_zoom_level (int): The new zoom level for the layer.
-            projected_rdd (RDD): A RDD that contains data only for that layer represented as
-                tuples of dictionaries.
-
-                key (dict): The index of the tile within the layer. There are two different
-                    types of keys, SpatialKeys and SpaceTimeKeys. SpatialKeys deal with data that
-                    have just a spatial component, whereas SpaceTimeKeys are for data with both a
-                    spatial and time component.
-
-                    Both SpatialKeys and SpaceTimeKeys share these fields:
-                        col (int): The column number of the grid, runs east to west.
-                        row (int): The row number of the grid, runs north to south.
-
-                    SpaceTimeKeys also have an additional field:
-                        instant (int): The time stamp of the tile.
-                tile (dict): The data of the tile.
-
-                    The fields to represent the tile:
-                        data (np.ndarray): The tile data itself is represented as a 3D, numpy
-                            array.  Note, even if the data was originally singleband, it will
-                            be reformatted as a multiband tile and read and saved as such.
-                        no_data_value (optional): The no data value of the tile. Can be a range of
-                            types including None.
-            metadata (dict): The metadata for the RDD.
-                dict: The dictionary representation of the RDD's metadata.
-                    The fields that are used to represent the metadata:
-                        cellType (str): The value type of every cell within the rasters.
-                        layoutDefinition (dict): Defines the raster layout of the rasters.
-
-                        The fields that are used to represent the layoutDefinition:
-                            extent (dict): The area covered by the layout tiles.
-                            tileLayout (dict): The tile layout of the rasters.
-                        extent (dict): The extent that covers the tiles.
-                        crs (str): The CRS that the rasters are projected in.
-                        bounds (dict): Represents the positions of the tile layer's tiles within
-                            a gird.  These positions are represented by keys. There are two
-                            different types of keys, SpatialKeys and SpaceTimeKeys. SpatialKeys are
-                            for data that only have a spatial component while SpaceTimeKeys are for
-                            data with both spatial and temporal components.
-
-                            Both SpatialKeys and SpaceTimeKeys share these fields:
-                                The fields that are used to represent the bounds:
-                                    minKey (dict): Represents where the tile layer begins in the
-                                        gird.
-                                    maxKey (dict): Represents where the tile layer ends in the gird.
-
-                                    The fields that are used to represent the minKey and maxKey:
-                                        col (int): The column number of the grid, runs east to west.
-                                        row (int): The row number of the grid, runs north to south.
-
-                            SpaceTimeKeys also have an additional field:
-                                instant (int): The time stamp of the tile.
-    """
-
-    reproject_wrapper = geopysc.rdd_reprojector
-    key = geopysc.map_key_input(rdd_type, True)
-
-    (java_rdd, schema) = _convert_to_java_rdd(geopysc, key, keyed_rdd)
-
-    result = reproject_wrapper.reproject(key,
-                                         java_rdd,
-                                         schema,
-                                         json.dumps(tile_layer_metadata),
-                                         dest_crs,
-                                         tile_size,
-                                         resolution_threshold,
-                                         resample_method,
-                                         match_layer_extent)
+    elif 'tile_size' and 'resolution_threshold' in layer_layout:
+        result = reproject_wrapper.reproject(key,
+                                             java_rdd,
+                                             schema,
+                                             json.dumps(tile_layer_metadata),
+                                             dest_crs,
+                                             layer_layout['tile_size'],
+                                             layer_layout['resolution_threshold'],
+                                             resample_method,
+                                             match_layer_extent)
+    else:
+        result = reproject_wrapper.reproject(key,
+                                             java_rdd,
+                                             schema,
+                                             json.dumps(tile_layer_metadata),
+                                             dest_crs,
+                                             layer_layout['tile_size'],
+                                             resample_method,
+                                             match_layer_extent)
 
     (rdd, returned_schema) = (result._2()._1(), result._2()._2())
     ser = geopysc.create_tuple_serializer(returned_schema, value_type=TILE)

--- a/geopyspark/geotrellis/tile_layer.py
+++ b/geopyspark/geotrellis/tile_layer.py
@@ -8,7 +8,7 @@ area information of the layer.
 import json
 
 from geopyspark.avroserializer import AvroSerializer
-from geopyspark.geotrellis.constants import NEARESTNEIGHBOR, TILE
+from geopyspark.geotrellis.constants import NEARESTNEIGHBOR, TILE, SPATIAL
 
 
 def _convert_to_java_rdd(geopysc, rdd_type, raster_rdd):
@@ -244,13 +244,151 @@ def collect_pyramid_metadata(geopysc,
 
     return (result._1(), json.loads(result._2()))
 
-
 def reproject(geopysc,
-              rdd_type,
-              keyed_rdd,
-              tile_layer_metadata,
+              raster_rdd,
               dest_crs,
-              match_layer_extent=False):
+              resample_method=NEARESTNEIGHBOR,
+              error_threshold=0.125):
+
+    """Reprojects the tiles within a RDD to a new projection.
+
+    The new RDD will have tiles that are laid according to the the layout definition
+    within the metadata. This function is used when the RDD has no corresponding zoom
+    (ie. is not a layer within a pyramid).
+
+    Args:
+        geopysc (GeoPyContext): The GeoPyContext being used this session.
+        rdd_type (str): What the spatial type of the geotiffs are. This is
+            represented by the constants: SPATIAL and SPACETIME. Note: All of the
+            GeoTiffs must have the same saptial type.
+        keyed_rdd(RDD): A RDD that contains tuples of dictionaries, (key, tile).
+            key (dict): The index of the tile within the layer. There are two different types
+                of keys, SpatialKeys and SpaceTimeKeys. SpatialKeys deal with data that have just
+                a spatial component, whereas SpaceTimeKeys are for data with both a spatial and
+                time component.
+
+                Both SpatialKeys and SpaceTimeKeys share these fields:
+                    col (int): The column number of the grid, runs east to west.
+                    row (int): The row number of the grid, runs north to south.
+
+                SpaceTimeKeys also have an additional field:
+                    instant (int): The time stamp of the tile.
+            tile (dict): The data of the tile.
+
+                The fields to represent the tile:
+                    data (np.ndarray): The tile data itself is represented as a 3D, numpy array.
+                        Note, even if the data was originally singleband, it will be reformatted as
+                        a multiband tile and read and saved as such.
+                    no_data_value (optional): The no data value of the tile. Can be a range of
+                        types including None.
+        tile_layer_metadata (dict): The metadata for this tile layer. This provides
+            the information needed to resample the old tiles and create new ones.
+
+            The fields that are used to represent the metadata:
+                cellType (str): The value type of every cell within the rasters.
+                layoutDefinition (dict): Defines the raster layout of the rasters.
+
+                The fields that are used to represent the layoutDefinition:
+                    extent (dict): The area covered by the layout tiles.
+                    tileLayout (dict): The tile layout of the rasters.
+                extent (dict): The extent that covers the tiles.
+                crs (str): The CRS that the rasters are projected in.
+                bounds (dict): Represents the positions of the tile layer tiles within a gird.
+
+                    The fields that are used to represent the bounds:
+                        minKey (dict): Represents where the tile layer begins in the gird.
+                        maxKey (dict): Represents where the tile layer ends in the gird.
+
+                        The fields that are used to represent the minKey and maxKey:
+                            col (int): The column number of the grid, runs east to west.
+                            row (int): The row number of the grid, runs north to south.
+        dest_crs (str): The CRS that the tiles should be reprojected to. Must be in well-known name
+            format. This can be same,or a different than what's in the tile_layer_metadata.
+        match_layer_extent (bool): Should the reprojection attempt to match the total layer's
+            extent. Defualts to False. This should only be used with small extents, as seems can
+            occur if the extent is too large.
+
+    Returns:
+        tuple: A tuple containing (reprojected_rdd, metadata).
+            projected_rdd (RDD): A RDD that contains data only for that layer represented as
+                tuples of dictionaries.
+
+                key (dict): The index of the tile within the layer. There are two different
+                    types of keys, SpatialKeys and SpaceTimeKeys. SpatialKeys deal with data that
+                    have just a spatial component, whereas SpaceTimeKeys are for data with both a
+                    spatial and time component.
+
+                    Both SpatialKeys and SpaceTimeKeys share these fields:
+                        col (int): The column number of the grid, runs east to west.
+                        row (int): The row number of the grid, runs north to south.
+
+                    SpaceTimeKeys also have an additional field:
+                        instant (int): The time stamp of the tile.
+                tile (dict): The data of the tile.
+
+                    The fields to represent the tile:
+                        data (np.ndarray): The tile data itself is represented as a 3D, numpy
+                            array.  Note, even if the data was originally singleband, it will
+                            be reformatted as a multiband tile and read and saved as such.
+                        no_data_value (optional): The no data value of the tile. Can be a range of
+                            types including None.
+            metadata (dict): The metadata for the RDD.
+                dict: The dictionary representation of the RDD's metadata.
+                    The fields that are used to represent the metadata:
+                        cellType (str): The value type of every cell within the rasters.
+                        layoutDefinition (dict): Defines the raster layout of the rasters.
+
+                        The fields that are used to represent the layoutDefinition:
+                            extent (dict): The area covered by the layout tiles.
+                            tileLayout (dict): The tile layout of the rasters.
+                        extent (dict): The extent that covers the tiles.
+                        crs (str): The CRS that the rasters are projected in.
+                        bounds (dict): Represents the positions of the tile layer's tiles within
+                            a gird.  These positions are represented by keys. There are two
+                            different types of keys, SpatialKeys and SpaceTimeKeys. SpatialKeys are
+                            for data that only have a spatial component while SpaceTimeKeys are for
+                            data with both spatial and temporal components.
+
+                            Both SpatialKeys and SpaceTimeKeys share these fields:
+                                The fields that are used to represent the bounds:
+                                    minKey (dict): Represents where the tile layer begins in the
+                                        gird.
+                                    maxKey (dict): Represents where the tile layer ends in the gird.
+
+                                    The fields that are used to represent the minKey and maxKey:
+                                        col (int): The column number of the grid, runs east to west.
+                                        row (int): The row number of the grid, runs north to south.
+
+                            SpaceTimeKeys also have an additional field:
+                                instant (int): The time stamp of the tile.
+    """
+
+    reproject_wrapper = geopysc.rdd_reprojector
+    key = geopysc.map_key_input(SPATIAL, False)
+
+    (java_rdd, schema) = _convert_to_java_rdd(geopysc, key, raster_rdd)
+
+    result = reproject_wrapper.reproject(java_rdd,
+                                         schema,
+                                         dest_crs,
+                                         resample_method,
+                                         error_threshold)
+
+    (rdd, returned_schema) = (result._2()._1(), result._2()._2())
+    ser = geopysc.create_tuple_serializer(returned_schema, value_type=TILE)
+    returned_rdd = geopysc.create_python_rdd(rdd, ser)
+
+    return (returned_rdd, json.loads(result._3()))
+
+def reproject_pyramid_layout(geopysc,
+                             rdd_type,
+                             keyed_rdd,
+                             tile_layer_metadata,
+                             dest_crs,
+                             layout_extent,
+                             tile_layout,
+                             resample_method=NEARESTNEIGHBOR,
+                             match_layer_extent=False):
 
     """Reprojects the tiles within a RDD to a new projection.
 
@@ -370,12 +508,15 @@ def reproject(geopysc,
 
     (java_rdd, schema) = _convert_to_java_rdd(geopysc, key, keyed_rdd)
 
-    result = reproject_wrapper.reproject(key,
-                                         java_rdd,
-                                         schema,
-                                         json.dumps(tile_layer_metadata),
-                                         dest_crs,
-                                         match_layer_extent)
+    result = reproject_wrapper.reprojectWithLayout(key,
+                                                   java_rdd,
+                                                   schema,
+                                                   json.dumps(tile_layer_metadata),
+                                                   dest_crs,
+                                                   layout_extent,
+                                                   tile_layout,
+                                                   resample_method,
+                                                   match_layer_extent)
 
     (rdd, returned_schema) = (result._2()._1(), result._2()._2())
     ser = geopysc.create_tuple_serializer(returned_schema, value_type=TILE)
@@ -383,14 +524,15 @@ def reproject(geopysc,
 
     return (returned_rdd, json.loads(result._3()))
 
-def reproject_pyramid(geopysc,
-                      rdd_type,
-                      keyed_rdd,
-                      tile_layer_metadata,
-                      dest_crs,
-                      tile_size,
-                      resolution_threshold=0.1,
-                      match_layer_extent=False):
+def reproject_pyramid_zoom(geopysc,
+                           rdd_type,
+                           keyed_rdd,
+                           tile_layer_metadata,
+                           dest_crs,
+                           tile_size,
+                           resolution_threshold=0.1,
+                           resample_method=NEARESTNEIGHBOR,
+                           match_layer_extent=False):
 
     """Reprojects a layer to a new projection.
 
@@ -527,6 +669,7 @@ def reproject_pyramid(geopysc,
                                                  dest_crs,
                                                  match_layer_extent,
                                                  tile_size,
+                                                 resample_method,
                                                  resolution_threshold)
 
     (rdd, returned_schema) = (result._2()._1(), result._2()._2())

--- a/geopyspark/tests/reproject_test.py
+++ b/geopyspark/tests/reproject_test.py
@@ -59,16 +59,18 @@ class ReprojectTest(BaseTestClass):
         self.assertDictEqual(layout_definition, new_metadata['layoutDefinition'])
 
     def test_same_crs_zoom(self):
-        (_, _, new_metadata) = reproject_with_zoomed_layout(BaseTestClass.geopysc,
-                                                            SPATIAL,
-                                                            self.laid_out_rdd,
-                                                            self.metadata,
-                                                            "EPSG:4326",
-                                                            self.expected_cols)
+        (_, new_rdd, new_metadata) = reproject_with_zoomed_layout(BaseTestClass.geopysc,
+                                                                  SPATIAL,
+                                                                  self.laid_out_rdd,
+                                                                  self.metadata,
+                                                                  "EPSG:4326",
+                                                                  self.expected_cols)
 
-        layout_definition = {'tileLayout': self.layout, 'extent': self.extent}
+        actual_tile = new_rdd.first()[1]['data']
+        (_, actual_rows, actual_cols) = actual_tile.shape
 
-        self.assertDictEqual(layout_definition, new_metadata['layoutDefinition'])
+        self.assertTrue(self.expected_cols >= actual_cols)
+        self.assertTrue(self.expected_rows >= actual_rows)
 
     def test_different_crs_layout(self):
         (_, new_rdd, new_metadata) = reproject_with_tile_layout(BaseTestClass.geopysc,

--- a/geopyspark/tests/reproject_test.py
+++ b/geopyspark/tests/reproject_test.py
@@ -2,7 +2,10 @@ import os
 import unittest
 
 from geopyspark.tests.python_test_utils import check_directory, geotiff_test_path
-from geopyspark.geotrellis.tile_layer import reproject_pyramid_layout, reproject_pyramid_zoom, collect_metadata, tile_to_layout
+from geopyspark.geotrellis.tile_layer import (reproject_with_tile_layout,
+                                              reproject_with_zoomed_layout,
+                                              collect_metadata,
+                                              tile_to_layout)
 from geopyspark.geotrellis.geotiff_rdd import geotiff_rdd
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis.constants import SPATIAL
@@ -43,38 +46,38 @@ class ReprojectTest(BaseTestClass):
                                   metadata)
 
     def test_same_crs_layout(self):
-        (_, new_metadata) = reproject_pyramid_layout(BaseTestClass.geopysc,
-                                                     SPATIAL,
-                                                     self.laid_out_rdd,
-                                                     self.metadata,
-                                                     "EPSG:4326",
-                                                     self.extent,
-                                                     self.layout)
+        (_, _, new_metadata) = reproject_with_tile_layout(BaseTestClass.geopysc,
+                                                          SPATIAL,
+                                                          self.laid_out_rdd,
+                                                          self.metadata,
+                                                          "EPSG:4326",
+                                                          self.extent,
+                                                          self.layout)
 
         layout_definition = {'tileLayout': self.layout, 'extent': self.extent}
 
         self.assertDictEqual(layout_definition, new_metadata['layoutDefinition'])
 
     def test_same_crs_zoom(self):
-        (_, _, new_metadata) = reproject_pyramid_zoom(BaseTestClass.geopysc,
-                                                      SPATIAL,
-                                                      self.laid_out_rdd,
-                                                      self.metadata,
-                                                      "EPSG:4326",
-                                                      self.expected_cols)
+        (_, _, new_metadata) = reproject_with_zoomed_layout(BaseTestClass.geopysc,
+                                                            SPATIAL,
+                                                            self.laid_out_rdd,
+                                                            self.metadata,
+                                                            "EPSG:4326",
+                                                            self.expected_cols)
 
         layout_definition = {'tileLayout': self.layout, 'extent': self.extent}
 
         self.assertDictEqual(layout_definition, new_metadata['layoutDefinition'])
 
     def test_different_crs_layout(self):
-        (new_rdd, new_metadata) = reproject_pyramid_layout(BaseTestClass.geopysc,
-                                                           SPATIAL,
-                                                           self.laid_out_rdd,
-                                                           self.metadata,
-                                                           "EPSG:4324",
-                                                           self.extent,
-                                                           self.layout)
+        (_, new_rdd, new_metadata) = reproject_with_tile_layout(BaseTestClass.geopysc,
+                                                                SPATIAL,
+                                                                self.laid_out_rdd,
+                                                                self.metadata,
+                                                                "EPSG:4324",
+                                                                self.extent,
+                                                                self.layout)
 
         actual_tile = new_rdd.first()[1]['data']
         (_, actual_rows, actual_cols) = actual_tile.shape
@@ -83,12 +86,12 @@ class ReprojectTest(BaseTestClass):
         self.assertTrue(self.expected_rows >= actual_rows)
 
     def test_different_crs_zoom(self):
-        (_, new_rdd, new_metadata) = reproject_pyramid_zoom(BaseTestClass.geopysc,
-                                                            SPATIAL,
-                                                            self.laid_out_rdd,
-                                                            self.metadata,
-                                                            "EPSG:4324",
-                                                            500)
+        (_, new_rdd, new_metadata) = reproject_with_zoomed_layout(BaseTestClass.geopysc,
+                                                                  SPATIAL,
+                                                                  self.laid_out_rdd,
+                                                                  self.metadata,
+                                                                  "EPSG:4324",
+                                                                  500)
 
         actual_tile = new_rdd.first()[1]['data']
         (_, actual_rows, actual_cols) = actual_tile.shape


### PR DESCRIPTION
This Pr seeks to expand, fix, and refactor the reprojections of GeoPySpark. Two reproject methods have been added, `reproject` and `reproject_with_floating_layout`. In addition, fixes have been made to the `reproject_with_tile_layout` method so that it now works correctly.

This Pr fixes #82 