### PR TITLE
Setup Environment Will No Longer Try to Run

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,9 +19,7 @@
 #
 import os
 import sys
-from geopyspark.geopyspark_utils import setup_environment
 
-setup_environment()
 sys.path.insert(0, os.path.abspath('../geopyspark/'))
 
 


### PR DESCRIPTION
This PR makes it so that `conf` will no longer try to setup environment variables when building the docs.