### PR TITLE
Query By Reprojected CRS

### DIFF
--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -287,6 +287,7 @@ def query(geopysc,
           layer_zoom,
           intersects,
           time_intervals=None,
+          proj_query=None,
           options=None,
           **kwargs):
 
@@ -349,19 +350,27 @@ def query(geopysc,
     if time_intervals is None:
         time_intervals = []
 
+    if proj_query is None:
+        proj_query = ""
+    if isinstance(proj_query, int):
+        proj_query = "EPSG:" + str(proj_query)
+
+
     if isinstance(intersects, Polygon) or isinstance(intersects, Point):
         srdd = cached.reader.query(key,
                                    layer_name,
                                    layer_zoom,
                                    dumps(intersects),
-                                   time_intervals)
+                                   time_intervals,
+                                   proj_query)
 
     elif isinstance(intersects, str):
         srdd = cached.reader.query(key,
                                    layer_name,
                                    layer_zoom,
                                    intersects,
-                                   time_intervals)
+                                   time_intervals,
+                                   proj_query)
     else:
         raise TypeError("Could not query intersection", intersects)
 

--- a/geopyspark/tests/catalog_test.py
+++ b/geopyspark/tests/catalog_test.py
@@ -52,5 +52,12 @@ class CatalogTest(BaseTestClass):
 
         self.assertDictEqual(queried.to_numpy_rdd().first()[0], {'col': 1450, 'row': 996})
 
+    def test_query_crs(self):
+        intersection = box(8348915.46680623, 543988.943201519, 8348915.4669, 543988.943201520)
+        queried = query(BaseTestClass.geopysc, SPATIAL, self.uri, self.layer_name, 11, intersection,
+                        proj_query=3857)
+
+        self.assertDictEqual(queried.to_numpy_rdd().first()[0], {'col': 1450, 'row': 996})
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR allows the user to change the `CRS` of the geometry that is being queried from the tile layer.

This PR resolves #134  