### PR TITLE
Mask Can Now Take Either a List or Just a Single Item

### DIFF
--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -665,6 +665,9 @@ class TiledRasterRDD(object):
         Returns:
             :class:`~geopyspark.geotrellis.rdd.TiledRasterRDD`
         """
+
+        if not isinstance(geometries, list):
+            geometries = [geometries]
         wkts = [shapely.wkt.dumps(g) for g in geometries]
         srdd = self.srdd.mask(wkts)
 

--- a/geopyspark/tests/mask_test.py
+++ b/geopyspark/tests/mask_test.py
@@ -38,7 +38,7 @@ class MaskTest(BaseTestClass):
                     'extent': extent,
                     'tileLayout': layout}}
 
-    geometries = [Polygon([(17, 17), (42, 17), (42, 42), (17, 42)])]
+    geometries = Polygon([(17, 17), (42, 17), (42, 42), (17, 42)])
     raster_rdd = TiledRasterRDD.from_numpy_rdd(BaseTestClass.geopysc, SPATIAL, rdd, metadata)
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
This PR makes it so that `mask` can now take a single `Polygon` in addition to a `[Polygon]`.

This PR resolves #198 