### PR TITLE
Metadata Refactor

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/TileLayerMetadataCollector.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/spark/TileLayerMetadataCollector.scala
@@ -133,15 +133,12 @@ object TileLayerMetadataCollector {
     returnedRdd: JavaRDD[Array[Byte]],
     schemaJson: String,
     floatingLayoutScheme: FloatingLayoutScheme,
-    outputCrs: String
+    crs: String
   ): (Int, String) = {
     val rdd = PythonTranslator.fromPython[(K, MultibandTile)](returnedRdd, Some(schemaJson))
 
     val (zoomLevel, metadata) =
-      outputCrs match {
-        case "" => TileLayerMetadata.fromRdd(rdd, floatingLayoutScheme)
-        case projection => TileLayerMetadata.fromRdd(rdd, CRS.fromName(projection), floatingLayoutScheme)
-      }
+      TileLayerMetadata.fromRdd(rdd, CRS.fromName(crs), floatingLayoutScheme)
 
     (zoomLevel, metadata.toJson.compactPrint)
   }
@@ -150,9 +147,9 @@ object TileLayerMetadataCollector {
     keyType: String,
     returnedRDD: JavaRDD[Array[Byte]],
     schemaJson: String,
+    crs: String,
     tileCols: Int,
-    tileRows: Int,
-    outputCrs: String
+    tileRows: Int
   ): (Int, String) =
       keyType match {
         case "ProjectedExtent" =>
@@ -160,12 +157,12 @@ object TileLayerMetadataCollector {
             returnedRDD,
             schemaJson,
             FloatingLayoutScheme(tileCols, tileRows),
-            outputCrs)
+            crs)
         case "TemporalProjectedExtent" =>
           createPyramidCollection[TemporalProjectedExtent, SpaceTimeKey](
             returnedRDD,
             schemaJson,
             FloatingLayoutScheme(tileCols, tileRows),
-            outputCrs)
+            crs)
       }
 }

--- a/geopyspark/geotrellis/tile_layer.py
+++ b/geopyspark/geotrellis/tile_layer.py
@@ -129,14 +129,14 @@ def collect_metadata(geopysc,
     return json.loads(metadata)
 
 
-def collect_pyramid_zoomed_metadata(geopysc,
-                                    rdd_type,
-                                    raster_rdd,
-                                    crs,
-                                    tile_size,
-                                    resolution_threshold=0.1,
-                                    max_zoom=12,
-                                    output_crs=None):
+def collect_pyramid_metadata(geopysc,
+                             rdd_type,
+                             raster_rdd,
+                             crs,
+                             tile_size,
+                             resolution_threshold=0.1,
+                             max_zoom=12,
+                             output_crs=None):
 
     """Collects the metadata of an RDD as well as the zoom level of the RDD.
 
@@ -244,12 +244,12 @@ def collect_pyramid_zoomed_metadata(geopysc,
 
     return (result._1(), json.loads(result._2()))
 
-def collect_pyramid_floating_metadata(geopysc,
-                                      rdd_type,
-                                      raster_rdd,
-                                      tile_cols,
-                                      tile_rows,
-                                      output_crs=None):
+def collect_floating_metadata(geopysc,
+                              rdd_type,
+                              raster_rdd,
+                              tile_cols,
+                              tile_rows,
+                              output_crs=None):
 
     """Collects the metadata of an RDD as well as the zoom level of the RDD.
 

--- a/geopyspark/geotrellis/tile_layer.py
+++ b/geopyspark/geotrellis/tile_layer.py
@@ -247,9 +247,9 @@ def collect_pyramid_zoomed_metadata(geopysc,
 def collect_pyramid_floating_metadata(geopysc,
                                       rdd_type,
                                       raster_rdd,
+                                      crs,
                                       tile_cols,
-                                      tile_rows,
-                                      output_crs=None):
+                                      tile_rows):
 
     """Collects the metadata of an RDD as well as the zoom level of the RDD.
 
@@ -262,17 +262,12 @@ def collect_pyramid_floating_metadata(geopysc,
 
     (java_rdd, schema) = _convert_to_java_rdd(geopysc, key, raster_rdd)
 
-    if output_crs:
-        output_crs = output_crs
-    else:
-        output_crs = ""
-
     result = metadata_wrapper.collectPythonMetadata(key,
                                                     java_rdd,
                                                     schema,
+                                                    crs,
                                                     tile_cols,
-                                                    tile_rows,
-                                                    output_crs)
+                                                    tile_rows)
     return (result._1(), json.loads(result._2()))
 
 def reproject(geopysc,

--- a/geopyspark/geotrellis/tile_layer.py
+++ b/geopyspark/geotrellis/tile_layer.py
@@ -247,15 +247,20 @@ def collect_pyramid_zoomed_metadata(geopysc,
 def collect_pyramid_floating_metadata(geopysc,
                                       rdd_type,
                                       raster_rdd,
-                                      crs,
                                       tile_cols,
-                                      tile_rows):
+                                      tile_rows,
+                                      output_crs=None):
 
     """Collects the metadata of an RDD as well as the zoom level of the RDD.
 
     TODO: Finish the rest of the docs.
 
     """
+
+    if output_crs:
+        output_crs = output_crs
+    else:
+        output_crs = ""
 
     metadata_wrapper = geopysc.tile_layer_metadata_collecter
     key = geopysc.map_key_input(rdd_type, False)
@@ -265,9 +270,9 @@ def collect_pyramid_floating_metadata(geopysc,
     result = metadata_wrapper.collectPythonMetadata(key,
                                                     java_rdd,
                                                     schema,
-                                                    crs,
                                                     tile_cols,
-                                                    tile_rows)
+                                                    tile_rows,
+                                                    output_crs)
     return (result._1(), json.loads(result._2()))
 
 def reproject(geopysc,

--- a/geopyspark/geotrellis/tile_layer.py
+++ b/geopyspark/geotrellis/tile_layer.py
@@ -129,14 +129,14 @@ def collect_metadata(geopysc,
     return json.loads(metadata)
 
 
-def collect_pyramid_metadata(geopysc,
-                             rdd_type,
-                             raster_rdd,
-                             crs,
-                             tile_size,
-                             resolution_threshold=0.1,
-                             max_zoom=12,
-                             output_crs=None):
+def collect_pyramid_zoomed_metadata(geopysc,
+                                    rdd_type,
+                                    raster_rdd,
+                                    crs,
+                                    tile_size,
+                                    resolution_threshold=0.1,
+                                    max_zoom=12,
+                                    output_crs=None):
 
     """Collects the metadata of an RDD as well as the zoom level of the RDD.
 
@@ -233,15 +233,46 @@ def collect_pyramid_metadata(geopysc,
     else:
         output_crs = ""
 
-    result = metadata_wrapper.collectPythonPyramidMetadata(key,
-                                                           java_rdd,
-                                                           schema,
-                                                           crs,
-                                                           tile_size,
-                                                           resolution_threshold,
-                                                           max_zoom,
-                                                           output_crs)
+    result = metadata_wrapper.collectPythonMetadata(key,
+                                                    java_rdd,
+                                                    schema,
+                                                    crs,
+                                                    tile_size,
+                                                    resolution_threshold,
+                                                    max_zoom,
+                                                    output_crs)
 
+    return (result._1(), json.loads(result._2()))
+
+def collect_pyramid_floating_metadata(geopysc,
+                                      rdd_type,
+                                      raster_rdd,
+                                      tile_cols,
+                                      tile_rows,
+                                      output_crs=None):
+
+    """Collects the metadata of an RDD as well as the zoom level of the RDD.
+
+    TODO: Finish the rest of the docs.
+
+    """
+
+    metadata_wrapper = geopysc.tile_layer_metadata_collecter
+    key = geopysc.map_key_input(rdd_type, False)
+
+    (java_rdd, schema) = _convert_to_java_rdd(geopysc, key, raster_rdd)
+
+    if output_crs:
+        output_crs = output_crs
+    else:
+        output_crs = ""
+
+    result = metadata_wrapper.collectPythonMetadata(key,
+                                                    java_rdd,
+                                                    schema,
+                                                    tile_cols,
+                                                    tile_rows,
+                                                    output_crs)
     return (result._1(), json.loads(result._2()))
 
 def reproject(geopysc,

--- a/geopyspark/tests/pyramiding_test.py
+++ b/geopyspark/tests/pyramiding_test.py
@@ -4,7 +4,7 @@ import rasterio
 
 from geopyspark.tests.python_test_utils import check_directory, geotiff_test_path
 from geopyspark.geotrellis.tile_layer import (collect_metadata,
-                                              collect_pyramid_zoomed_metadata,
+                                              collect_pyramid_metadata,
                                               tile_to_layout,
                                               pyramid)
 from geopyspark.geotrellis.geotiff_rdd import geotiff_rdd
@@ -20,11 +20,11 @@ class PyramidingTest(BaseTestClass):
     rdd = geotiff_rdd(BaseTestClass.geopysc, SPATIAL, dir_path)
 
     def test_pyramid_building(self):
-        (zoom, metadata) = collect_pyramid_zoomed_metadata(BaseTestClass.geopysc,
-                                                           SPATIAL,
-                                                           self.rdd,
-                                                           "EPSG:4326",
-                                                           1024)
+        (zoom, metadata) = collect_pyramid_metadata(BaseTestClass.geopysc,
+                                                    SPATIAL,
+                                                    self.rdd,
+                                                    "EPSG:4326",
+                                                    1024)
 
         laid_out = tile_to_layout(BaseTestClass.geopysc,
                                   SPATIAL,

--- a/geopyspark/tests/pyramiding_test.py
+++ b/geopyspark/tests/pyramiding_test.py
@@ -4,7 +4,7 @@ import rasterio
 
 from geopyspark.tests.python_test_utils import check_directory, geotiff_test_path
 from geopyspark.geotrellis.tile_layer import (collect_metadata,
-                                              collect_pyramid_metadata,
+                                              collect_pyramid_zoomed_metadata,
                                               tile_to_layout,
                                               pyramid)
 from geopyspark.geotrellis.geotiff_rdd import geotiff_rdd
@@ -20,11 +20,11 @@ class PyramidingTest(BaseTestClass):
     rdd = geotiff_rdd(BaseTestClass.geopysc, SPATIAL, dir_path)
 
     def test_pyramid_building(self):
-        (zoom, metadata) = collect_pyramid_metadata(BaseTestClass.geopysc,
-                                                    SPATIAL,
-                                                    self.rdd,
-                                                    "EPSG:4326",
-                                                    1024)
+        (zoom, metadata) = collect_pyramid_zoomed_metadata(BaseTestClass.geopysc,
+                                                           SPATIAL,
+                                                           self.rdd,
+                                                           "EPSG:4326",
+                                                           1024)
 
         laid_out = tile_to_layout(BaseTestClass.geopysc,
                                   SPATIAL,

--- a/geopyspark/tests/tile_layer_metadata_test.py
+++ b/geopyspark/tests/tile_layer_metadata_test.py
@@ -3,7 +3,8 @@ import unittest
 import rasterio
 
 from geopyspark.tests.python_test_utils import check_directory, geotiff_test_path
-from geopyspark.geotrellis.tile_layer import collect_metadata, collect_pyramid_metadata
+from geopyspark.geotrellis.tile_layer import (collect_metadata,
+                                              collect_pyramid_floating_metadata)
 from geopyspark.geotrellis.geotiff_rdd import geotiff_rdd
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis.constants import SPATIAL
@@ -54,7 +55,6 @@ class TileLayerMetadataTest(BaseTestClass):
 
         self.check_results(self.actual, expected)
 
-
     def test_collection_python_rdd(self):
         data = rasterio.open(self.dir_path)
         tile_dict = {'data': data.read(), 'no_data_value': data.nodata}
@@ -65,6 +65,19 @@ class TileLayerMetadataTest(BaseTestClass):
                                   rasterio_rdd,
                                   self.extent,
                                   self.layout)
+
+        expected = [[result['layoutDefinition']['extent'],
+                     result['layoutDefinition']['tileLayout']],
+                    result['extent']]
+
+        self.check_results(self.actual, expected)
+
+    def test_collection_floating(self):
+        (_, result) = collect_pyramid_floating_metadata(BaseTestClass.geopysc,
+                                                        SPATIAL,
+                                                        self.rdd,
+                                                        self.cols,
+                                                        self.rows)
 
         expected = [[result['layoutDefinition']['extent'],
                      result['layoutDefinition']['tileLayout']],

--- a/geopyspark/tests/tile_layer_metadata_test.py
+++ b/geopyspark/tests/tile_layer_metadata_test.py
@@ -76,6 +76,7 @@ class TileLayerMetadataTest(BaseTestClass):
         (_, result) = collect_pyramid_floating_metadata(BaseTestClass.geopysc,
                                                         SPATIAL,
                                                         self.rdd,
+                                                        "EPSG:{}".format(self.projected_extent['epsg']),
                                                         self.cols,
                                                         self.rows)
 

--- a/geopyspark/tests/tile_layer_metadata_test.py
+++ b/geopyspark/tests/tile_layer_metadata_test.py
@@ -4,7 +4,7 @@ import rasterio
 
 from geopyspark.tests.python_test_utils import check_directory, geotiff_test_path
 from geopyspark.geotrellis.tile_layer import (collect_metadata,
-                                              collect_pyramid_floating_metadata)
+                                              collect_floating_metadata)
 from geopyspark.geotrellis.geotiff_rdd import geotiff_rdd
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis.constants import SPATIAL
@@ -73,11 +73,11 @@ class TileLayerMetadataTest(BaseTestClass):
         self.check_results(self.actual, expected)
 
     def test_collection_floating(self):
-        (_, result) = collect_pyramid_floating_metadata(BaseTestClass.geopysc,
-                                                        SPATIAL,
-                                                        self.rdd,
-                                                        self.cols,
-                                                        self.rows)
+        (_, result) = collect_floating_metadata(BaseTestClass.geopysc,
+                                                SPATIAL,
+                                                self.rdd,
+                                                self.cols,
+                                                self.rows)
 
         expected = [[result['layoutDefinition']['extent'],
                      result['layoutDefinition']['tileLayout']],

--- a/geopyspark/tests/tile_layer_metadata_test.py
+++ b/geopyspark/tests/tile_layer_metadata_test.py
@@ -76,7 +76,6 @@ class TileLayerMetadataTest(BaseTestClass):
         (_, result) = collect_pyramid_floating_metadata(BaseTestClass.geopysc,
                                                         SPATIAL,
                                                         self.rdd,
-                                                        "EPSG:{}".format(self.projected_extent['epsg']),
                                                         self.cols,
                                                         self.rows)
 


### PR DESCRIPTION
This Pr is based another, open Pr #84 . This Pr seeks to add a new way of collecting metadata through using `FloatingLayoutScheme`. In addition to this new method, the metadata collecting code has been cleaned up and a few function names have been changes.