### PR TITLE
Fixed Packaging Error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,13 @@ setup(
         'numpy>=1.8',
         'shapely>=1.6b3'
     ],
-    include_package_data=True,
-    data_files=[('jars', ['geopyspark/jars/geotrellis-backend-assembly-0.1.0.jar'])],
-    packages=['geopyspark', 'geopyspark.geotrellis', 'geopyspark.tests', 'geopyspark.jars'],
+    packages=[
+        'geopyspark',
+        'geopyspark.geotrellis',
+        'geopyspark.tests',
+        'geopyspark.tests.schema_tests',
+        'geopyspark.jars'
+    ],
     scripts=[],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
This PR fixes a packaging error where the jar file is included twice when packaging GeoPySpark.