### PR TITLE
Get Layer Ids from Catalog

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerReaderFactory.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerReaderFactory.scala
@@ -63,6 +63,9 @@ abstract class FilteringLayerReaderWrapper()
   def attributeStore: AttributeStore
   def layerReader: FilteringLayerReader[LayerId]
 
+  def layerIds: Array[String] =
+    attributeStore.layerIds.map { x => x.toString }.toArray
+
   def getValueClass(id: LayerId): String =
     attributeStore.readHeader[LayerHeader](id).valueClass
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerReaderFactory.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerReaderFactory.scala
@@ -63,8 +63,8 @@ abstract class FilteringLayerReaderWrapper()
   def attributeStore: AttributeStore
   def layerReader: FilteringLayerReader[LayerId]
 
-  def layerIds: Array[String] =
-    attributeStore.layerIds.map { x => x.toString }.toArray
+  def layerIds: Array[java.util.Map[String, Any]] =
+    attributeStore.layerIds.map { x => Map("name" -> x.name, "zoom" -> x.zoom).asJava }.toArray
 
   def getValueClass(id: LayerId): String =
     attributeStore.readHeader[LayerHeader](id).valueClass

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -207,6 +207,23 @@ def read_layer_metadata(geopysc,
 
     return json.loads(metadata)
 
+def get_layer_ids(geopysc,
+                  uri,
+                  options=None,
+                  **kwargs):
+
+    if options:
+        options = options
+    elif kwargs:
+        options = kwargs
+    else:
+        options = {}
+
+    _construct_catalog(geopysc, uri, options)
+    cached = _mapped_cached[uri]
+
+    return cached.reader.layerIds()
+
 def read(geopysc,
          rdd_type,
          uri,

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -211,7 +211,8 @@ def get_layer_ids(geopysc,
                   uri,
                   options=None,
                   **kwargs):
-    """Returns a list of all of the layer ids in the selected catalog as strings.
+    """Returns a list of all of the layer ids in the selected catalog as dicts that contain the
+    name and zoom of a given layer.
 
     Args:
         geopysc (GeoPyContext): The GeoPyContext being used this session.
@@ -224,7 +225,11 @@ def get_layer_ids(geopysc,
             be in camel case. If both options and keywords are set, then the options will be used.
 
     Returns:
-        ["Layer(name = <name_of_layer>, zoom = <zoom_level}"]
+        [layerIds]
+
+        Where ``layerIds`` is a ``dict`` with the following fields:
+            - **name** (str): The name of the layer
+            - **zoom** (int): The zoom level of the given layer.
     """
 
     if options:

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -211,6 +211,21 @@ def get_layer_ids(geopysc,
                   uri,
                   options=None,
                   **kwargs):
+    """Returns a list of all of the layer ids in the selected catalog as strings.
+
+    Args:
+        geopysc (GeoPyContext): The GeoPyContext being used this session.
+        uri (str): The Uniform Resource Identifier used to point towards the desired GeoTrellis
+            catalog to be read from. The shape of this string varies depending on backend.
+        options (dict, optional): Additional parameters for reading the layer for specific backends.
+            The dictionary is only used for Cassandra and HBase, no other backend requires this
+            to be set.
+        **kwargs: The optional parameters can also be set as keywords arguments. The keywords must
+            be in camel case. If both options and keywords are set, then the options will be used.
+
+    Returns:
+        ["Layer(name = <name_of_layer>, zoom = <zoom_level}"]
+    """
 
     if options:
         options = options

--- a/geopyspark/tests/catalog_test.py
+++ b/geopyspark/tests/catalog_test.py
@@ -4,11 +4,7 @@ import pytest
 
 from shapely.geometry import box
 
-<<<<<<< ace3e106adedcd3ab3c7fb216410bf05f4eaa6a0
-from geopyspark.geotrellis.catalog import read, read_value, query, read_layer_metadata
-=======
-from geopyspark.geotrellis.catalog import read, read_value, query, get_layer_ids
->>>>>>> Added get_layer_ids test.
+from geopyspark.geotrellis.catalog import read, read_value, query, read_layer_metadata, get_layer_ids
 from geopyspark.geotrellis.constants import SPATIAL, ZOOM
 from geopyspark.geotrellis.geotiff_rdd import get
 from geopyspark.tests.base_test_class import BaseTestClass

--- a/geopyspark/tests/catalog_test.py
+++ b/geopyspark/tests/catalog_test.py
@@ -4,7 +4,11 @@ import pytest
 
 from shapely.geometry import box
 
+<<<<<<< ace3e106adedcd3ab3c7fb216410bf05f4eaa6a0
 from geopyspark.geotrellis.catalog import read, read_value, query, read_layer_metadata
+=======
+from geopyspark.geotrellis.catalog import read, read_value, query, get_layer_ids
+>>>>>>> Added get_layer_ids test.
 from geopyspark.geotrellis.constants import SPATIAL, ZOOM
 from geopyspark.geotrellis.geotiff_rdd import get
 from geopyspark.tests.base_test_class import BaseTestClass
@@ -72,6 +76,12 @@ class CatalogTest(BaseTestClass):
                                                 self.layer_name, 5)
 
         self.assertDictEqual(actual_metadata, expected_metadata)
+
+    def test_layer_ids(self):
+        ids = get_layer_ids(BaseTestClass.geopysc, self.uri)
+
+        self.assertTrue(len(ids) == 11)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR allows the user to get a list of all the `LayerId`s of a GeoTrellis catalog as strings. 