### PR TITLE
Constants Refactor

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
@@ -108,13 +108,13 @@ class ProjectedRasterRDD(val rdd: RDD[(ProjectedExtent, MultibandTile)]) extends
   def cutTiles(layerMetadata: String, resampleMethod: String): TiledRasterRDD[SpatialKey] = {
     val md = layerMetadata.parseJson.convertTo[TileLayerMetadata[SpatialKey]]
     val rm = TileRDD.getResampleMethod(resampleMethod)
-    new SpatialTiledRasterRDD(MultibandTileLayerRDD(rdd.cutTiles(md, rm), md))
+    new SpatialTiledRasterRDD(None, MultibandTileLayerRDD(rdd.cutTiles(md, rm), md))
   }
 
   def tileToLayout(tileLayerMetadata: String, resampleMethod: String): TiledRasterRDD[SpatialKey] = {
     val md = tileLayerMetadata.parseJson.convertTo[TileLayerMetadata[SpatialKey]]
     val rm = TileRDD.getResampleMethod(resampleMethod)
-    new SpatialTiledRasterRDD(MultibandTileLayerRDD(rdd.tileToLayout(md, rm), md))
+    new SpatialTiledRasterRDD(None, MultibandTileLayerRDD(rdd.tileToLayout(md, rm), md))
   }
 
   def reproject(target_crs: String, resampleMethod: String): ProjectedRasterRDD = {
@@ -146,13 +146,13 @@ class TemporalProjectedRasterRDD(val rdd: RDD[(TemporalProjectedExtent, Multiban
     val md = layerMetadata.parseJson.convertTo[TileLayerMetadata[SpaceTimeKey]]
     val rm = TileRDD.getResampleMethod(resampleMethod)
     val tiles = rdd.cutTiles[SpaceTimeKey](md, rm)
-    new TemporalTiledRasterRDD(MultibandTileLayerRDD(tiles, md))
+    new TemporalTiledRasterRDD(None, MultibandTileLayerRDD(tiles, md))
   }
 
   def tileToLayout(layerMetadata: String, resampleMethod: String): TiledRasterRDD[SpaceTimeKey] = {
     val md = layerMetadata.parseJson.convertTo[TileLayerMetadata[SpaceTimeKey]]
     val rm = TileRDD.getResampleMethod(resampleMethod)
-    new TemporalTiledRasterRDD(MultibandTileLayerRDD(rdd.tileToLayout(md, rm), md))
+    new TemporalTiledRasterRDD(None, MultibandTileLayerRDD(rdd.tileToLayout(md, rm), md))
   }
 
   def reproject(target_crs: String, resampleMethod: String): TemporalProjectedRasterRDD = {

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
@@ -23,6 +23,13 @@ import scala.reflect._
 
 abstract class TiledRasterRDD[K: SpatialComponent: AvroRecordCodec: JsonFormat: ClassTag] extends TileRDD[K] {
   def rdd: RDD[(K, MultibandTile)] with Metadata[TileLayerMetadata[K]]
+  def zoomLevel: Option[Int]
+
+  def getZoom: Int =
+    zoomLevel match {
+      case None => -1
+      case Some(z) => z
+    }
 
   /** Encode RDD as Avro bytes and return it with avro schema used */
   def toAvroRDD(): (JavaRDD[Array[Byte]], String) = PythonTranslator.toPython(rdd)

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
@@ -36,6 +36,7 @@ abstract class TiledRasterRDD[K: SpatialComponent: AvroRecordCodec: JsonFormat: 
 }
 
 class SpatialTiledRasterRDD(
+  val zoomLevel: Option[Int],
   val rdd: RDD[(SpatialKey, MultibandTile)] with Metadata[TileLayerMetadata[SpatialKey]]
 ) extends TiledRasterRDD[SpatialKey] {
 
@@ -60,13 +61,15 @@ class SpatialTiledRasterRDD(
       }
     import Reproject.Options
     // TODO: return the zoom as well as RDD
-    new SpatialTiledRasterRDD(TileRDDReproject(rdd, _crs, schemeOrLayout, Options.DEFAULT)._2)
+    val (zoom, reprojected) = TileRDDReproject(rdd, _crs, schemeOrLayout, Options.DEFAULT)
+    new SpatialTiledRasterRDD(Some(zoom), reprojected)
   }
 
 }
 
 
 class TemporalTiledRasterRDD(
+  val zoomLevel: Option[Int],
   val rdd: RDD[(SpaceTimeKey, MultibandTile)] with Metadata[TileLayerMetadata[SpaceTimeKey]]
 ) extends TiledRasterRDD[SpaceTimeKey] {
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerReaderFactory.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerReaderFactory.scala
@@ -75,19 +75,19 @@ abstract class FilteringLayerReaderWrapper()
     (keyType, valueClass) match {
       case ("SpatialKey", "geotrellis.raster.Tile") => {
         val result = layerReader.read[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](id)
-        new SpatialTiledRasterRDD(MultibandTileLayerRDD(tileToMultiband[SpatialKey](result), result.metadata))
+        new SpatialTiledRasterRDD(Some(zoom), MultibandTileLayerRDD(tileToMultiband[SpatialKey](result), result.metadata))
       }
       case ("SpatialKey", "geotrellis.raster.MultibandTile") => {
         val result = layerReader.read[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]](id)
-        new SpatialTiledRasterRDD(MultibandTileLayerRDD(result, result.metadata))
+        new SpatialTiledRasterRDD(Some(zoom), MultibandTileLayerRDD(result, result.metadata))
       }
       case ("SpaceTimeKey", "geotrellis.raster.Tile") => {
         val result = layerReader.read[SpaceTimeKey, Tile, TileLayerMetadata[SpaceTimeKey]](id)
-        new TemporalTiledRasterRDD(MultibandTileLayerRDD(tileToMultiband[SpaceTimeKey](result), result.metadata))
+        new TemporalTiledRasterRDD(Some(zoom), MultibandTileLayerRDD(tileToMultiband[SpaceTimeKey](result), result.metadata))
       }
       case ("SpaceTimeKey", "geotrellis.raster.MultibandTile") => {
         val result = layerReader.read[SpaceTimeKey, MultibandTile, TileLayerMetadata[SpaceTimeKey]](id)
-        new TemporalTiledRasterRDD(MultibandTileLayerRDD(result, result.metadata))
+        new TemporalTiledRasterRDD(Some(zoom), MultibandTileLayerRDD(result, result.metadata))
       }
     }
   }
@@ -153,7 +153,7 @@ abstract class FilteringLayerReaderWrapper()
 
         val result = tileToMultiband[SpatialKey](query.result)
 
-        new SpatialTiledRasterRDD(MultibandTileLayerRDD(result, query.result.metadata))
+        new SpatialTiledRasterRDD(Some(zoom), MultibandTileLayerRDD(result, query.result.metadata))
       }
 
       case ("SpatialKey", "geotrellis.raster.MultibandTile") => {
@@ -166,7 +166,7 @@ abstract class FilteringLayerReaderWrapper()
           case None => layer
           case _ => throw new Exception("Unsupported Geometry")
         }
-        new SpatialTiledRasterRDD(query.result)
+        new SpatialTiledRasterRDD(Some(zoom), query.result)
       }
 
       case ("SpaceTimeKey", "geotrellis.raster.Tile") => {
@@ -186,7 +186,7 @@ abstract class FilteringLayerReaderWrapper()
         }
         val result = tileToMultiband[SpaceTimeKey](query2.result)
 
-        new TemporalTiledRasterRDD(MultibandTileLayerRDD(result, query2.result.metadata))
+        new TemporalTiledRasterRDD(Some(zoom), MultibandTileLayerRDD(result, query2.result.metadata))
       }
 
       case ("SpaceTimeKey", "geotrellis.raster.MultibandTile") => {
@@ -204,7 +204,7 @@ abstract class FilteringLayerReaderWrapper()
           case Some(q) => query1.where(q)
           case None => query1
         }
-        new TemporalTiledRasterRDD(query2.result)
+        new TemporalTiledRasterRDD(Some(zoom), query2.result)
       }
     }
   }

--- a/geopyspark/constants.py
+++ b/geopyspark/constants.py
@@ -67,7 +67,7 @@ RESAMPLE_METHODS = [
 ZOOM = 'zoom'
 
 """Layout scheme to match resolution of source rasters"""
-FLOATING = 'float'
+FLOAT = 'float'
 
 
 """A key indexing method. Works for RDDs that contain both SpatialKeys and SpacetimeKeys."""

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -8,7 +8,7 @@ import json
 
 from collections import namedtuple
 from geopyspark.rdd import TiledRasterRDD
-from geopyspark.geotrellis.constants import SPATIAL, TILE, ZORDER
+from geopyspark.constants import SPATIAL, TILE, ZORDER
 from shapely.geometry import Polygon
 from shapely.wkt import dumps
 from urllib.parse import urlparse

--- a/geopyspark/geotrellis/geotiff_rdd.py
+++ b/geopyspark/geotrellis/geotiff_rdd.py
@@ -3,6 +3,7 @@
 There is only one function found within this module at this time, geotiff_rdd.
 """
 
+from geopyspark.constants import TILE
 from geopyspark.rdd import RasterRDD
 
 def geotiff_rdd(geopysc,
@@ -111,7 +112,7 @@ def geotiff_rdd(geopysc,
                                                         options,
                                                         geopysc.sc)
 
-    ser = geopysc.create_tuple_serializer(result._2(), value_type="Tile")
+    ser = geopysc.create_tuple_serializer(result._2(), value_type=TILE)
     return geopysc.create_python_rdd(result._1(), ser)
 
 

--- a/geopyspark/geotrellis/tile_layer.py
+++ b/geopyspark/geotrellis/tile_layer.py
@@ -9,7 +9,7 @@ import json
 import shapely.wkt
 
 from geopyspark.avroserializer import AvroSerializer
-from geopyspark.geotrellis.constants import NEARESTNEIGHBOR, TILE, SPATIAL
+from geopyspark.constants import NEARESTNEIGHBOR, TILE
 
 
 def _convert_to_java_rdd(geopysc, rdd_type, raster_rdd):

--- a/geopyspark/rdd.py
+++ b/geopyspark/rdd.py
@@ -57,9 +57,19 @@ class TiledRasterRDD(object):
         self.rdd_type = rdd_type
         self.srdd = srdd
 
+    @property
     def layer_metadata(self):
         """Layer metadata associated with this layer"""
         return json.loads(self.srdd.layerMetadata())
+
+    @property
+    def zoom_level(self):
+        zoom = self.srdd.getZoom()
+
+        if zoom >= 0:
+            return zoom
+        else:
+            raise AttributeError("Tile layer does not have a corresponding zoom level")
 
     def to_numpy_rdd(self):
         result = self.srdd.toAvroRDD()

--- a/geopyspark/rdd.py
+++ b/geopyspark/rdd.py
@@ -1,5 +1,7 @@
-from geopyspark.geotrellis.constants import RESAMPLE_METHODS, NEARESTNEIGHBOR, ZOOM, FLOAT
 import json
+
+from geopyspark.constants import RESAMPLE_METHODS, NEARESTNEIGHBOR, ZOOM, FLOAT
+
 
 class RasterRDD(object):
     """Holds an RDD of GeoTrellis rasters"""

--- a/geopyspark/tests/geotiff_raster_rdd_test.py
+++ b/geopyspark/tests/geotiff_raster_rdd_test.py
@@ -2,10 +2,10 @@ import unittest
 from os import walk, path
 import rasterio
 
+from geopyspark.constants import SPATIAL
 from geopyspark.tests.python_test_utils import check_directory, geotiff_test_path
 from geopyspark.geotrellis.geotiff_rdd import geotiff_rdd, geotiff_raster_rdd
 from geopyspark.tests.base_test_class import BaseTestClass
-from geopyspark.geotrellis.constants import SPATIAL
 
 
 check_directory()

--- a/geopyspark/tests/hadoop_geotiff_rdd_test.py
+++ b/geopyspark/tests/hadoop_geotiff_rdd_test.py
@@ -2,10 +2,10 @@ import unittest
 from os import walk, path
 import rasterio
 
+from geopyspark.constants import SPATIAL
 from geopyspark.tests.python_test_utils import check_directory, geotiff_test_path
 from geopyspark.geotrellis.geotiff_rdd import geotiff_rdd
 from geopyspark.tests.base_test_class import BaseTestClass
-from geopyspark.geotrellis.constants import SPATIAL
 
 
 check_directory()

--- a/geopyspark/tests/pyramiding_test.py
+++ b/geopyspark/tests/pyramiding_test.py
@@ -2,6 +2,7 @@ import os
 import unittest
 import rasterio
 
+from geopyspark.constants import SPATIAL
 from geopyspark.tests.python_test_utils import check_directory, geotiff_test_path
 from geopyspark.geotrellis.tile_layer import (collect_metadata,
                                               collect_pyramid_metadata,
@@ -9,7 +10,6 @@ from geopyspark.geotrellis.tile_layer import (collect_metadata,
                                               pyramid)
 from geopyspark.geotrellis.geotiff_rdd import geotiff_rdd
 from geopyspark.tests.base_test_class import BaseTestClass
-from geopyspark.geotrellis.constants import SPATIAL
 
 
 check_directory()

--- a/geopyspark/tests/reproject_test.py
+++ b/geopyspark/tests/reproject_test.py
@@ -1,11 +1,11 @@
 import os
 import unittest
 
+from geopyspark.constants import SPATIAL
 from geopyspark.tests.python_test_utils import check_directory, geotiff_test_path
 from geopyspark.geotrellis.tile_layer import reproject_to_layout, collect_metadata, tile_to_layout
 from geopyspark.geotrellis.geotiff_rdd import geotiff_rdd
 from geopyspark.tests.base_test_class import BaseTestClass
-from geopyspark.geotrellis.constants import SPATIAL
 
 
 check_directory()

--- a/geopyspark/tests/s3_geotiff_rdd_test.py
+++ b/geopyspark/tests/s3_geotiff_rdd_test.py
@@ -2,10 +2,10 @@ from os import walk, path
 import unittest
 import rasterio
 
+from geopyspark.constants import SPATIAL
 from geopyspark.tests.python_test_utils import check_directory, geotiff_test_path
 from geopyspark.geotrellis.geotiff_rdd import geotiff_rdd
 from geopyspark.tests.base_test_class import BaseTestClass
-from geopyspark.geotrellis.constants import SPATIAL
 from py4j.java_gateway import java_import
 
 

--- a/geopyspark/tests/tile_layer_metadata_test.py
+++ b/geopyspark/tests/tile_layer_metadata_test.py
@@ -2,12 +2,12 @@ import os
 import unittest
 import rasterio
 
+from geopyspark.constants import SPATIAL
 from geopyspark.tests.python_test_utils import check_directory, geotiff_test_path
 from geopyspark.geotrellis.tile_layer import (collect_metadata,
                                               collect_floating_metadata)
 from geopyspark.geotrellis.geotiff_rdd import geotiff_rdd
 from geopyspark.tests.base_test_class import BaseTestClass
-from geopyspark.geotrellis.constants import SPATIAL
 
 
 check_directory()

--- a/geopyspark/tests/tile_layer_methods_test.py
+++ b/geopyspark/tests/tile_layer_methods_test.py
@@ -2,6 +2,7 @@ import os
 import unittest
 import rasterio
 
+from geopyspark.constants import SPATIAL
 from geopyspark.tests.python_test_utils import check_directory, geotiff_test_path
 from geopyspark.geotrellis.tile_layer import (collect_metadata,
                                               cut_tiles,
@@ -9,7 +10,6 @@ from geopyspark.geotrellis.tile_layer import (collect_metadata,
                                               tile_to_layout)
 from geopyspark.geotrellis.geotiff_rdd import geotiff_rdd
 from geopyspark.tests.base_test_class import BaseTestClass
-from geopyspark.geotrellis.constants import SPATIAL
 
 
 check_directory()


### PR DESCRIPTION
This Pr is based on another, open Pr #94 . This Pr simply moves `geopyspark.geotrellis.constants` to `geopyspark.constants`. The reasoning behind this is because `rdd.py` uses constants, and before the move had to access a submodule to retrieve them. Thus, to keep things more in-line with the library's structure, `constants.py` was moved up a directory. 