### PR TITLE
Add better histogram handling and rdd persistence to PngRDD

### DIFF
--- a/docker/notebooks/Park citing.ipynb
+++ b/docker/notebooks/Park citing.ipynb
@@ -62,7 +62,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "with fiona.open(\"/tmp/bart.geojson\") as source:\n",
@@ -88,7 +90,29 @@
    "source": [
     "bart_layer = TiledRasterRDD.euclidean_distance(geopysc, bart, bart_crs, 12)\n",
     "schools_layer = TiledRasterRDD.euclidean_distance(geopysc, schools, schools_crs, 12)\n",
-    "parks_layer = TiledRasterRDD.euclidean_distance(geopysc, parks, parks_crs, 12).cache()"
+    "parks_layer = TiledRasterRDD.euclidean_distance(geopysc, parks, parks_crs, 12)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from pyspark.storagelevel import StorageLevel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bart_layer.persist(StorageLevel.MEMORY_AND_DISK)\n",
+    "schools_layer.persist(StorageLevel.MEMORY_AND_DISK)\n",
+    "parks_layer.persist(StorageLevel.MEMORY_AND_DISK)"
    ]
   },
   {
@@ -105,12 +129,41 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weighted_layer.persist(StorageLevel.MEMORY_AND_DISK)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "png_layer = PngRDD.makePyramid(weighted_layer, \"viridis\", end_zoom=8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "png_layer.cache()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "M.add_layer(RddRasterData(PngRDD.makePyramid(weighted_layer, \"viridis\", end_zoom=8), name=\"Weighted\"))\n",
+    "M.add_layer(RddRasterData(png_layer, name=\"Weighted\"))\n",
     "M.add_layer(VectorData(\"/tmp/bart.geojson\"), name=\"BART stops\")\n",
     "M.add_layer(VectorData(\"/tmp/parks.geojson\"), name=\"Parks\")"
    ]
@@ -119,6 +172,27 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "M.add_layer(VectorData(\"/tmp/bart.geojson\"), name=\"BART stops\", colors=[0xff0000])\n",
+    "M.add_layer(VectorData(\"/tmp/parks.geojson\"), name=\"Parks\", colors=[0xffff00])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "M.layers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "M.remove_layer(M.layers[2])\n",

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/PngRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/PngRDD.scala
@@ -66,18 +66,32 @@ abstract class PngRDD[K: SpatialComponent :ClassTag] {
 }
 
 object PngRDD {
-  def asSingleband(tiled: SpatialTiledRasterRDD, rampName: String): SpatialPngRDD = {
+  def asIntSingleband(tiled: SpatialTiledRasterRDD, histogram: Histogram[Int], rampName: String): SpatialPngRDD = {
     val rdd = tiled.rdd
-    val histogram = rdd.histogram().head
     val mapped = rdd.mapValues({ mbtile =>
       mbtile.band(0).renderPng(Coloring.makeColorMap(histogram, rampName))
     })
     new SpatialPngRDD(mapped.asInstanceOf[RDD[(tiled.keyType, Png)]])
   }
 
-  def asSingleband(tiled: TemporalTiledRasterRDD, rampName: String): TemporalPngRDD = {
+  def asSingleband(tiled: SpatialTiledRasterRDD, histogram: Histogram[Double], rampName: String): SpatialPngRDD = {
     val rdd = tiled.rdd
-    val histogram = rdd.histogram().head
+    val mapped = rdd.mapValues({ mbtile =>
+      mbtile.band(0).renderPng(Coloring.makeColorMap(histogram, rampName))
+    })
+    new SpatialPngRDD(mapped.asInstanceOf[RDD[(tiled.keyType, Png)]])
+  }
+
+  def asIntSingleband(tiled: TemporalTiledRasterRDD, histogram: Histogram[Int], rampName: String): TemporalPngRDD = {
+    val rdd = tiled.rdd
+    val mapped = rdd.mapValues({ mbtile =>
+      mbtile.band(0).renderPng(Coloring.makeColorMap(histogram, rampName))
+    })
+    new TemporalPngRDD(mapped.asInstanceOf[RDD[(tiled.keyType, Png)]])
+  }
+
+  def asSingleband(tiled: TemporalTiledRasterRDD, histogram: Histogram[Double], rampName: String): TemporalPngRDD = {
+    val rdd = tiled.rdd
     val mapped = rdd.mapValues({ mbtile =>
       mbtile.band(0).renderPng(Coloring.makeColorMap(histogram, rampName))
     })

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/PngRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/PngRDD.scala
@@ -65,6 +65,7 @@ object ColorRamp {
 abstract class PngRDD[K: SpatialComponent :ClassTag] {
   def rdd: RDD[(K, Png)]
   def persist(storageLevel: StorageLevel) = rdd.persist(storageLevel)
+  def unpersist() = rdd.unpersist()
 }
 
 object PngRDD {

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/PngRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/PngRDD.scala
@@ -1,6 +1,7 @@
 package geopyspark.geotrellis
 
 import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.StorageLevel
 
 import geotrellis.raster._
 import geotrellis.raster.histogram._
@@ -63,6 +64,7 @@ object ColorRamp {
 
 abstract class PngRDD[K: SpatialComponent :ClassTag] {
   def rdd: RDD[(K, Png)]
+  def persist(storageLevel: StorageLevel) = rdd.persist(storageLevel)
 }
 
 object PngRDD {

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
@@ -5,6 +5,7 @@ import geopyspark.geotrellis.GeoTrellisUtils._
 import geotrellis.proj4._
 import geotrellis.raster._
 import geotrellis.raster.distance._
+import geotrellis.raster.histogram._
 import geotrellis.raster.rasterize._
 import geotrellis.raster.render._
 import geotrellis.raster.resample.ResampleMethod
@@ -277,6 +278,12 @@ abstract class TiledRasterRDD[K: SpatialComponent: AvroRecordCodec: JsonFormat: 
       case poly: Polygon => singleTileLayerRDD.polygonalSumDouble(poly)
       case multi: MultiPolygon => singleTileLayerRDD.polygonalSumDouble(multi)
     }
+
+  def isFloatingPointLayer(): Boolean = rdd.metadata.cellType.isFloatingPoint
+
+  def getIntHistograms(): Histogram[Int] = rdd.histogramExactInt.head
+
+  def getDoubleHistograms(): Histogram[Double] = rdd.histogram.head
 
   protected def withRDD(result: RDD[(K, MultibandTile)]): TiledRasterRDD[K]
 }

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -1006,6 +1006,16 @@ class TiledRasterRDD(RDDWrapper):
         """
         return list(self.srdd.quantileBreaksExactInt(num_breaks))
 
+    def is_floating_point_layer(self):
+        return self.srdd.isFloatingPointLayer()
+
+    def get_histogram(self):
+        if self.is_floating_point_layer:
+            histogram = self.srdd.getDoubleHistograms()
+        else:
+            histogram = self.srdd.getIntHistograms()
+        return histogram
+
     def _process_operation(self, value, operation):
         if isinstance(value, int) or isinstance(value, float):
             srdd = operation(value)

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -1007,9 +1007,25 @@ class TiledRasterRDD(RDDWrapper):
         return list(self.srdd.quantileBreaksExactInt(num_breaks))
 
     def is_floating_point_layer(self):
+        """Determines whether the content of the TiledRasterRDD is of floating point type.
+
+        Args: 
+            None
+
+        Returns:
+            [boolean]
+        """
         return self.srdd.isFloatingPointLayer()
 
     def get_histogram(self):
+        """Returns an array of Java histogram objects, one for each band of the raster.
+
+        Args:
+            None
+
+        Returns:
+            An array of Java objects containing the histograms of each band
+        """
         if self.is_floating_point_layer:
             histogram = self.srdd.getDoubleHistograms()
         else:

--- a/geopyspark/geotrellis/render.py
+++ b/geopyspark/geotrellis/render.py
@@ -1,3 +1,6 @@
+from geopyspark.geopyspark_utils import check_environment
+check_environment()
+
 from geopyspark.geotrellis.constants import RESAMPLE_METHODS, NEARESTNEIGHBOR, ZOOM, COLOR_RAMPS
 from .rdd import RDDWrapper
 from pyspark.storagelevel import StorageLevel
@@ -78,10 +81,9 @@ class PngRDD(RDDWrapper):
         self.max_zoom = level0.zoom_level
         histogram = level0.get_histogram()
         if level0.is_floating_point_layer():
-            mapper = lambda layer: self.geopysc._jvm.geopyspark.geotrellis.PngRDD.asSingleband(layer.srdd, histogram, ramp_name)
+            self.pngpyramid = [self.geopysc._jvm.geopyspark.geotrellis.PngRDD.asSingleband(layer.srdd, histogram, ramp_name) for layer in pyramid]
         else:
-            mapper = lambda layer: self.geopysc._jvm.geopyspark.geotrellis.PngRDD.asIntSingleband(layer.srdd, histogram, ramp_name)
-        self.pngpyramid = list(map(mapper, pyramid))
+            self.pngpyramid = [self.geopysc._jvm.geopyspark.geotrellis.PngRDD.asIntSingleband(layer.srdd, histogram, ramp_name) for layer in pyramid]
         self.debug = debug
         self.is_cached = False
 

--- a/geopyspark/geotrellis/render.py
+++ b/geopyspark/geotrellis/render.py
@@ -159,30 +159,3 @@ class PngRDD(CachableRDD):
     def wrapped_rdds(self):
         return self.pngpyramid
 
-    # def persist(self, storageLevel=StorageLevel.MEMORY_ONLY):
-    #     """Set the persistence mode of the underlying RDD structure.
-
-    #     Args:
-    #         storage_mode (StorageLevel): The storage mode to set.
-
-    #     Returns: The current object
-    #     """
-    #     self.is_cached = True
-    #     javaStorageLevel = self.geopysc.pysc._getJavaStorageLevel(storageLevel)
-        
-    #     for level in self.pngpyramid:
-    #         level.persist(javaStorageLevel)
-
-    #     return self
-
-    # def unpersist(self):
-    #     """
-    #     Mark the RDD as non-persistent, and remove all blocks for it from
-    #     memory and disk.
-    #     """
-
-    #     self.is_cached = False
-    #     for level in self.pngpyramid:
-    #         level.unpersist()
-    #     return self
-

--- a/geopyspark/geotrellis/render.py
+++ b/geopyspark/geotrellis/render.py
@@ -163,9 +163,10 @@ class PngRDD(RDDWrapper):
         Returns: The current object
         """
         self.is_cached = True
-
+        javaStorageLevel = self.geopysc.pysc._getJavaStorageLevel(storageLevel)
+        
         for level in self.pngpyramid:
-            level.persist(storageLevel)
+            level.persist(javaStorageLevel)
 
         return self
 


### PR DESCRIPTION
PngRDD is now a subclass of RDDWrapper, and as such has persist methods.  Also adds improved histogram support to PngRDD that allows for a single histogram to be computed from the base layer and used at all pyramid levels.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>