### PR TITLE
Convert Raster Type

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
@@ -123,8 +123,16 @@ abstract class TileRDD[K: ClassTag] {
     }
   }
 
+  def toInt: TileRDD[_] =
+    toInt(rdd.map { x => (x._1, x._2.convert(IntCellType)) })
+
+  def toDouble: TileRDD[_] =
+    toDouble(rdd.map { x => (x._1, x._2.convert(DoubleCellType)) })
+
   protected def reclassify(reclassifiedRDD: RDD[(K, MultibandTile)]): TileRDD[_]
   protected def reclassifyDouble(reclassifiedRDD: RDD[(K, MultibandTile)]): TileRDD[_]
+  protected def toInt(converted: RDD[(K, MultibandTile)]): TileRDD[_]
+  protected def toDouble(converted: RDD[(K, MultibandTile)]): TileRDD[_]
 }
 
 /**
@@ -203,6 +211,12 @@ class ProjectedRasterRDD(val rdd: RDD[(ProjectedExtent, MultibandTile)]) extends
 
   def reclassifyDouble(reclassifiedRDD: RDD[(ProjectedExtent, MultibandTile)]): RasterRDD[ProjectedExtent] =
     ProjectedRasterRDD(reclassifiedRDD)
+
+  def toInt(converted: RDD[(ProjectedExtent, MultibandTile)]): RasterRDD[ProjectedExtent] =
+    ProjectedRasterRDD(converted)
+
+  def toDouble(converted: RDD[(ProjectedExtent, MultibandTile)]): RasterRDD[ProjectedExtent] =
+    ProjectedRasterRDD(converted)
 }
 
 
@@ -245,6 +259,12 @@ class TemporalRasterRDD(val rdd: RDD[(TemporalProjectedExtent, MultibandTile)]) 
 
   def reclassifyDouble(reclassifiedRDD: RDD[(TemporalProjectedExtent, MultibandTile)]): RasterRDD[TemporalProjectedExtent] =
     TemporalRasterRDD(reclassifiedRDD)
+
+  def toInt(converted: RDD[(TemporalProjectedExtent, MultibandTile)]): RasterRDD[TemporalProjectedExtent] =
+    TemporalRasterRDD(converted)
+
+  def toDouble(converted: RDD[(TemporalProjectedExtent, MultibandTile)]): RasterRDD[TemporalProjectedExtent] =
+    TemporalRasterRDD(converted)
 }
 
 object ProjectedRasterRDD {

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
@@ -356,6 +356,12 @@ class SpatialTiledRasterRDD(
 
   def withRDD(result: RDD[(SpatialKey, MultibandTile)]): TiledRasterRDD[SpatialKey] =
     SpatialTiledRasterRDD(zoomLevel, MultibandTileLayerRDD(result, rdd.metadata))
+
+  def toInt(converted: RDD[(SpatialKey, MultibandTile)]): TiledRasterRDD[SpatialKey] =
+    SpatialTiledRasterRDD(zoomLevel, MultibandTileLayerRDD(converted, rdd.metadata))
+
+  def toDouble(converted: RDD[(SpatialKey, MultibandTile)]): TiledRasterRDD[SpatialKey] =
+    SpatialTiledRasterRDD(zoomLevel, MultibandTileLayerRDD(converted, rdd.metadata))
 }
 
 
@@ -498,6 +504,12 @@ class TemporalTiledRasterRDD(
 
   def withRDD(result: RDD[(SpaceTimeKey, MultibandTile)]): TiledRasterRDD[SpaceTimeKey] =
     TemporalTiledRasterRDD(zoomLevel, MultibandTileLayerRDD(result, rdd.metadata))
+
+  def toInt(converted: RDD[(SpaceTimeKey, MultibandTile)]): TiledRasterRDD[SpaceTimeKey] =
+    TemporalTiledRasterRDD(zoomLevel, MultibandTileLayerRDD(converted, rdd.metadata))
+
+  def toDouble(converted: RDD[(SpaceTimeKey, MultibandTile)]): TiledRasterRDD[SpaceTimeKey] =
+    TemporalTiledRasterRDD(zoomLevel, MultibandTileLayerRDD(converted, rdd.metadata))
 }
 
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
@@ -205,6 +205,9 @@ abstract class TiledRasterRDD[K: SpatialComponent: AvroRecordCodec: JsonFormat: 
         }
       })
 
+  def convertDataType(newType: String): TiledRasterRDD[_] =
+    withRDD(rdd.convert(CellType.fromName(newType)))
+
   protected def withRDD(result: RDD[(K, MultibandTile)]): TiledRasterRDD[_]
 }
 

--- a/geopyspark/avroregistry.py
+++ b/geopyspark/avroregistry.py
@@ -1,5 +1,6 @@
 """Contains the various encoding/decoding methods to bring values to/from python from scala."""
 import array
+from bitstring import BitArray
 from functools import partial
 import numpy as np
 
@@ -13,11 +14,16 @@ class AvroRegistry(object):
     def _tile_decoder(schema_dict):
         cells = schema_dict['cells']
 
-        if isinstance(cells, bytes):
-            cells = bytearray(cells)
-
         # cols and rows are opposite for GeoTrellis ArrayTiles and Numpy Arrays
-        arr = np.array(cells).reshape(schema_dict['rows'], schema_dict['cols'])
+        cols = schema_dict['rows']
+        rows = schema_dict['cols']
+
+        if isinstance(cells, bytes) and cols * rows == len(cells):
+            cells = bytearray(cells)
+        elif isinstance(cells, bytes) and cols * rows != len(cells):
+            cells = bytearray(BitArray(cells))
+
+        arr = np.array(cells).reshape(cols, rows)
 
         return arr
 

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -180,3 +180,100 @@ LESSTHANOREQUALTO = "LessThanOrEqualTo"
 
 """A classification strategy."""
 EXACT = "Exact"
+
+
+"""Representes Bit Cells."""
+BOOLRAW = "boolraw"
+
+"""Representes Byte Cells."""
+INT8RAW = "int8raw"
+
+"""Representes UByte Cells."""
+UINT8RAW = "uint8raw"
+
+"""Representes Short Cells."""
+INT16RAW = "int16raw"
+
+"""Representes UShort Cells."""
+UINT16RAW = "uint16raw"
+
+"""Representes Int Cells."""
+INT32RAW = "int32raw"
+
+"""Representes Float Cells."""
+FLOAT32RAW = "float32raw"
+
+"""Representes Double Cells."""
+FLOAT64RAW = "float64raw"
+
+"""Representes Bit Cells."""
+BOOL = "bool"
+
+"""Representes Byte Cells with constant NoData values."""
+INT8 = "int8"
+
+"""Representes UByte Cells with constant NoData values."""
+UINT8 = "uint8"
+
+"""Representes Short Cells with constant NoData values."""
+INT16 = "int16"
+
+"""Representes UShort Cells with constant NoData values."""
+UINT16 = "uint16"
+
+"""Representes Int Cells with constant NoData values."""
+INT32 = "int32"
+
+"""Representes Float Cells with constant NoData values."""
+FLOAT32 = "float32"
+
+"""Representes Double Cells with constant NoData values."""
+FLOAT64 = "float64"
+
+"""Representes Byte Cells with user defined NoData values."""
+INT8UD = "int8ud"
+
+"""Representes UByte Cells with user defined NoData values."""
+UINT8UD = "uint8ud"
+
+"""Representes Short Cells with user defined NoData values."""
+INT16UD = "int16ud"
+
+"""Representes UShort Cells with user defined NoData values."""
+UINT16UD = "uint16ud"
+
+"""Representes Int Cells with user defined NoData values."""
+INT32UD = "int32ud"
+
+"""Representes Float Cells with user defined NoData values."""
+FLOAT32UD = "float32ud"
+
+"""Representes Double Cells with user defined NoData values."""
+FLOAT64UD = "float64ud"
+
+
+CELL_TYPES = [
+    BOOLRAW,
+    INT8RAW,
+    UINT8RAW,
+    INT16RAW,
+    UINT16RAW,
+    INT32RAW,
+    FLOAT32RAW,
+    FLOAT64RAW,
+    BOOL,
+    INT8,
+    UINT8,
+    INT16,
+    UINT16,
+    INT32,
+    FLOAT32,
+    FLOAT64,
+    INT8UD,
+    UINT8UD,
+    INT16UD,
+    UINT16UD,
+    INT32UD,
+    FLOAT32UD,
+    FLOAT64UD
+]

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -151,6 +151,22 @@ class RasterRDD(object):
         return self.tile_to_layout(self.collect_metadata(extent, layout, crs, tile_size),
                                    resample_method)
 
+    def to_int(self):
+        """Converts the underlying, raster values to ``int``s.
+
+        Returns:
+            :class:`~geopyspark.geotrellis.rdd.RasterRDD`
+        """
+        return RasterRDD(self.geopysc, self.rdd_type, self.srdd.toInt())
+
+    def to_float(self):
+        """Converts the underlying, raster values to ``float``s.
+
+        Returns:
+            :class:`~geopyspark.geotrellis.rdd.RasterRDD`
+        """
+        return RasterRDD(self.geopysc, self.rdd_type, self.srdd.toDouble())
+
     def collect_metadata(self, extent=None, layout=None, crs=None, tile_size=256):
         """Iterate over RDD records and generates layer metadata desribing the contained rasters.
 
@@ -426,6 +442,22 @@ class TiledRasterRDD(object):
         result = self.srdd.toAvroRDD()
         ser = self.geopysc.create_tuple_serializer(result._2(), key_type="Projected", value_type=TILE)
         return self.geopysc.create_python_rdd(result._1(), ser)
+
+    def to_int(self):
+        """Converts the underlying, raster values to ``int``s.
+
+        Returns:
+            :class:`~geopyspark.geotrellis.rdd.TiledRasterRDD`
+        """
+        return RasterRDD(self.geopysc, self.rdd_type, self.srdd.toInt())
+
+    def to_float(self):
+        """Converts the underlying, raster values to ``float``s.
+
+        Returns:
+            :class:`~geopyspark.geotrellis.rdd.TiledRasterRDD`
+        """
+        return RasterRDD(self.geopysc, self.rdd_type, self.srdd.toDouble())
 
     def reproject(self, target_crs, extent=None, layout=None, scheme=FLOAT, tile_size=256,
                   resolution_threshold=0.1, resample_method=NEARESTNEIGHBOR):

--- a/geopyspark/tests/geotiff_raster_rdd_test.py
+++ b/geopyspark/tests/geotiff_raster_rdd_test.py
@@ -2,10 +2,12 @@ import unittest
 from os import walk, path
 import rasterio
 import pytest
+import numpy as np
 
 from geopyspark.geotrellis.constants import SPATIAL
 from geopyspark.tests.python_test_utils import geotiff_test_path
 from geopyspark.geotrellis.geotiff_rdd import get
+from geopyspark.geotrellis.rdd import RasterRDD
 from geopyspark.tests.base_test_class import BaseTestClass
 
 
@@ -81,6 +83,29 @@ class Multiband(GeoTiffIOTest, BaseTestClass):
         converted = self.result.to_tiled_layer()
 
         self.assertDictEqual(tiled.layer_metadata, converted.layer_metadata)
+
+    def test_to_int(self):
+        arr = np.array([[0.0, 0.0, 0.0],
+                        [1.0, 1.0, 1.0]], dtype=float)
+
+        epsg_code = 3857
+        extent = {'xmin': 0.0, 'ymin': 0.0, 'xmax': 10.0, 'ymax': 10.0}
+        projected_extent = {'extent': extent, 'epsg': epsg_code}
+
+        tile = {'data': arr, 'no_data_value': float('nan')}
+        rdd = BaseTestClass.geopysc.pysc.parallelize([(self.projected_extent, tile)])
+        raster_rdd = RasterRDD.from_numpy_rdd(BaseTestClass.geopysc, SPATIAL, rdd)
+
+        converted = raster_rdd.to_int()
+        arr = converted.to_numpy_rdd().first()[1]['data']
+
+        self.assertEqual(arr.dtype, np.int64)
+
+    def test_to_float(self):
+        converted = self.result.to_float()
+        arr = converted.to_numpy_rdd().first()[1]['data']
+
+        self.assertEqual(arr.dtype, np.float64)
 
 
 if __name__ == "__main__":

--- a/geopyspark/tests/geotiff_raster_rdd_test.py
+++ b/geopyspark/tests/geotiff_raster_rdd_test.py
@@ -4,7 +4,7 @@ import rasterio
 import pytest
 import numpy as np
 
-from geopyspark.geotrellis.constants import SPATIAL
+from geopyspark.geotrellis.constants import SPATIAL, INT32, BOOLRAW
 from geopyspark.tests.python_test_utils import geotiff_test_path
 from geopyspark.geotrellis.geotiff_rdd import get
 from geopyspark.geotrellis.rdd import RasterRDD
@@ -85,7 +85,7 @@ class Multiband(GeoTiffIOTest, BaseTestClass):
         self.assertDictEqual(tiled.layer_metadata, converted.layer_metadata)
 
     def test_to_int(self):
-        arr = np.array([[0.0, 0.0, 0.0],
+        arr = np.array([[0.4324323432124, 0.0, 0.0],
                         [1.0, 1.0, 1.0]], dtype=float)
 
         epsg_code = 3857
@@ -96,16 +96,16 @@ class Multiband(GeoTiffIOTest, BaseTestClass):
         rdd = BaseTestClass.geopysc.pysc.parallelize([(self.projected_extent, tile)])
         raster_rdd = RasterRDD.from_numpy_rdd(BaseTestClass.geopysc, SPATIAL, rdd)
 
-        converted = raster_rdd.to_int()
+        converted = raster_rdd.convert_data_type(INT32)
         arr = converted.to_numpy_rdd().first()[1]['data']
 
         self.assertEqual(arr.dtype, np.int64)
 
-    def test_to_float(self):
-        converted = self.result.to_float()
+    def test_to_boolraw(self):
+        converted = self.result.convert_data_type(BOOLRAW)
         arr = converted.to_numpy_rdd().first()[1]['data']
 
-        self.assertEqual(arr.dtype, np.float64)
+        self.assertEqual(arr.dtype, np.uint8)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ fastavro>=0.13.0
 shapely>=1.6b3
 rasterio>=1.0a7
 setuptools
+bitstring>=3.1.5

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ setup(
     install_requires=[
         'fastavro>=0.13.0',
         'numpy>=1.8',
-        'shapely>=1.6b3'
+        'shapely>=1.6b3',
+        'bitstring>=3.1.5'
     ],
     packages=[
         'geopyspark',


### PR DESCRIPTION
This PR gives the user the ability to convert the underlying `Raster` data type to either `int` or `float` (`Double` in Scala).

Note: It is not possible to recreate the `to_int` and `to_float` methods via `int(raster_rdd)` and `float(raster_rdd)`. This is because `def __int__(self, x)` and `def __float__(self, x)` expects an `int` and `float` to be returned, respectively.

This PR resolves #152 