### PR TITLE
Opertaions Performance Refactor

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Constants.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Constants.scala
@@ -22,4 +22,15 @@ object Constants {
   final val MEDIAN = "Median"
   final val MAX = "Max"
   final val MIN = "Min"
+
+  final val MEAN = "Mean"
+  final val SUM = "Sum"
+  final val STANDARDDEVIATION = "StandardDeviation"
+  final val SLOPE = "Slope"
+  final val ASPECT = "Aspect"
+
+  final val ANNULUS = "annulus"
+  final val NESW = "nesw"
+  final val SQUARE = "square"
+  final val WEDGE = "wedge"
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/GeoTrellisUtils.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/GeoTrellisUtils.scala
@@ -2,6 +2,7 @@ package geopyspark.geotrellis
 
 import geotrellis.proj4._
 import geotrellis.raster._
+import geotrellis.raster.mapalgebra.focal._
 import geotrellis.vector._
 import geotrellis.spark._
 import geotrellis.spark.reproject._

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
@@ -304,4 +304,45 @@ class TemporalTiledRasterRDD(
     new TemporalTiledRasterRDD(None, multibandRDD)
   }
 }
+
+object SpatialTiledRasterRDD {
+  def fromAvroEncodedRDD(
+    javaRDD: JavaRDD[Array[Byte]],
+    schema: String,
+    metadata: String
+  ): SpatialTiledRasterRDD = {
+    val md = metadata.parseJson.convertTo[TileLayerMetadata[SpatialKey]]
+    val tileLayer = MultibandTileLayerRDD(
+      PythonTranslator.fromPython[(SpatialKey, MultibandTile)](javaRDD, Some(schema)),
+      md)
+
+    SpatialTiledRasterRDD(None, tileLayer)
+  }
+
+  def apply(
+    zoomLevel: Option[Int],
+    rdd: RDD[(SpatialKey, MultibandTile)] with Metadata[TileLayerMetadata[SpatialKey]]
+  ): SpatialTiledRasterRDD =
+    new SpatialTiledRasterRDD(zoomLevel, rdd)
+}
+
+object TemporalTiledRasterRDD {
+  def fromAvroEncodedRDD(
+    javaRDD: JavaRDD[Array[Byte]],
+    schema: String,
+    metadata: String
+  ): TemporalTiledRasterRDD = {
+    val md = metadata.parseJson.convertTo[TileLayerMetadata[SpaceTimeKey]]
+    val tileLayer = MultibandTileLayerRDD(
+      PythonTranslator.fromPython[(SpaceTimeKey, MultibandTile)](javaRDD, Some(schema)),
+      md)
+
+    TemporalTiledRasterRDD(None, tileLayer)
+  }
+
+  def apply(
+    zoomLevel: Option[Int],
+    rdd: RDD[(SpaceTimeKey, MultibandTile)] with Metadata[TileLayerMetadata[SpaceTimeKey]]
+  ): TemporalTiledRasterRDD =
+    new TemporalTiledRasterRDD(zoomLevel, rdd)
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
@@ -199,6 +199,15 @@ class SpatialTiledRasterRDD(
 
     new SpatialTiledRasterRDD(None, multibandRDD)
   }
+
+  def stitch: (Array[Byte], String) = {
+    val contextRDD = ContextRDD(
+      rdd.map({ case (k, v) => (k, v.band(0)) }),
+      rdd.metadata
+    )
+
+    PythonTranslator.toPython(contextRDD.stitch.tile)
+  }
 }
 
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
@@ -6,6 +6,7 @@ import geotrellis.util._
 import geotrellis.proj4._
 import geotrellis.vector._
 import geotrellis.vector.io._
+import geotrellis.vector.io.wkt.WKT
 import geotrellis.raster._
 import geotrellis.raster.io._
 import geotrellis.raster.merge._

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -110,6 +110,7 @@ MONTHS = 'months'
 """A time unit used with ZORDER."""
 YEARS = 'years'
 
+
 """Neighborhood type: Annulus."""
 ANNULUS = 'annulus'
 
@@ -125,6 +126,9 @@ WEDGE = 'wedge'
 """Focal operation type: Sum."""
 SUM = 'Sum'
 
+"""Focal operation type: Mean."""
+MEAN = 'Mean'
+
 """Focal operation type: Aspect."""
 ASPECT = 'Aspect'
 
@@ -133,3 +137,24 @@ SLOPE = 'Slope'
 
 """Focal operation type: Standard Deviation."""
 STANDARDDEVIATION = 'StandardDeviation'
+
+OPERATIONS = [
+    SUM,
+    MIN,
+    MAX,
+    MEAN,
+    MEDIAN,
+    MODE,
+    STANDARDDEVIATION,
+    ASPECT,
+    SLOPE
+]
+
+NEIGHBORHOODS = [
+    ANNULUS,
+    NESW,
+    SQUARE,
+    WEDGE,
+    ASPECT,
+    SLOPE
+]

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -1,4 +1,5 @@
 import json
+import shapely.wkt
 
 from geopyspark.geotrellis.constants import (RESAMPLE_METHODS,
                                              OPERATIONS,
@@ -172,3 +173,9 @@ class TiledRasterRDD(object):
         tup = self.srdd.stitch()
         ser = self.geopysc.create_value_serializer(tup._2(), TILE)
         return ser.loads(tup._1())[0]
+
+    def cost_distance(self, geometries, max_distance):
+        wkts = [shapely.wkt.dumps(g) for g in geometries]
+        srdd = self.srdd.costDistance(self.geopysc.sc, wkts, max_distance)
+
+        return TiledRasterRDD(self.geopysc, self.rdd_type, srdd)

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -1,7 +1,12 @@
 import json
 
-from geopyspark.geotrellis.constants import RESAMPLE_METHODS, NEARESTNEIGHBOR, FLOAT, TILE
-
+from geopyspark.geotrellis.constants import (RESAMPLE_METHODS,
+                                             OPERATIONS,
+                                             NEIGHBORHOODS,
+                                             NEARESTNEIGHBOR,
+                                             FLOAT,
+                                             TILE
+                                            )
 
 class RasterRDD(object):
     """Holds an RDD of GeoTrellis rasters"""

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -164,3 +164,11 @@ class TiledRasterRDD(object):
         srdd = self.srdd.focal(operation, neighborhood, param_1, param_2, param_3)
 
         return TiledRasterRDD(self.geopysc, self.rdd_type, srdd)
+
+    def stitch(self):
+        assert(self.rdd_type == "SpatialKey",
+               "Only TiledRasterRDDs with a rdd_type of SpatialKey can use stitch()")
+
+        tup = self.srdd.stitch()
+        ser = self.geopysc.create_value_serializer(tup._2(), TILE)
+        return ser.loads(tup._1())[0]

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -131,5 +131,17 @@ class TiledRasterRDD(object):
 
         return [TiledRasterRDD(self.geopysc, self.rdd_type, srdd) for srdd in result]
 
-    def focal(self):
-        pass
+    def focal(self, operation, neighborhood, param_1=None, param_2=None, param_3=None):
+        assert(operation in OPERATIONS)
+        assert(neighborhood in NEIGHBORHOODS)
+
+        if param_1 is None:
+            param_1 = 0.0
+        if param_2 is None:
+            param_2 = 0.0
+        if param_3 is None:
+            param_3 = 0.0
+
+        srdd = self.srdd.focal(operation, neighborhood, param_1, param_2, param_3)
+
+        return TiledRasterRDD(self.geopysc, self.rdd_type, srdd)

--- a/geopyspark/tests/costdistance_test.py
+++ b/geopyspark/tests/costdistance_test.py
@@ -4,8 +4,8 @@ import rasterio
 import numpy as np
 
 from shapely.geometry import Point
-from geopyspark.geotrellis.tile_layer import costdistance
 from geopyspark.tests.base_test_class import BaseTestClass
+from geopyspark.geotrellis.rdd import TiledRasterRDD
 from geopyspark.geotrellis.constants import SPATIAL
 
 
@@ -37,19 +37,16 @@ class CostDistanceTest(BaseTestClass):
                     'extent': extent,
                     'tileLayout': {'tileCols': 5, 'tileRows': 5, 'layoutCols': 2, 'layoutRows': 2}}}
 
+    raster_rdd = TiledRasterRDD.from_numpy_rdd(BaseTestClass.geopysc, SPATIAL, rdd, metadata)
+
     def test_costdistance_finite(self):
         def zero_one(kv):
             k = kv[0]
             return (k['col'] == 0 and k['row'] == 1)
 
-        result = costdistance(geopysc=self.geopysc,
-                              rdd_type=SPATIAL,
-                              keyed_rdd=self.rdd,
-                              metadata=self.metadata,
-                              geometries=[Point(13, 13)],
-                              max_distance=144000.0)
+        result = self.raster_rdd.cost_distance(geometries=[Point(13, 13)], max_distance=144000.0)
 
-        tile = result.filter(zero_one).first()[1]
+        tile = result.to_numpy_rdd().filter(zero_one).first()[1]
         point_distance = tile['data'][0][1][3]
         self.assertEqual(point_distance, 0.0)
 
@@ -58,14 +55,9 @@ class CostDistanceTest(BaseTestClass):
             k = kv[0]
             return (k['col'] == 0 and k['row'] == 1)
 
-        result = costdistance(geopysc=self.geopysc,
-                              rdd_type=SPATIAL,
-                              keyed_rdd=self.rdd,
-                              metadata=self.metadata,
-                              geometries=[Point(13, 13)],
-                              max_distance=float('inf'))
+        result = self.raster_rdd.cost_distance(geometries=[Point(13, 13)], max_distance=float('inf'))
 
-        tile = result.filter(zero_one).first()[1]
+        tile = result.to_numpy_rdd().filter(zero_one).first()[1]
         point_distance = tile['data'][0][0][0]
         self.assertTrue(point_distance > 1250000)
 

--- a/geopyspark/tests/focal_test.py
+++ b/geopyspark/tests/focal_test.py
@@ -3,12 +3,9 @@ import unittest
 import rasterio
 import numpy as np
 
-from geopyspark.tests.python_test_utils import check_directory, geotiff_test_path
-from geopyspark.geotrellis.tile_layer import collect_metadata, focal
-from geopyspark.geotrellis.geotiff_rdd import geotiff_rdd
+from geopyspark.geotrellis.rdd import TiledRasterRDD
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis.constants import SPATIAL, SUM, MIN, SQUARE, ANNULUS
-
 
 
 class FocalTest(BaseTestClass):
@@ -39,27 +36,21 @@ class FocalTest(BaseTestClass):
                     'extent': extent,
                     'tileLayout': {'tileCols': 5, 'tileRows': 5, 'layoutCols': 2, 'layoutRows': 2}}}
 
-    def test_focal_sum(self):
-        result = focal(geopysc=self.geopysc,
-                       rdd_type=SPATIAL,
-                       keyed_rdd=self.rdd,
-                       metadata=self.metadata,
-                       op=SUM,
-                       neighborhood=SQUARE,
-                       param1=1.0)
+    raster_rdd = TiledRasterRDD.from_numpy_rdd(BaseTestClass.geopysc, SPATIAL, rdd, metadata)
 
-        self.assertTrue(result.first()[1]['data'][0][1][0] >= 6)
+    def test_focal_sum(self):
+        result = self.raster_rdd.focal(
+            operation=SUM,
+            neighborhood=SQUARE,
+            param_1=1.0)
+
+        self.assertTrue(result.to_numpy_rdd().first()[1]['data'][0][1][0] >= 6)
 
     def test_focal_min(self):
-        result = focal(geopysc=self.geopysc,
-                       rdd_type=SPATIAL,
-                       keyed_rdd=self.rdd,
-                       metadata=self.metadata,
-                       op=MIN,
-                       neighborhood=ANNULUS,
-                       param1=2.0, param2=1.0)
+        result = self.raster_rdd.focal(operation=MIN, neighborhood=ANNULUS, param_1=2.0, param_2=1.0)
 
-        self.assertEqual(result.first()[1]['data'][0][0][0], -1)
+        self.assertEqual(result.to_numpy_rdd().first()[1]['data'][0][0][0], -1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/geopyspark/tests/stitch_test.py
+++ b/geopyspark/tests/stitch_test.py
@@ -4,7 +4,7 @@ import rasterio
 import numpy as np
 
 from shapely.geometry import Point
-from geopyspark.geotrellis.tile_layer import stitch
+from geopyspark.geotrellis.rdd import TiledRasterRDD
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis.constants import SPATIAL
 
@@ -37,14 +37,13 @@ class StitchTest(BaseTestClass):
                     'extent': extent,
                     'tileLayout': {'tileCols': 5, 'tileRows': 5, 'layoutCols': 2, 'layoutRows': 2}}}
 
+    raster_rdd = TiledRasterRDD.from_numpy_rdd(BaseTestClass.geopysc, SPATIAL, rdd, metadata)
+
     def test_stitch(self):
+        result = self.raster_rdd.stitch()
 
-        result = stitch(geopysc=self.geopysc,
-                        rdd_type=SPATIAL,
-                        keyed_rdd=self.rdd,
-                        metadata=self.metadata)
+        self.assertTrue(result['data'].shape == (1, 10, 10))
 
-        self.assertTrue(result[0]['data'].shape == (1, 10, 10))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This Pr is based on another, open Pr #113 . This Pr refactors the `focal`, `stitch`, and `costDistance` methods to make them usable with `TiledRasterRDD[_]` and `TiledRasterRDD`.

This Pr fixes #111 