### PR TITLE
Documentation Update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,28 @@ Make Targets
  - **wheel** - build python ``GeoPySpark`` wheel for distribution
  - **pyspark** - start pyspark shell with project jars
  - **docker-build** - build docker image for Jupyter with ``GeoPySpark``
+ - **clean** - remove the wheel, the backend jar file, and clean the
+   ``geotrellis-backend`` directory
+ - **cleaner** - the same as **clean**, but also erase all ``.pyc``
+   files and delete binary artifacts in the ``docker`` directory
+
+Docker Container
+^^^^^^^^^^^^^^^^
+
+To build the docker container, type the following in a terminal:
+
+.. code:: console
+
+   make docker-build
+
+If you encounter problems, typing ``make cleaner`` before typing
+``make docker-build`` could help.
+
+To run the container, type:
+
+.. code:: console
+
+   docker run -it --rm -p 8000:8000 quay.io/geodocker/jupyter-geopyspark:3
 
 Contributing
 ------------


### PR DESCRIPTION
~~Starting tile servers on random ports allows multiple tile servers (and therefore multiple layers) to exist.~~

~~### Problems ###~~
   - ~~Ideally there would only be one tile server (for all of the layers) but I do not know how to accomplish that.~~
   - ~~The servers should probably assign their own port numbers rather than having them assigned (since the port could be bound already).~~
    - ~~Tile servers will just keep piling up and piling up because I do not know how to stop them.~~

~~The reason that this is not marked "work in progress" -- even with the above problems -- is because this patch allows multiple GeoTrellis layers on screen at once so that people who need that capability for developing notebooks will have it.~~

~~@jpolchlo ~~

~~See jamesmcclain/geonotebook#4~~

Documentation update