### PR TITLE
Allow loading multiple GeoTIFFs via `get`

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/geotiff/GeoTiffRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/geotiff/GeoTiffRDD.scala
@@ -81,37 +81,6 @@ object GeoTiffRDD {
     }
   }
 
-  def get(
-    sc: SparkContext,
-    keyType: String,
-    path: String
-  ): RasterRDD[_] = {
-    val uri = new URI(path)
-
-    uri.getScheme match {
-      case S3 =>
-        getS3GeoTiffRDD(sc, keyType, uri, S3GeoTiffRDDOptions.default)
-      case _ =>
-        getHadoopGeoTiffRDD(sc, keyType, new Path(path), HadoopGeoTiffRDDOptions.default)
-    }
-  }
-
-  def get(
-    sc: SparkContext,
-    keyType: String,
-    path: String,
-    options: java.util.Map[String, Any]
-  ): RasterRDD[_] = {
-    val uri = new URI(path)
-
-    uri.getScheme match {
-      case S3 =>
-        getS3GeoTiffRDD(sc, keyType, uri, S3GeoTiffRDDOptions.setValues(options))
-      case _ =>
-        getHadoopGeoTiffRDD(sc, keyType, new Path(uri), HadoopGeoTiffRDDOptions.setValues(options))
-    }
-  }
-
   def get_many(
     sc: SparkContext,
     keyType: String,

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/geotiff/GeoTiffRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/geotiff/GeoTiffRDD.scala
@@ -3,18 +3,20 @@ package geopyspark.geotrellis.io.geotiff
 import geopyspark.geotrellis._
 
 import geotrellis.proj4._
+import geotrellis.spark.io.avro._
 import geotrellis.spark.io.hadoop._
 import geotrellis.spark.io.s3._
 import geotrellis.spark.io.s3.testkit._
 
 import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
 
 import java.net.URI
 import java.util.Map
+import scala.reflect._
 
 import org.apache.spark._
 import org.apache.hadoop.fs.Path
-
 
 object GeoTiffRDD {
   import Constants._
@@ -106,8 +108,61 @@ object GeoTiffRDD {
       case S3 =>
         getS3GeoTiffRDD(sc, keyType, uri, S3GeoTiffRDDOptions.setValues(options))
       case _ =>
-        getHadoopGeoTiffRDD(sc, keyType, new Path(path), HadoopGeoTiffRDDOptions.setValues(options))
+        getHadoopGeoTiffRDD(sc, keyType, new Path(uri), HadoopGeoTiffRDDOptions.setValues(options))
     }
+  }
+
+  def get_many(
+    sc: SparkContext,
+    keyType: String,
+    paths: java.util.List[String]
+  ): RasterRDD[_] = {
+    val uris = paths.map{ path => new URI(path) }
+
+    uris
+      .map { uri => 
+        uri.getScheme match {
+          case S3 =>
+            getS3GeoTiffRDD(sc, keyType, uri, S3GeoTiffRDDOptions.default)
+          case _ =>
+            getHadoopGeoTiffRDD(sc, keyType, new Path(uri), HadoopGeoTiffRDDOptions.default)
+        }
+      }
+      .reduce{ (r1, r2) => 
+        keyType match {
+          case PROJECTEDEXTENT =>
+            ProjectedRasterRDD(r1.asInstanceOf[ProjectedRasterRDD].rdd.union(r2.asInstanceOf[ProjectedRasterRDD].rdd))
+          case TEMPORALPROJECTEDEXTENT =>
+            TemporalRasterRDD(r1.asInstanceOf[TemporalRasterRDD].rdd.union(r2.asInstanceOf[TemporalRasterRDD].rdd))
+        }
+      }
+  }
+
+  def get_many(
+    sc: SparkContext,
+    keyType: String,
+    paths: java.util.List[String],
+    options: java.util.Map[String, Any]
+  ): RasterRDD[_] = {
+    val uris = paths.map{ path => new URI(path) }
+
+    uris
+      .map { uri => 
+        uri.getScheme match {
+          case S3 =>
+            getS3GeoTiffRDD(sc, keyType, uri, S3GeoTiffRDDOptions.setValues(options))
+          case _ =>
+            getHadoopGeoTiffRDD(sc, keyType, new Path(uri), HadoopGeoTiffRDDOptions.setValues(options))
+        }
+      }
+      .reduce{ (r1, r2) => 
+        keyType match {
+          case PROJECTEDEXTENT =>
+            ProjectedRasterRDD(r1.asInstanceOf[ProjectedRasterRDD].rdd.union(r2.asInstanceOf[ProjectedRasterRDD].rdd))
+          case TEMPORALPROJECTEDEXTENT =>
+            TemporalRasterRDD(r1.asInstanceOf[TemporalRasterRDD].rdd.union(r2.asInstanceOf[TemporalRasterRDD].rdd))
+        }
+      }
   }
 
   private def getHadoopGeoTiffRDD(

--- a/geopyspark/geotrellis/geotiff_rdd.py
+++ b/geopyspark/geotrellis/geotiff_rdd.py
@@ -79,18 +79,18 @@ def get(geopysc,
                                         uri,
                                         options)
         else:
-            srdd = geotiff_rdd.get(geopysc.sc,
-                                   key,
-                                   uri,
-                                   options)
+            srdd = geotiff_rdd.get_many(geopysc.sc,
+                                        key,
+                                        [uri],
+                                        options)
     else:
         if type(uri) == list:
             srdd = geotiff_rdd.get_many(geopysc.sc,
                                         key,
                                         uri)
         else:
-            srdd = geotiff_rdd.get(geopysc.sc,
-                                   key,
-                                   uri)
+            srdd = geotiff_rdd.get_many(geopysc.sc,
+                                        key,
+                                        [uri])
 
     return RasterRDD(geopysc, rdd_type, srdd)

--- a/geopyspark/geotrellis/geotiff_rdd.py
+++ b/geopyspark/geotrellis/geotiff_rdd.py
@@ -73,24 +73,26 @@ def get(geopysc,
         options = kwargs
 
     if options:
-        if type(uri) == list:
-            srdd = geotiff_rdd.get_many(geopysc.sc,
-                                        key,
-                                        uri,
-                                        options)
+        if isinstance(uri, list):
+            srdd = geotiff_rdd.get(geopysc.sc,
+                                   key,
+                                   uri,
+                                   options)
         else:
-            srdd = geotiff_rdd.get_many(geopysc.sc,
-                                        key,
-                                        [uri],
-                                        options)
+            srdd = geotiff_rdd.get(geopysc.sc,
+                                   key,
+                                   [uri],
+                                   options)
     else:
-        if type(uri) == list:
-            srdd = geotiff_rdd.get_many(geopysc.sc,
-                                        key,
-                                        uri)
+        if isinstance(uri, list):
+            srdd = geotiff_rdd.get(geopysc.sc,
+                                   key,
+                                   uri,
+                                   {})
         else:
-            srdd = geotiff_rdd.get_many(geopysc.sc,
-                                        key,
-                                        [uri])
+            srdd = geotiff_rdd.get(geopysc.sc,
+                                   key,
+                                   [uri],
+                                   {})
 
     return RasterRDD(geopysc, rdd_type, srdd)

--- a/geopyspark/geotrellis/geotiff_rdd.py
+++ b/geopyspark/geotrellis/geotiff_rdd.py
@@ -4,6 +4,7 @@ There is only one function found within this module at this time, geotiff_rdd.
 """
 
 from geopyspark.geotrellis.rdd import RasterRDD
+from functools import reduce
 
 def get(geopysc,
         rdd_type,
@@ -72,13 +73,24 @@ def get(geopysc,
         options = kwargs
 
     if options:
-        srdd = geotiff_rdd.get(geopysc.sc,
-                               key,
-                               uri,
-                               options)
+        if type(uri) == list:
+            srdd = geotiff_rdd.get_many(geopysc.sc,
+                                        key,
+                                        uri,
+                                        options)
+        else:
+            srdd = geotiff_rdd.get(geopysc.sc,
+                                   key,
+                                   uri,
+                                   options)
     else:
-        srdd = geotiff_rdd.get(geopysc.sc,
-                               key,
-                               uri)
+        if type(uri) == list:
+            srdd = geotiff_rdd.get_many(geopysc.sc,
+                                        key,
+                                        uri)
+        else:
+            srdd = geotiff_rdd.get(geopysc.sc,
+                                   key,
+                                   uri)
 
     return RasterRDD(geopysc, rdd_type, srdd)


### PR DESCRIPTION
This PR introduces the ability to supply a list of URIs to `geopyspark.geotrellis.geotiff_rdd.get`.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>