### PR TITLE
get_layer_ids Now Returns a List

### DIFF
--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -265,7 +265,7 @@ def get_layer_ids(geopysc,
     _construct_catalog(geopysc, uri, options)
     cached = _mapped_cached[uri]
 
-    return cached.reader.layerIds()
+    return list(cached.reader.layerIds())
 
 def read(geopysc,
          rdd_type,


### PR DESCRIPTION
This PR fixes an issue with `get_layer_ids` where it will not return a `list` instead of a `JavaObject`.