### PR TITLE
Min Max Method

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
@@ -114,6 +114,15 @@ abstract class TileRDD[K: ClassTag] {
     reclassifyDouble(reclassifiedRDD)
   }
 
+  def getMinMax: (Double, Double) = {
+    val minMaxs: Array[(Double, Double)] = rdd.histogram.map{ x => x.minMaxValues.get }
+
+    minMaxs.foldLeft(minMaxs(0)) {
+      (acc, elem) =>
+        (math.min(acc._1, elem._1), math.max(acc._2, elem._2))
+    }
+  }
+
   protected def reclassify(reclassifiedRDD: RDD[(K, MultibandTile)]): TileRDD[_]
   protected def reclassifyDouble(reclassifiedRDD: RDD[(K, MultibandTile)]): TileRDD[_]
 }

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -264,6 +264,15 @@ class RasterRDD(object):
 
         return RasterRDD(self.geopysc, self.rdd_type, srdd)
 
+    def get_min_max(self):
+        """Returns the maximum and minimum values of all of the rasters in the RDD.
+
+        Returns:
+            (float, float)
+        """
+        min_max = self.srdd.getMinMax()
+        return (min_max._1(), min_max._2())
+
 
 class TiledRasterRDD(object):
     """Wraps a RDD of tiled, GeoTrellis rasters.
@@ -637,6 +646,15 @@ class TiledRasterRDD(object):
         srdd = _reclassify(self.srdd, value_map, data_type, boundary_strategy, replace_nodata_with)
 
         return TiledRasterRDD(self.geopysc, self.rdd_type, srdd)
+
+    def get_min_max(self):
+        """Returns the maximum and minimum values of all of the rasters in the RDD.
+
+        Returns:
+            (float, float)
+        """
+        min_max = self.srdd.getMinMax()
+        return (min_max._1(), min_max._2())
 
     def _process_operation(self, value, operation):
         if isinstance(value, int) or isinstance(value, float):

--- a/geopyspark/tests/min_max_test.py
+++ b/geopyspark/tests/min_max_test.py
@@ -1,0 +1,60 @@
+import os
+import sys
+import numpy as np
+import pytest
+import unittest
+
+from geopyspark.geotrellis.rdd import RasterRDD
+from geopyspark.geotrellis.constants import SPATIAL
+from geopyspark.tests.base_test_class import BaseTestClass
+
+
+class MinMaxTest(BaseTestClass):
+    epsg_code = 3857
+    extent = {'xmin': 0.0, 'ymin': 0.0, 'xmax': 10.0, 'ymax': 10.0}
+
+    projected_extent = {'extent': extent, 'epsg': epsg_code}
+
+    @pytest.fixture(autouse=True)
+    def tearDown(self):
+        yield
+        BaseTestClass.geopysc.pysc._gateway.close()
+
+    def test_all_zeros(self):
+        arr = np.zeros((1, 16, 16))
+        tile = {'data': arr, 'no_data_value': -500}
+
+        rdd = BaseTestClass.geopysc.pysc.parallelize([(self.projected_extent, tile)])
+        raster_rdd = RasterRDD.from_numpy_rdd(BaseTestClass.geopysc, SPATIAL, rdd)
+        min_max = raster_rdd.get_min_max()
+
+        self.assertEqual((0.0, 0.0), min_max)
+
+    def test_multibands(self):
+        arr = np.array([[[1, 1, 1, 1]],
+                        [[2, 2, 2, 2]],
+                        [[3, 3, 3, 3]],
+                        [[4, 4, 4, 4]]], dtype=int)
+        tile = {'data': arr, 'no_data_value': -500}
+
+        rdd = BaseTestClass.geopysc.pysc.parallelize([(self.projected_extent, tile)])
+        raster_rdd = RasterRDD.from_numpy_rdd(BaseTestClass.geopysc, SPATIAL, rdd)
+        min_max = raster_rdd.get_min_max()
+
+        self.assertEqual((1.0, 4.0), min_max)
+
+    def test_floating(self):
+        arr = np.array([[[0.0, 0.0, 0.0, 0.0],
+                         [1.0, 1.0, 1.0, 1.0],
+                         [1.5, 1.5, 1.5, 1.5],
+                         [2.0, 2.0, 2.0, 2.0]]], dtype=float)
+
+        tile = {'data': arr, 'no_data_value': float('nan')}
+        rdd = BaseTestClass.geopysc.pysc.parallelize([(self.projected_extent, tile)])
+        raster_rdd = RasterRDD.from_numpy_rdd(BaseTestClass.geopysc, SPATIAL, rdd)
+        min_max = raster_rdd.get_min_max()
+
+        self.assertEqual((0.0, 2.0), min_max)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds the `get_min_max()` method to `RasterRDD` and `TiledRasterRDD` which returns the min and max value of all of the rasters within the `RDD` as `(float, float)`.