### PR TITLE
Read Metadata from GeoTrellis Layer

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerReaderFactory.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerReaderFactory.scala
@@ -50,12 +50,6 @@ abstract class LayerReaderWrapper {
     projQuery: String,
     numPartitions: Int
   ): TiledRasterRDD[_]
-
-  def readMetadata(
-    keyType: String,
-    layerName: String,
-    zoom: Int
-  ): String
 }
 
 
@@ -74,21 +68,6 @@ abstract class FilteringLayerReaderWrapper()
 
   def tileToMultiband[K](rdd: RDD[(K, Tile)]): RDD[(K, MultibandTile)] =
     rdd.map{ x => (x._1, MultibandTile(x._2)) }
-
-  def readMetadata(
-    keyType: String,
-    layerName: String,
-    zoom: Int
-  ): String = {
-    val id = LayerId(layerName, zoom)
-
-    keyType match {
-      case "SpatialKey" =>
-        attributeStore.readMetadata[TileLayerMetadata[SpatialKey]](id).toJson.compactPrint
-      case "SpaceTimeKey" =>
-        attributeStore.readMetadata[TileLayerMetadata[SpaceTimeKey]](id).toJson.compactPrint
-    }
-  }
 
   def read(
     keyType: String,

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerReaderFactory.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerReaderFactory.scala
@@ -50,6 +50,12 @@ abstract class LayerReaderWrapper {
     projQuery: String,
     numPartitions: Int
   ): TiledRasterRDD[_]
+
+  def readMetadata(
+    keyType: String,
+    layerName: String,
+    zoom: Int
+  ): String
 }
 
 
@@ -68,6 +74,21 @@ abstract class FilteringLayerReaderWrapper()
 
   def tileToMultiband[K](rdd: RDD[(K, Tile)]): RDD[(K, MultibandTile)] =
     rdd.map{ x => (x._1, MultibandTile(x._2)) }
+
+  def readMetadata(
+    keyType: String,
+    layerName: String,
+    zoom: Int
+  ): String = {
+    val id = LayerId(layerName, zoom)
+
+    keyType match {
+      case "SpatialKey" =>
+        attributeStore.readMetadata[TileLayerMetadata[SpatialKey]](id).toJson.compactPrint
+      case "SpaceTimeKey" =>
+        attributeStore.readMetadata[TileLayerMetadata[SpaceTimeKey]](id).toJson.compactPrint
+    }
+  }
 
   def read(
     keyType: String,

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -162,13 +162,13 @@ def _construct_catalog(geopysc, new_uri, options):
                                           value_reader=value_reader,
                                           writer=writer)
 
-def read_metadata(geopysc,
-                  rdd_type,
-                  uri,
-                  layer_name,
-                  layer_zoom,
-                  options=None,
-                  **kwargs):
+def read_layer_metadata(geopysc,
+                        rdd_type,
+                        uri,
+                        layer_name,
+                        layer_zoom,
+                        options=None,
+                        **kwargs):
     """Reads the metadata from a saved layer without reading in the whole layer.
 
     Args:

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -200,9 +200,10 @@ def read_metadata(geopysc,
     _construct_catalog(geopysc, uri, options)
     cached = _mapped_cached[uri]
 
-    key = geopysc.map_key_input(rdd_type, True)
-
-    metadata = cached.reader.readMetadata(key, layer_name, layer_zoom)
+    if rdd_type == SPATIAL:
+        metadata = cached.store.metadataSpatial(layer_name, layer_zoom)
+    else:
+        metadata = cached.store.metadataSpaceTime(layer_name, layer_zoom)
 
     return json.loads(metadata)
 

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -169,6 +169,26 @@ def read_metadata(geopysc,
                   layer_zoom,
                   options=None,
                   **kwargs):
+    """Reads the metadata from a saved layer without reading in the whole layer.
+
+    Args:
+        geopysc (GeoPyContext): The GeoPyContext being used this session.
+        rdd_type (str): What the spatial type of the geotiffs are. This is
+            represented by the constants: ``SPATIAL`` and ``SPACETIME``.
+        uri (str): The Uniform Resource Identifier used to point towards the desired GeoTrellis
+            catalog to be read from. The shape of this string varies depending on backend.
+        layer_name (str): The name of the GeoTrellis catalog to be read from.
+        layer_zoom (int): The zoom level of the layer that is to be read.
+        options (dict, optional): Additional parameters for reading the layer for specific backends.
+            The dictionary is only used for Cassandra and HBase, no other backend requires this
+            to be set.
+        numPartitions (int, optional): Sets RDD partition count when reading from catalog.
+        **kwargs: The optional parameters can also be set as keywords arguments. The keywords must
+            be in camel case. If both options and keywords are set, then the options will be used.
+
+    Returns:
+        :ref:`metadata`
+    """
 
     if options:
         options = options

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -49,6 +49,7 @@ Fields that can be set for ``HBase``:
  - **master** (str, optional): If not specified, then 'null' will be used.
 """
 
+import json
 from collections import namedtuple
 from urllib.parse import urlparse
 
@@ -160,6 +161,30 @@ def _construct_catalog(geopysc, new_uri, options):
                                           reader=reader,
                                           value_reader=value_reader,
                                           writer=writer)
+
+def read_metadata(geopysc,
+                  rdd_type,
+                  uri,
+                  layer_name,
+                  layer_zoom,
+                  options=None,
+                  **kwargs):
+
+    if options:
+        options = options
+    elif kwargs:
+        options = kwargs
+    else:
+        options = {}
+
+    _construct_catalog(geopysc, uri, options)
+    cached = _mapped_cached[uri]
+
+    key = geopysc.map_key_input(rdd_type, True)
+
+    metadata = cached.reader.readMetadata(key, layer_name, layer_zoom)
+
+    return json.loads(metadata)
 
 def read(geopysc,
          rdd_type,

--- a/geopyspark/tests/catalog_test.py
+++ b/geopyspark/tests/catalog_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from shapely.geometry import box
 
-from geopyspark.geotrellis.catalog import read, read_value, query, read_metadata
+from geopyspark.geotrellis.catalog import read, read_value, query, read_layer_metadata
 from geopyspark.geotrellis.constants import SPATIAL, ZOOM
 from geopyspark.geotrellis.geotiff_rdd import get
 from geopyspark.tests.base_test_class import BaseTestClass
@@ -68,7 +68,8 @@ class CatalogTest(BaseTestClass):
         layer = read(BaseTestClass.geopysc, SPATIAL, self.uri, self.layer_name, 5)
         actual_metadata = layer.layer_metadata
 
-        expected_metadata = read_metadata(BaseTestClass.geopysc, SPATIAL, self.uri, self.layer_name, 5)
+        expected_metadata = read_layer_metadata(BaseTestClass.geopysc, SPATIAL, self.uri,
+                                                self.layer_name, 5)
 
         self.assertDictEqual(actual_metadata, expected_metadata)
 

--- a/geopyspark/tests/catalog_test.py
+++ b/geopyspark/tests/catalog_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from shapely.geometry import box
 
-from geopyspark.geotrellis.catalog import read, read_value, query
+from geopyspark.geotrellis.catalog import read, read_value, query, read_metadata
 from geopyspark.geotrellis.constants import SPATIAL, ZOOM
 from geopyspark.geotrellis.geotiff_rdd import get
 from geopyspark.tests.base_test_class import BaseTestClass
@@ -63,6 +63,14 @@ class CatalogTest(BaseTestClass):
                         proj_query=3857)
 
         self.assertDictEqual(queried.to_numpy_rdd().first()[0], {'col': 1450, 'row': 996})
+
+    def test_read_metadata(self):
+        layer = read(BaseTestClass.geopysc, SPATIAL, self.uri, self.layer_name, 5)
+        actual_metadata = layer.layer_metadata
+
+        expected_metadata = read_metadata(BaseTestClass.geopysc, SPATIAL, self.uri, self.layer_name, 5)
+
+        self.assertDictEqual(actual_metadata, expected_metadata)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds the `read_metadata` function to `catalog`. This will allow the user to read `tileLayerMetadata` from a saved, GeoTrellis layer without having to read in the whole layer.

This PR resolves #190 