### PR TITLE
Int Params for Focal and Cost Distace

### DIFF
--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -502,10 +502,10 @@ class TiledRasterRDD(object):
         Args:
             operation (str): The focal operation such as SUM, ASPECT, SLOPE, etc.
             neighborhood (str): The type of neighborhood to use such as ANNULUS, SQUARE, etc.
-            param_1 (int, optional): If using SLOPE, then this is the zFactor, else it is the first
-                argument of the `neighborhood`.
-            param_2 (int, optional): The second argument of the `neighborhood`.
-            param_3 (int, optional): The third argument of the `neighborhood`.
+            param_1 (int, float, optional): If using ``SLOPE``, then this is the zFactor, else it
+                is the first argument of the ``neighborhood``.
+            param_2 (int, float, optional): The second argument of the `neighborhood`.
+            param_3 (int, float, optional): The third argument of the `neighborhood`.
 
         Note:
             Any `param` that is not set will default to 0.0.
@@ -524,7 +524,8 @@ class TiledRasterRDD(object):
         if param_3 is None:
             param_3 = 0.0
 
-        srdd = self.srdd.focal(operation, neighborhood, param_1, param_2, param_3)
+        srdd = self.srdd.focal(operation, neighborhood, float(param_1), float(param_2),
+                               float(param_3))
 
         return TiledRasterRDD(self.geopysc, self.rdd_type, srdd)
 
@@ -570,14 +571,15 @@ class TiledRasterRDD(object):
 
                 Note:
                     All geometries must be in the same CRS as the TileLayer.
-            max_distance (int): The maximum ocst that a path may reach before operation.
+            max_distance (int, float): The maximum ocst that a path may reach before operation.
+                This value can be an ``int`` or ``float``.
 
         Returns:
             :class:`~geopyspark.geotrellis.rdd.TiledRasterRDD`
         """
 
         wkts = [shapely.wkt.dumps(g) for g in geometries]
-        srdd = self.srdd.costDistance(self.geopysc.sc, wkts, max_distance)
+        srdd = self.srdd.costDistance(self.geopysc.sc, wkts, float(max_distance))
 
         return TiledRasterRDD(self.geopysc, self.rdd_type, srdd)
 

--- a/geopyspark/tests/costdistance_test.py
+++ b/geopyspark/tests/costdistance_test.py
@@ -54,6 +54,17 @@ class CostDistanceTest(BaseTestClass):
         point_distance = tile['data'][0][1][3]
         self.assertEqual(point_distance, 0.0)
 
+    def test_costdistance_finite_int(self):
+        def zero_one(kv):
+            k = kv[0]
+            return (k['col'] == 0 and k['row'] == 1)
+
+        result = self.raster_rdd.cost_distance(geometries=[Point(13, 13)], max_distance=144000)
+
+        tile = result.to_numpy_rdd().filter(zero_one).first()[1]
+        point_distance = tile['data'][0][1][3]
+        self.assertEqual(point_distance, 0.0)
+
     def test_costdistance_infinite(self):
         def zero_one(kv):
             k = kv[0]

--- a/geopyspark/tests/focal_test.py
+++ b/geopyspark/tests/focal_test.py
@@ -49,8 +49,21 @@ class FocalTest(BaseTestClass):
 
         self.assertTrue(result.to_numpy_rdd().first()[1]['data'][0][1][0] >= 6)
 
+    def test_focal_sum_int(self):
+        result = self.raster_rdd.focal(
+            operation=SUM,
+            neighborhood=SQUARE,
+            param_1=1)
+
+        self.assertTrue(result.to_numpy_rdd().first()[1]['data'][0][1][0] >= 6)
+
     def test_focal_min(self):
         result = self.raster_rdd.focal(operation=MIN, neighborhood=ANNULUS, param_1=2.0, param_2=1.0)
+
+        self.assertEqual(result.to_numpy_rdd().first()[1]['data'][0][0][0], -1)
+
+    def test_focal_min_int(self):
+        result = self.raster_rdd.focal(operation=MIN, neighborhood=ANNULUS, param_1=2, param_2=1)
 
         self.assertEqual(result.to_numpy_rdd().first()[1]['data'][0][0][0], -1)
 


### PR DESCRIPTION
This PR makes it so that you can now enter in `int`s as parameters for both the `focal` and `costdistance` methods.

This PR resolves #135 