### PR TITLE
Geopycontext Refactor

### DIFF
--- a/geopyspark/geopycontext.py
+++ b/geopyspark/geopycontext.py
@@ -22,51 +22,51 @@ class GeoPyContext(object):
         self.avroregistry = AvroRegistry()
 
     @property
-    def schema_producer(self):
+    def _schema_producer(self):
         return self._jvm.geopyspark.geotrellis.SchemaProducer
 
     @property
-    def hadoop_geotiff_rdd(self):
+    def _hadoop_geotiff_rdd(self):
         return self._jvm.geopyspark.geotrellis.io.hadoop.HadoopGeoTiffRDDWrapper
 
     @property
-    def s3_geotiff_rdd(self):
+    def _s3_geotiff_rdd(self):
         return self._jvm.geopyspark.geotrellis.io.s3.S3GeoTiffRDDWrapper
 
     @property
-    def store_factory(self):
+    def _store_factory(self):
         return self._jvm.geopyspark.geotrellis.io.AttributeStoreFactory
 
     @property
-    def reader_factory(self):
+    def _reader_factory(self):
         return self._jvm.geopyspark.geotrellis.io.LayerReaderFactory
 
     @property
-    def value_reader_factory(self):
+    def _value_reader_factory(self):
         return self._jvm.geopyspark.geotrellis.io.ValueReaderFactory
 
     @property
-    def writer_factory(self):
+    def _writer_factory(self):
         return self._jvm.geopyspark.geotrellis.io.LayerWriterFactory
 
     @property
-    def tile_layer_metadata_collecter(self):
+    def _tile_layer_metadata_collecter(self):
         return self._jvm.geopyspark.geotrellis.spark.TileLayerMetadataCollector
 
     @property
-    def tile_layer_methods(self):
+    def _tile_layer_methods(self):
         return self._jvm.geopyspark.geotrellis.spark.tiling.TilerMethodsWrapper
 
     @property
-    def tile_layer_merge(self):
+    def _tile_layer_merge(self):
         return self._jvm.geopyspark.geotrellis.spark.merge.MergeMethodsWrapper
 
     @property
-    def pyramid_builder(self):
+    def _pyramid_builder(self):
         return self._jvm.geopyspark.geotrellis.spark.pyramid.PyramidWrapper
 
     @property
-    def rdd_reprojector(self):
+    def _rdd_reprojector(self):
         return self._jvm.geopyspark.geotrellis.spark.reproject.ReprojectWrapper
 
     @staticmethod
@@ -87,7 +87,7 @@ class GeoPyContext(object):
                 raise Exception("Could not find key type that matches", key_type)
 
     def create_schema(self, key_type):
-        return self.schema_producer.getSchema(key_type)
+        return self._schema_producer.getSchema(key_type)
 
     def create_tuple_serializer(self, schema, key_type=None, value_type=None):
         decoder = \
@@ -111,13 +111,3 @@ class GeoPyContext(object):
             return RDD(jrdd, self.pysc, serializer)
         else:
             return RDD(jrdd, self.pysc, AutoBatchedSerializer(serializer))
-
-    @staticmethod
-    def reserialize_python_rdd(rdd, serializer):
-        return rdd._reserialize(AutoBatchedSerializer(serializer))
-
-    def stop(self):
-        self.pysc.stop()
-
-    def close_gateway(self):
-        self.pysc._gateway.close()

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -26,22 +26,22 @@ def _construct_catalog(geopysc, new_uri, options):
         backend = parsed_uri.scheme
 
         if backend == 'hdfs':
-            store = geopysc.store_factory.buildHadoop(new_uri)
-            reader = geopysc.reader_factory.buildHadoop(store, geopysc.sc)
-            value_reader = geopysc.value_reader_factory.buildHadoop(store)
-            writer = geopysc.writer_factory.buildHadoop(store)
+            store = geopysc._store_factory.buildHadoop(new_uri)
+            reader = geopysc._reader_factory.buildHadoop(store, geopysc.sc)
+            value_reader = geopysc._value_reader_factory.buildHadoop(store)
+            writer = geopysc._writer_factory.buildHadoop(store)
 
         elif backend == 'file':
-            store = geopysc.store_factory.buildFile(new_uri[7:])
-            reader = geopysc.reader_factory.buildFile(store, geopysc.sc)
-            value_reader = geopysc.value_reader_factory.buildFile(store)
-            writer = geopysc.writer_factory.buildFile(store)
+            store = geopysc._store_factory.buildFile(new_uri[7:])
+            reader = geopysc._reader_factory.buildFile(store, geopysc.sc)
+            value_reader = geopysc._value_reader_factory.buildFile(store)
+            writer = geopysc._writer_factory.buildFile(store)
 
         elif backend == 's3':
-            store = geopysc.store_factory.buildS3(parsed_uri.netloc, parsed_uri.path[1:])
-            reader = geopysc.reader_factory.buildS3(store, geopysc.sc)
-            value_reader = geopysc.value_reader_factory.buildS3(store)
-            writer = geopysc.writer_factory.buildS3(store)
+            store = geopysc._store_factory.buildS3(parsed_uri.netloc, parsed_uri.path[1:])
+            reader = geopysc._reader_factory.buildS3(store, geopysc.sc)
+            value_reader = geopysc._value_reader_factory.buildS3(store)
+            writer = geopysc._writer_factory.buildS3(store)
 
         elif backend == 'cassandra':
             parameters = parsed_uri.query.split('&')
@@ -51,7 +51,7 @@ def _construct_catalog(geopysc, new_uri, options):
                 split_param = param.split('=', 1)
                 parameter_dict[split_param[0]] = split_param[1]
 
-            store = geopysc.store_factory.buildCassandra(
+            store = geopysc._store_factory.buildCassandra(
                 parameter_dict['host'],
                 parameter_dict['username'],
                 parameter_dict['password'],
@@ -59,9 +59,9 @@ def _construct_catalog(geopysc, new_uri, options):
                 parameter_dict['table'],
                 options)
 
-            reader = geopysc.reader_factory.buildCassandra(store, geopysc.sc)
-            value_reader = geopysc.value_reader_factory.buildCassandra(store)
-            writer = geopysc.writer_factory.buildCassandra(store,
+            reader = geopysc._reader_factory.buildCassandra(store, geopysc.sc)
+            value_reader = geopysc._value_reader_factory.buildCassandra(store)
+            writer = geopysc._writer_factory.buildCassandra(store,
                                                            parameter_dict['keyspace'],
                                                            parameter_dict['table'])
 
@@ -76,10 +76,10 @@ def _construct_catalog(geopysc, new_uri, options):
             else:
                 master = ""
 
-            store = geopysc.store_factory.buildHBase(zookeepers, master, port, table)
-            reader = geopysc.reader_factory.buildHBase(store, geopysc.sc)
-            value_reader = geopysc.value_reader_factory.buildHBase(store)
-            writer = geopysc.writer_factory.buildHBase(store, table)
+            store = geopysc._store_factory.buildHBase(zookeepers, master, port, table)
+            reader = geopysc._reader_factory.buildHBase(store, geopysc.sc)
+            value_reader = geopysc._value_reader_factory.buildHBase(store)
+            writer = geopysc._writer_factory.buildHBase(store, table)
 
         elif backend == 'accumulo':
 
@@ -87,19 +87,19 @@ def _construct_catalog(geopysc, new_uri, options):
             (user, password) = parsed_uri.netloc.split(':')
             split_parameters = parsed_uri.path.split('/')[1:]
 
-            store = geopysc.store_factory.buildAccumulo(split_parameters[0],
+            store = geopysc._store_factory.buildAccumulo(split_parameters[0],
                                                         split_parameters[1],
                                                         user,
                                                         password,
                                                         split_parameters[2])
 
-            reader = geopysc.reader_factory.buildAccumulo(split_parameters[1],
+            reader = geopysc._reader_factory.buildAccumulo(split_parameters[1],
                                                           store,
                                                           geopysc.sc)
 
-            value_reader = geopysc.value_reader_factory.buildAccumulo(store)
+            value_reader = geopysc._value_reader_factory.buildAccumulo(store)
 
-            writer = geopysc.writer_factory.buildAccumulo(split_parameters[1],
+            writer = geopysc._writer_factory.buildAccumulo(split_parameters[1],
                                                           store,
                                                           split_parameters[2])
 

--- a/geopyspark/geotrellis/geotiff_rdd.py
+++ b/geopyspark/geotrellis/geotiff_rdd.py
@@ -88,27 +88,27 @@ def geotiff_rdd(geopysc,
         (bucket, prefix) = key_and_bucket_uri.split("/", 1)
 
         if not options:
-            result = geopysc.s3_geotiff_rdd.getRDD(key,
-                                                   bucket,
-                                                   prefix,
-                                                   geopysc.sc)
+            result = geopysc._s3_geotiff_rdd.getRDD(key,
+                                                    bucket,
+                                                    prefix,
+                                                    geopysc.sc)
         else:
-            result = geopysc.s3_geotiff_rdd.getRDD(key,
-                                                   bucket,
-                                                   prefix,
-                                                   options,
-                                                   geopysc.sc)
+            result = geopysc._s3_geotiff_rdd.getRDD(key,
+                                                    bucket,
+                                                    prefix,
+                                                    options,
+                                                    geopysc.sc)
 
     else:
         if not options:
-            result = geopysc.hadoop_geotiff_rdd.getRDD(key,
-                                                       uri,
-                                                       geopysc.sc)
+            result = geopysc._hadoop_geotiff_rdd.getRDD(key,
+                                                        uri,
+                                                        geopysc.sc)
         else:
-            result = geopysc.hadoop_geotiff_rdd.getRDD(key,
-                                                       uri,
-                                                       options,
-                                                       geopysc.sc)
+            result = geopysc._hadoop_geotiff_rdd.getRDD(key,
+                                                        uri,
+                                                        options,
+                                                        geopysc.sc)
 
     ser = geopysc.create_tuple_serializer(result._2(), value_type="Tile")
     return geopysc.create_python_rdd(result._1(), ser)

--- a/geopyspark/geotrellis/tile_layer.py
+++ b/geopyspark/geotrellis/tile_layer.py
@@ -109,7 +109,7 @@ def collect_metadata(geopysc,
                         instant (int): The time stamp of the tile.
     """
 
-    metadata_wrapper = geopysc.tile_layer_metadata_collecter
+    metadata_wrapper = geopysc._tile_layer_metadata_collecter
     key = geopysc.map_key_input(rdd_type, False)
 
     (java_rdd, schema) = _convert_to_java_rdd(geopysc, key, raster_rdd)
@@ -223,7 +223,7 @@ def collect_pyramid_metadata(geopysc,
                             instant (int): The time stamp of the tile.
     """
 
-    metadata_wrapper = geopysc.tile_layer_metadata_collecter
+    metadata_wrapper = geopysc._tile_layer_metadata_collecter
     key = geopysc.map_key_input(rdd_type, False)
 
     (java_rdd, schema) = _convert_to_java_rdd(geopysc, key, raster_rdd)
@@ -262,7 +262,7 @@ def collect_floating_metadata(geopysc,
     else:
         output_crs = ""
 
-    metadata_wrapper = geopysc.tile_layer_metadata_collecter
+    metadata_wrapper = geopysc._tile_layer_metadata_collecter
     key = geopysc.map_key_input(rdd_type, False)
 
     (java_rdd, schema) = _convert_to_java_rdd(geopysc, key, raster_rdd)
@@ -281,7 +281,13 @@ def reproject(geopysc,
               resample_method=NEARESTNEIGHBOR,
               error_threshold=0.125):
 
-    reproject_wrapper = geopysc.rdd_reprojector
+    """Reprojects the tiles within a RDD to a new projection.
+
+    TODO: Write the remaining docs.
+
+    """
+
+    reproject_wrapper = geopysc._rdd_reprojector
     key = geopysc.map_key_input(SPATIAL, False)
 
     (java_rdd, schema) = _convert_to_java_rdd(geopysc, key, raster_rdd)
@@ -407,7 +413,7 @@ def reproject_to_layout(geopysc,
     if kwargs and not layer_layout:
         layer_layout = kwargs
 
-    reproject_wrapper = geopysc.rdd_reprojector
+    reproject_wrapper = geopysc._rdd_reprojector
     key = geopysc.map_key_input(rdd_type, True)
 
     (java_rdd, schema) = _convert_to_java_rdd(geopysc, key, keyed_rdd)
@@ -551,7 +557,7 @@ def cut_tiles(geopysc,
                         types including None.
 
     """
-    tiler_wrapper = geopysc.tile_layer_methods
+    tiler_wrapper = geopysc._tile_layer_methods
     key = geopysc.map_key_input(rdd_type, False)
 
     (java_rdd, schema) = _convert_to_java_rdd(geopysc, key, raster_rdd)
@@ -668,7 +674,7 @@ def tile_to_layout(geopysc,
                 MIN
 
     """
-    tiler_wrapper = geopysc.tile_layer_methods
+    tiler_wrapper = geopysc._tile_layer_methods
     key = geopysc.map_key_input(rdd_type, False)
 
     (java_rdd, schema) = _convert_to_java_rdd(geopysc, key, raster_rdd)
@@ -779,7 +785,7 @@ def merge_tiles(geopysc,
                         types including None.
 
     """
-    merge_wrapper = geopysc.tile_layer_merge
+    merge_wrapper = geopysc._tile_layer_merge
     key = geopysc.map_key_input(rdd_type, False)
 
     (java_rdd_1, schema_1) = _convert_to_java_rdd(geopysc, key, rdd_1)
@@ -939,7 +945,7 @@ def pyramid(geopysc,
     """
 
 
-    pyramider = geopysc.pyramid_builder
+    pyramider = geopysc._pyramid_builder
     key = geopysc.map_key_input(rdd_type, True)
 
     (java_rdd, schema) = _convert_to_java_rdd(geopysc, key, base_raster_rdd)


### PR DESCRIPTION
This Pr is based on another, open Pr #86 . This Pr seeks to make certain methods of `GeoPyContext` private. The main reason for doing this is these methods act as a bridge between scala classes/objects and python; Thus, the user has no reason to use them and leaving them exposed could cause potential issues.

This Pr fixes #83 