### PR TITLE
Fixed Shapely Geometries Check

### DIFF
--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -55,7 +55,7 @@ from urllib.parse import urlparse
 from geopyspark.geotrellis.rdd import TiledRasterRDD
 from geopyspark.geotrellis.constants import TILE, ZORDER, SPATIAL
 
-from shapely.geometry import Polygon
+from shapely.geometry import Polygon, Point
 from shapely.wkt import dumps
 
 
@@ -349,7 +349,7 @@ def query(geopysc,
     if time_intervals is None:
         time_intervals = []
 
-    if isinstance(intersects, Polygon):
+    if isinstance(intersects, Polygon) or isinstance(intersects, Point):
         srdd = cached.reader.query(key,
                                    layer_name,
                                    layer_zoom,

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -328,12 +328,11 @@ class TiledRasterRDD(object):
                 ``instant``.
         """
 
-        if isinstance(geometry, str):
-            pass
-        elif isinstance(geometry, Polygon):
-            geometry = dumps(geometry)
-        else:
-            raise TypeError(geometry, "Needs to be either a Polygon or a string")
+        if not isinstance(geometry, str):
+            try:
+                geometry = dumps(geometry)
+            except:
+                raise TypeError(geometry, "Needs to be either a Shapely Geometry or a string")
 
         if instant and rdd_type != SPATIAL:
             srdd = geopysc._jvm.geopyspark.geotrellis.TemporalTiledRasterRDD.rasterize(


### PR DESCRIPTION
This Pr fixes an oversight where it was assumed that all Shapely geometries had the type `Polygon`. Now, any Shapely geometry can be used.