### PR TITLE
Improve Travis Reliability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,13 @@ docker-build: docker/archives/${ASSEMBLYNAME} docker/archives/${WHEELNAME}
 	(cd docker && make stage1)
 
 clean:
-	(cd geopyspark-backend && ./sbt "project geotrellis-backend" clean)
 	rm -f ${WHEEL} ${DIST-ASSEMBLY}
+	(cd geopyspark-backend && ./sbt "project geotrellis-backend" clean)
+	(cd docker && make clean)
 
 cleaner: clean
 	rm -f `find ./build ./geopyspark | grep "\.pyc"`
+	(cd docker && make cleaner)
 
 cleanest: cleaner
+	(cd docker && make cleanest)

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -55,6 +55,6 @@ clean:
 	rm -f $(WHL) $(JAR)
 
 cleaner: clean
-	rm -f $(GDAL-BLOB) $(PYTHON-BLOB)
+	rm -f $(GDAL-BLOB) $(PYTHON-BLOB) blobs/*
 
 cleanest: cleaner

--- a/geopyspark/geopyspark_utils.py
+++ b/geopyspark/geopyspark_utils.py
@@ -70,7 +70,15 @@ def setup_environment():
     os.environ['JARS'] = jar_string
     os.environ["PYSPARK_PYTHON"] = "python3"
     os.environ["PYSPARK_DRIVER_PYTHON"] = "python3"
-    os.environ["PYSPARK_SUBMIT_ARGS"] = "--jars {} \
+    if 'TRAVIS' in os.environ:
+        os.environ["PYSPARK_SUBMIT_ARGS"] = "--jars {} \
+            --conf spark.ui.enabled=false \
+            --conf spark.serializer=org.apache.spark.serializer.KryoSerializer \
+            --driver-memory 2G \
+            --executor-memory 2G \
+            pyspark-shell".format(jar_string)
+    else:
+        os.environ["PYSPARK_SUBMIT_ARGS"] = "--jars {} \
             --conf spark.ui.enabled=false \
             --conf spark.serializer=org.apache.spark.serializer.KryoSerializer \
             --driver-memory 8G \


### PR DESCRIPTION
Six successes and zero failures with this patch.  By contrast, [the Python 3.5 test for 50c416d696272a9ab8b7a1db747e9fc9a914ab80](https://travis-ci.org/locationtech-labs/geopyspark/builds/227613993?utm_source=github_status&utm_medium=notification) had to be run three times before passing.

Also contains changes to the `clean`, `cleaner`, and `cleanest` targets in the Makefile.