### PR TITLE
to_tiled_rdd Method

### DIFF
--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -120,8 +120,8 @@ class RasterRDD(object):
         ser = self.geopysc.create_tuple_serializer(result._2(), value_type=TILE)
         return self.geopysc.create_python_rdd(result._1(), ser)
 
-    def to_tiled_raster_rdd(self, extent=None, layout=None, crs=None, tile_size=256,
-                            resample_method=NEARESTNEIGHBOR):
+    def to_tiled_rdd(self, extent=None, layout=None, crs=None, tile_size=256,
+                     resample_method=NEARESTNEIGHBOR):
         """Converts this ``RasterRDD`` to a ``TiledRasterRDD``.
 
         This method combines :meth:`~geopyspark.geotrellis.rdd.RasterRDD.collect_metadata` and

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -120,8 +120,8 @@ class RasterRDD(object):
         ser = self.geopysc.create_tuple_serializer(result._2(), value_type=TILE)
         return self.geopysc.create_python_rdd(result._1(), ser)
 
-    def to_tiled_rdd(self, extent=None, layout=None, crs=None, tile_size=256,
-                     resample_method=NEARESTNEIGHBOR):
+    def to_tiled_layer(self, extent=None, layout=None, crs=None, tile_size=256,
+                       resample_method=NEARESTNEIGHBOR):
         """Converts this ``RasterRDD`` to a ``TiledRasterRDD``.
 
         This method combines :meth:`~geopyspark.geotrellis.rdd.RasterRDD.collect_metadata` and

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -120,6 +120,32 @@ class RasterRDD(object):
         ser = self.geopysc.create_tuple_serializer(result._2(), value_type=TILE)
         return self.geopysc.create_python_rdd(result._1(), ser)
 
+    def to_tiled_raster_rdd(self, extent=None, layout=None, crs=None, tile_size=256,
+                            resample_method=NEARESTNEIGHBOR):
+        """Converts this ``RasterRDD`` to a ``TiledRasterRDD``.
+
+        This method combines :meth:`~geopyspark.geotrellis.rdd.RasterRDD.collect_metadata` and
+        :meth:`~geopyspark.geotrellis.rdd.RasterRDD.tile_to_layout` into one step.
+
+        Args:
+            extent (:ref:`extent`, optional): Specify layout extent, must also specify layout.
+            layout (:ref:`tile_layout`, optional): Specify tile layout, must also specify extent.
+            crs (str, int, optional): Ignore CRS from records and use given one instead.
+            tile_size (int, optional): Pixel dimensions of each tile, if not using layout.
+            resample_method (str, optional): The resample method to use for the reprojection.
+                This is represented by a constant. If none is specified, then ``NEARESTNEIGHBOR``
+                is used.
+
+        Note:
+            ``extent`` and ``layout`` must both be defined if they are to be used.
+
+        Returns:
+            :class:`~geopyspark.geotrellis.rdd.TiledRasterRDD`
+        """
+
+        return self.tile_to_layout(self.collect_metadata(extent, layout, crs, tile_size),
+                                   resample_method)
+
     def collect_metadata(self, extent=None, layout=None, crs=None, tile_size=256):
         """Iterate over RDD records and generates layer metadata desribing the contained rasters.
 

--- a/geopyspark/tests/geotiff_raster_rdd_test.py
+++ b/geopyspark/tests/geotiff_raster_rdd_test.py
@@ -75,6 +75,13 @@ class Multiband(GeoTiffIOTest, BaseTestClass):
         md = tiles.collect_metadata()
         self.assertTrue('+proj=merc' in md['crs'])
 
+    def test_to_tiled_raster(self):
+        md = self.result.collect_metadata()
+        tiled = self.result.tile_to_layout(md)
+        converted = self.result.to_tiled_raster_rdd()
+
+        self.assertDictEqual(tiled.layer_metadata, converted.layer_metadata)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/geopyspark/tests/geotiff_raster_rdd_test.py
+++ b/geopyspark/tests/geotiff_raster_rdd_test.py
@@ -78,7 +78,7 @@ class Multiband(GeoTiffIOTest, BaseTestClass):
     def test_to_tiled_raster(self):
         md = self.result.collect_metadata()
         tiled = self.result.tile_to_layout(md)
-        converted = self.result.to_tiled_raster_rdd()
+        converted = self.result.to_tiled_rdd()
 
         self.assertDictEqual(tiled.layer_metadata, converted.layer_metadata)
 

--- a/geopyspark/tests/geotiff_raster_rdd_test.py
+++ b/geopyspark/tests/geotiff_raster_rdd_test.py
@@ -78,7 +78,7 @@ class Multiband(GeoTiffIOTest, BaseTestClass):
     def test_to_tiled_raster(self):
         md = self.result.collect_metadata()
         tiled = self.result.tile_to_layout(md)
-        converted = self.result.to_tiled_rdd()
+        converted = self.result.to_tiled_layer()
 
         self.assertDictEqual(tiled.layer_metadata, converted.layer_metadata)
 


### PR DESCRIPTION
This PR adds the method, `to_tiled_rdd` that combined `collect_metadata` and `tile_to_layout` into one step.

This PR resolves #151 