### PR TITLE
zoomLevel Kept When Using Mask

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
@@ -314,7 +314,7 @@ class SpatialTiledRasterRDD(
       result.map({ case (k, v) => (k, MultibandTile(v)) }),
       result.metadata
     )
-    SpatialTiledRasterRDD(None, multiBand)
+    SpatialTiledRasterRDD(zoomLevel, multiBand)
   }
 
   def stitch: (Array[Byte], String) = {
@@ -377,7 +377,7 @@ class TemporalTiledRasterRDD(
       result.map({ case (k, v) => (k, MultibandTile(v)) }),
       result.metadata
     )
-    TemporalTiledRasterRDD(None, multiBand)
+    TemporalTiledRasterRDD(zoomLevel, multiBand)
   }
 
   def reproject(


### PR DESCRIPTION
This PR makes it so that when calling `mask`, the resulting instance will retain the `zoomLevel` of the instance that was used to create it.

This PR resolves #193 