### PR TITLE
query Will Now Except MultiPolygons

### DIFF
--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -55,7 +55,7 @@ from urllib.parse import urlparse
 from geopyspark.geotrellis.rdd import TiledRasterRDD
 from geopyspark.geotrellis.constants import TILE, ZORDER, SPATIAL
 
-from shapely.geometry import Polygon, Point
+from shapely.geometry import Polygon, MultiPolygon, Point
 from shapely.wkt import dumps
 
 
@@ -355,8 +355,8 @@ def query(geopysc,
     if isinstance(proj_query, int):
         proj_query = "EPSG:" + str(proj_query)
 
-
-    if isinstance(intersects, Polygon) or isinstance(intersects, Point):
+    if isinstance(intersects, Polygon) or isinstance(intersects, MultiPolygon) \
+       or isinstance(intersects, Point):
         srdd = cached.reader.query(key,
                                    layer_name,
                                    layer_zoom,


### PR DESCRIPTION
The docstring of `query` says that it can except a `MultiPolygon` as an input, However, because the type `MultiPolygon` was never checked, an error would be thrown if someone tried to use it. This PR fixes this issue.

This PR resolves #195 