### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ install: ${DIST-ASSEMBLY} ${WHEEL}
 ${DIST-ASSEMBLY}: ${BUILD-ASSEMBLY}
 	cp -f ${BUILD-ASSEMBLY} ${DIST-ASSEMBLY}
 
-${BUILD-ASSEMBLY}: $(call rwildcard, geopyspark-backend/, *.jar)
+${BUILD-ASSEMBLY}: $(call rwildcard, geopyspark-backend/, *.scala)
 	(cd geopyspark-backend && ./sbt "project geotrellis-backend" assembly)
 
-${WHEEL}: $(call rwildcard, geopyspark, *.py) setup.py
+${WHEEL}: ${DIST-ASSEMBLY} $(call rwildcard, geopyspark, *.py) setup.py
 	${PYTHON} setup.py bdist_wheel
 
 pyspark: ${DIST-ASSEMBLY}


### PR DESCRIPTION
   - The wheel should depend on the jar
   - The jar should depend on the *.scala, not *.jar

The second of those was most-likely the source of the circular dependency warning that would occasionally pop up.

Signed-off-by: James McClain <jmcclain@azavea.com>