### PR TITLE
Add numPartitions argument to query and read

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerReaderFactory.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerReaderFactory.scala
@@ -37,7 +37,9 @@ abstract class LayerReaderWrapper {
   def read(
     keyType: String,
     layerName: String,
-    zoom: Int): TiledRasterRDD[_]
+    zoom: Int,
+    numPartitions: Int
+  ): TiledRasterRDD[_]
 
   def query(
     keyType: String,
@@ -45,7 +47,8 @@ abstract class LayerReaderWrapper {
     zoom: Int,
     queryGeometryString: String,
     queryIntervalStrings: ArrayList[String],
-    projQuery: String
+    projQuery: String,
+    numPartitions: Int
   ): TiledRasterRDD[_]
 }
 
@@ -69,26 +72,27 @@ abstract class FilteringLayerReaderWrapper()
   def read(
     keyType: String,
     layerName: String,
-    zoom: Int
+    zoom: Int,
+    numPartitions: Int
   ): TiledRasterRDD[_] = {
     val id = LayerId(layerName, zoom)
     val valueClass = getValueClass(id)
 
     (keyType, valueClass) match {
       case ("SpatialKey", "geotrellis.raster.Tile") => {
-        val result = layerReader.read[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](id)
+        val result = layerReader.read[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](id, numPartitions)
         new SpatialTiledRasterRDD(Some(zoom), MultibandTileLayerRDD(tileToMultiband[SpatialKey](result), result.metadata))
       }
       case ("SpatialKey", "geotrellis.raster.MultibandTile") => {
-        val result = layerReader.read[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]](id)
+        val result = layerReader.read[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]](id, numPartitions)
         new SpatialTiledRasterRDD(Some(zoom), MultibandTileLayerRDD(result, result.metadata))
       }
       case ("SpaceTimeKey", "geotrellis.raster.Tile") => {
-        val result = layerReader.read[SpaceTimeKey, Tile, TileLayerMetadata[SpaceTimeKey]](id)
+        val result = layerReader.read[SpaceTimeKey, Tile, TileLayerMetadata[SpaceTimeKey]](id, numPartitions)
         new TemporalTiledRasterRDD(Some(zoom), MultibandTileLayerRDD(tileToMultiband[SpaceTimeKey](result), result.metadata))
       }
       case ("SpaceTimeKey", "geotrellis.raster.MultibandTile") => {
-        val result = layerReader.read[SpaceTimeKey, MultibandTile, TileLayerMetadata[SpaceTimeKey]](id)
+        val result = layerReader.read[SpaceTimeKey, MultibandTile, TileLayerMetadata[SpaceTimeKey]](id, numPartitions)
         new TemporalTiledRasterRDD(Some(zoom), MultibandTileLayerRDD(result, result.metadata))
       }
     }
@@ -136,7 +140,8 @@ abstract class FilteringLayerReaderWrapper()
     zoom: Int,
     queryGeometryString: String,
     queryIntervalStrings: ArrayList[String],
-    projQuery: String
+    projQuery: String,
+    numPartitions: Int
   ): TiledRasterRDD[_] = {
     val id = LayerId(layerName, zoom)
     val valueClass = getValueClass(id)
@@ -145,7 +150,7 @@ abstract class FilteringLayerReaderWrapper()
 
     (keyType, valueClass) match {
       case ("SpatialKey", "geotrellis.raster.Tile") => {
-        val layer = layerReader.query[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](id)
+        val layer = layerReader.query[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](id, numPartitions)
         val layerCRS = layer.result.metadata.crs
         val query = (queryCRS, spatialQuery) match {
           case (Some(crs), Some(point: Point)) => layer.where(Contains(point.reproject(layerCRS, crs)))
@@ -167,7 +172,7 @@ abstract class FilteringLayerReaderWrapper()
       }
 
       case ("SpatialKey", "geotrellis.raster.MultibandTile") => {
-        val layer = layerReader.query[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]](id)
+        val layer = layerReader.query[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]](id, numPartitions)
         val layerCRS = layer.result.metadata.crs
         val query = (queryCRS, spatialQuery) match {
           case (Some(crs), Some(polygon: Polygon)) => layer.where(Intersects(polygon.reproject(layerCRS, crs)))
@@ -185,7 +190,7 @@ abstract class FilteringLayerReaderWrapper()
       case ("SpaceTimeKey", "geotrellis.raster.Tile") => {
         val temporalQuery = getTemporalQuery(queryIntervalStrings)
 
-        val layer = layerReader.query[SpaceTimeKey, Tile, TileLayerMetadata[SpaceTimeKey]](id)
+        val layer = layerReader.query[SpaceTimeKey, Tile, TileLayerMetadata[SpaceTimeKey]](id, numPartitions)
         val layerCRS = layer.result.metadata.crs
         val query1 = (queryCRS, spatialQuery) match {
           case (Some(crs), Some(polygon: Polygon)) => layer.where(Intersects(polygon.reproject(layerCRS, crs)))
@@ -209,7 +214,7 @@ abstract class FilteringLayerReaderWrapper()
       case ("SpaceTimeKey", "geotrellis.raster.MultibandTile") => {
         val temporalQuery = getTemporalQuery(queryIntervalStrings)
 
-        val layer = layerReader.query[SpaceTimeKey, MultibandTile, TileLayerMetadata[SpaceTimeKey]](id)
+        val layer = layerReader.query[SpaceTimeKey, MultibandTile, TileLayerMetadata[SpaceTimeKey]](id, numPartitions)
         val layerCRS = layer.result.metadata.crs
         val query1 = (queryCRS, spatialQuery) match {
           case (Some(crs), Some(polygon: Polygon)) => layer.where(Intersects(polygon.reproject(layerCRS, crs)))

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -167,6 +167,7 @@ def read(geopysc,
          layer_name,
          layer_zoom,
          options=None,
+         numPartitions=None,
          **kwargs):
 
     """Reads a single, zoom layer from a GeoTrellis catalog.
@@ -208,7 +209,11 @@ def read(geopysc,
     cached = _mapped_cached[uri]
 
     key = geopysc.map_key_input(rdd_type, True)
-    srdd = cached.reader.read(key, layer_name, layer_zoom)
+
+    if numPartitions is None:
+        numPartitions  = geopysc.pysc.defaultMinPartitions
+
+    srdd = cached.reader.read(key, layer_name, layer_zoom, numPartitions)
 
     return TiledRasterRDD(geopysc, rdd_type, srdd)
 
@@ -289,6 +294,7 @@ def query(geopysc,
           time_intervals=None,
           proj_query=None,
           options=None,
+          numPartitions=None,
           **kwargs):
 
     """Queries a single, zoom layer from a GeoTrellis catalog given spatial and/or time parameters.
@@ -355,6 +361,9 @@ def query(geopysc,
     if isinstance(proj_query, int):
         proj_query = "EPSG:" + str(proj_query)
 
+    if numPartitions is None:
+        numPartitions  = geopysc.pysc.defaultMinPartitions
+
     if isinstance(intersects, Polygon) or isinstance(intersects, MultiPolygon) \
        or isinstance(intersects, Point):
         srdd = cached.reader.query(key,
@@ -362,7 +371,8 @@ def query(geopysc,
                                    layer_zoom,
                                    dumps(intersects),
                                    time_intervals,
-                                   proj_query)
+                                   proj_query,
+                                   numPartitions)
 
     elif isinstance(intersects, str):
         srdd = cached.reader.query(key,

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -190,6 +190,7 @@ def read(geopysc,
         options (dict, optional): Additional parameters for reading the layer for specific backends.
             The dictionary is only used for Cassandra and HBase, no other backend requires this
             to be set.
+        numPartitions (int, optional): Sets RDD partition count when reading from catalog.
         **kwargs: The optional parameters can also be set as keywords arguments. The keywords must
             be in camel case. If both options and keywords are set, then the options will be used.
 
@@ -333,6 +334,7 @@ def query(geopysc,
         options (dict, optional): Additional parameters for querying the tile for specific backends.
             The dictioanry is only used for Cassandra and HBase, no other backend requires this
             to be set.
+        numPartitions (int, optional): Sets RDD partition count when reading from catalog.
         **kwargs: The optional parameters can also be set as keywords arguements. The keywords must
             be in camel case. If both options and keywords are set, then the options will be used.
 

--- a/geopyspark/tests/catalog_test.py
+++ b/geopyspark/tests/catalog_test.py
@@ -52,6 +52,11 @@ class CatalogTest(BaseTestClass):
 
         self.assertDictEqual(queried.to_numpy_rdd().first()[0], {'col': 1450, 'row': 996})
 
+    def test_query_partitions(self):
+        intersection = box(8348915.46680623, 543988.943201519, 8348915.4669, 543988.943201520)
+        queried = query(BaseTestClass.geopysc, SPATIAL, self.uri, self.layer_name, 11, intersection, numPartitions = 2)
+        self.assertDictEqual(queried.to_numpy_rdd().first()[0], {'col': 1450, 'row': 996})
+
     def test_query_crs(self):
         intersection = box(8348915.46680623, 543988.943201519, 8348915.4669, 543988.943201520)
         queried = query(BaseTestClass.geopysc, SPATIAL, self.uri, self.layer_name, 11, intersection,


### PR DESCRIPTION
The default behavior of using `defaultParallism` is often undesirable.