### PR TITLE
Fixed Importing Error

### DIFF
--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -5,6 +5,8 @@ performing operations.
 '''
 import json
 import shapely.wkt
+from geopyspark.geopyspark_utils import check_environment
+check_environment()
 
 from pyspark.storagelevel import StorageLevel
 from shapely.geometry import Polygon, MultiPolygon


### PR DESCRIPTION
This PR fixes a bug that occurs when you try to import something that relies on, or is `rdd.py` before importing other modules. This is due to a recent addition to `rdd,py` https://github.com/locationtech-labs/geopyspark/blob/master/geopyspark/geotrellis/rdd.py#L9  Because the GeoPySpark environment was not setup before the import, `pyspark` is not a known module. This can be fixed by adding a check to see if the environment has been created before importing like https://github.com/locationtech-labs/geopyspark/blob/master/geopyspark/geopycontext.py#L5