### PR TITLE
Added flag to reclassify to allow NODATA to be remapped

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
@@ -64,13 +64,18 @@ abstract class TileRDD[K: ClassTag] {
 
   def reclassify(
     intMap: java.util.Map[Int, Int],
-    boundaryType: String
+    boundaryType: String,
+    ignoreNoData: Boolean = false
   ): TileRDD[_] = {
     val scalaMap = intMap.asScala.toMap
 
     val boundary = getBoundary(boundaryType)
     val mapStrategy = new MapStrategy(boundary, NODATA, NODATA, false)
-    val breakMap = new BreakMap(scalaMap, mapStrategy, { i: Int => isNoData(i) })
+    val breakMap = 
+      if (ignoreNoData)
+        new BreakMap(scalaMap, mapStrategy, { i: Int => false })
+      else
+        new BreakMap(scalaMap, mapStrategy, { i: Int => isNoData(i) })
 
     val reclassifiedRDD =
       rdd.map { x =>
@@ -89,13 +94,18 @@ abstract class TileRDD[K: ClassTag] {
 
   def reclassifyDouble(
     doubleMap: java.util.Map[Double, Double],
-    boundaryType: String
+    boundaryType: String,
+    ignoreNoData: Boolean = false
   ): TileRDD[_] = {
     val scalaMap = doubleMap.asScala.toMap
 
     val boundary = getBoundary(boundaryType)
     val mapStrategy = new MapStrategy(boundary, doubleNODATA, doubleNODATA, false)
-    val breakMap = new BreakMap(scalaMap, mapStrategy, { d: Double => isNoData(d) })
+    val breakMap = 
+      if (ignoreNoData)
+        new BreakMap(scalaMap, mapStrategy, { d: Double => false })
+      else
+        new BreakMap(scalaMap, mapStrategy, { d: Double => isNoData(d) })
 
     val reclassifiedRDD =
       rdd.map { x =>

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
@@ -65,17 +65,13 @@ abstract class TileRDD[K: ClassTag] {
   def reclassify(
     intMap: java.util.Map[Int, Int],
     boundaryType: String,
-    ignoreNoData: Boolean = false
+    replaceNoDataWith: Int
   ): TileRDD[_] = {
     val scalaMap = intMap.asScala.toMap
 
     val boundary = getBoundary(boundaryType)
-    val mapStrategy = new MapStrategy(boundary, NODATA, NODATA, false)
-    val breakMap = 
-      if (ignoreNoData)
-        new BreakMap(scalaMap, mapStrategy, { i: Int => false })
-      else
-        new BreakMap(scalaMap, mapStrategy, { i: Int => isNoData(i) })
+    val mapStrategy = new MapStrategy(boundary, replaceNoDataWith, NODATA, false)
+    val breakMap = new BreakMap(scalaMap, mapStrategy, { i: Int => isNoData(i) })
 
     val reclassifiedRDD =
       rdd.map { x =>
@@ -95,17 +91,13 @@ abstract class TileRDD[K: ClassTag] {
   def reclassifyDouble(
     doubleMap: java.util.Map[Double, Double],
     boundaryType: String,
-    ignoreNoData: Boolean = false
+    replaceNoDataWith: Double
   ): TileRDD[_] = {
     val scalaMap = doubleMap.asScala.toMap
 
     val boundary = getBoundary(boundaryType)
-    val mapStrategy = new MapStrategy(boundary, doubleNODATA, doubleNODATA, false)
-    val breakMap = 
-      if (ignoreNoData)
-        new BreakMap(scalaMap, mapStrategy, { d: Double => false })
-      else
-        new BreakMap(scalaMap, mapStrategy, { d: Double => isNoData(d) })
+    val mapStrategy = new MapStrategy(boundary, replaceNoDataWith, doubleNODATA, false)
+    val breakMap = new BreakMap(scalaMap, mapStrategy, { d: Double => isNoData(d) })
 
     val reclassifiedRDD =
       rdd.map { x =>

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -551,7 +551,7 @@ class TiledRasterRDD(object):
             represent NoData.
 
         Returns:
-            :class:`~geopyspark.geotrellis.rdd.RasterRDD`
+            :class:`~geopyspark.geotrellis.rdd.TiledRasterRDD`
         """
 
         srdd = _reclassify(self.srdd, value_map, data_type, boundary_strategy, replace_nodata_with)

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -15,10 +15,11 @@ from geopyspark.geotrellis.constants import (RESAMPLE_METHODS,
                                              FLOAT,
                                              TILE,
                                              SPATIAL,
-                                             LESSTHANOREQUALTO
+                                             LESSTHANOREQUALTO,
+                                             NODATAINT
                                             )
 
-def _reclassify(srdd, value_map, data_type, boundary_strategy, ignore_nodata):
+def _reclassify(srdd, value_map, data_type, boundary_strategy, replace_nodata_with):
     new_dict = {}
 
     for key, value in value_map.items():
@@ -30,9 +31,15 @@ def _reclassify(srdd, value_map, data_type, boundary_strategy, ignore_nodata):
             new_dict[key] = value
 
     if data_type is int:
-        return srdd.reclassify(new_dict, boundary_strategy, ignore_nodata)
+        if not replace_nodata_with:
+            return srdd.reclassify(new_dict, boundary_strategy, NODATAINT)
+        else:
+            return srdd.reclassify(new_dict, boundary_strategy, replace_nodata_with)
     else:
-        return srdd.reclassifyDouble(new_dict, boundary_strategy, ignore_nodata)
+        if not replace_nodata_with:
+            return srdd.reclassifyDouble(new_dict, boundary_strategy, float('nan'))
+        else:
+            return srdd.reclassifyDouble(new_dict, boundary_strategy, replace_nodata_with)
 
 
 class RasterRDD(object):
@@ -199,7 +206,7 @@ class RasterRDD(object):
         srdd = self.srdd.tileToLayout(json.dumps(layer_metadata), resample_method)
         return TiledRasterRDD(self.geopysc, self.rdd_type, srdd)
 
-    def reclassify(self, value_map, data_type, boundary_strategy=LESSTHANOREQUALTO, ignore_nodata=False):
+    def reclassify(self, value_map, data_type, boundary_strategy=LESSTHANOREQUALTO, replace_nodata_with=None):
         """Changes the cell values of a raster based on how the data is broken up.
 
         Args:
@@ -209,10 +216,10 @@ class RasterRDD(object):
                 ``float``.
             boundary_strategy (str, optional): How the cells should be classified along the breaks.
                 If unspecified, then ``LESSTHANOREQUALTO`` will be used.
-            ignore_nodata (bool, optional): When remapping values, if set to True, nodata values in
-                the cells will be treated literally as their numerical value, rather than nodata.  
-                Should be set to True if nodata values are intended to be replaced during the reclassify.
-                If unspecified, the default value is False.
+            replace_nodata_with (data_type, optional): When remapping values, nodata values must be 
+                treated separately.  If nodata values are intended to be replaced during the 
+                reclassify, this variable should be set to the intended value.  If unspecified, 
+                nodata values will be preserved.
 
         NOTE:
             NoData symbolizes a different value depending on if ``data_type`` is ``int`` or
@@ -224,7 +231,8 @@ class RasterRDD(object):
             :class:`~geopyspark.geotrellis.rdd.RasterRDD`
         """
 
-        srdd = _reclassify(self.srdd, value_map, data_type, boundary_strategy, ignore_nodata)
+        srdd = _reclassify(self.srdd, value_map, data_type, boundary_strategy, replace_nodata_with)
+
         return RasterRDD(self.geopysc, self.rdd_type, srdd)
 
 
@@ -521,7 +529,7 @@ class TiledRasterRDD(object):
 
         return TiledRasterRDD(self.geopysc, self.rdd_type, srdd)
 
-    def reclassify(self, value_map, data_type, boundary_strategy=LESSTHANOREQUALTO, ignore_nodata=False):
+    def reclassify(self, value_map, data_type, boundary_strategy=LESSTHANOREQUALTO, replace_nodata_with=None):
         """Changes the cell values of a raster based on how the data is broken up.
 
         Args:
@@ -531,10 +539,10 @@ class TiledRasterRDD(object):
                 ``float``.
             boundary_strategy (str, optional): How the cells should be classified along the breaks.
                 If unspecified, then ``LESSTHANOREQUALTO`` will be used.
-            ignore_nodata (bool, optional): When remapping values, if set to True, nodata values in
-                the cells will be treated literally as their numerical value, rather than nodata.  
-                Should be set to True if nodata values are intended to be replaced during the reclassify.
-                If unspecified, the default value is False.
+            replace_nodata_with (data_type, optional): When remapping values, nodata values must be 
+                treated separately.  If nodata values are intended to be replaced during the 
+                reclassify, this variable should be set to the intended value.  If unspecified, 
+                nodata values will be preserved.
 
         NOTE:
             NoData symbolizes a different value depending on if ``data_type`` is ``int`` or
@@ -543,11 +551,12 @@ class TiledRasterRDD(object):
             represent NoData.
 
         Returns:
-            :class:`~geopyspark.geotrellis.rdd.TiledRasterRDD`
+            :class:`~geopyspark.geotrellis.rdd.RasterRDD`
         """
 
-        srdd = _reclassify(self.srdd, value_map, data_type, boundary_strategy, ignore_nodata)
-        return TiledRasterRDD(self.geopysc, self.rdd_type, srdd)
+        srdd = _reclassify(self.srdd, value_map, data_type, boundary_strategy, replace_nodata_with)
+
+        return RasterRDD(self.geopysc, self.rdd_type, srdd)
 
     def _process_operation(self, value, operation):
         if isinstance(value, int) or isinstance(value, float):

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -556,7 +556,7 @@ class TiledRasterRDD(object):
 
         srdd = _reclassify(self.srdd, value_map, data_type, boundary_strategy, replace_nodata_with)
 
-        return RasterRDD(self.geopysc, self.rdd_type, srdd)
+        return TiledRasterRDD(self.geopysc, self.rdd_type, srdd)
 
     def _process_operation(self, value, operation):
         if isinstance(value, int) or isinstance(value, float):

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -215,9 +215,9 @@ class RasterRDD(object):
                 If unspecified, the default value is False.
 
         NOTE:
-            Symbolizing a NoData value differs depending on if the ``data_type`` is an ``int`` or a
-            ``float``. For an ``int``, the constant ``NODATAINT`` can be used which represents the
-            NoData value for ``int`` in GeoTrellis. If ``float``, then ``float('nan')`` is used to
+            NoData symbolizes a different value depending on if ``data_type`` is ``int`` or
+            ``float``. For ``int``, the constant ``NODATAINT`` can be used which represents the
+            NoData value for ``int`` in GeoTrellis. For ``float``, ``float('nan')`` is used to
             represent NoData.
 
         Returns:
@@ -537,7 +537,7 @@ class TiledRasterRDD(object):
                 If unspecified, the default value is False.
 
         NOTE:
-            NoData value symbolizes a different value depending on if ``data_type`` is ``int`` or
+            NoData symbolizes a different value depending on if ``data_type`` is ``int`` or
             ``float``. For ``int``, the constant ``NODATAINT`` can be used which represents the
             NoData value for ``int`` in GeoTrellis. For ``float``, ``float('nan')`` is used to
             represent NoData.

--- a/geopyspark/tests/reclassify_test.py
+++ b/geopyspark/tests/reclassify_test.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import math
 import numpy as np

--- a/geopyspark/tests/reclassify_test.py
+++ b/geopyspark/tests/reclassify_test.py
@@ -148,6 +148,8 @@ class ReclassifyTest(BaseTestClass):
         for x in list(result.flatten()):
             self.assertTrue(math.isnan(x))
 
+    @pytest.mark.skipif('TRAVIS' in os.environ,
+                         reason="Encoding using methods in Main causes issues on Travis")
     def test_ignore_no_data_ints(self):
         arr = np.ones((1, 16, 16), int)
         np.fill_diagonal(arr[0], NODATAINT)
@@ -162,6 +164,8 @@ class ReclassifyTest(BaseTestClass):
 
         self.assertTrue((result == np.identity(16, int)).all())
 
+    @pytest.mark.skipif('TRAVIS' in os.environ,
+                         reason="Encoding using methods in Main causes issues on Travis")
     def test_ignore_no_data_floats(self):
         arr = np.ones((1, 4, 4))
         np.fill_diagonal(arr[0], float('nan'))


### PR DESCRIPTION
There was no good way to replace nodata values in a raster.  This PR adds the `replace_nodata_with` flag to allow nodata to be dealt with by `reclassify`.

Fixes #136 

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>