### PR TITLE
Expand development docs section on editable installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ WHEELNAME := geopyspark-0.1.0-py3-none-any.whl
 WHEEL := dist/${WHEELNAME}
 rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
 
+export PYSPARK_SUBMIT_ARGS := --master local[*] --driver-memory 8G --jars ${PWD}/${DIST-ASSEMBLY} \
+--conf spark.serializer=org.apache.spark.serializer.KryoSerializer pyspark-shell
+
 install: ${DIST-ASSEMBLY} ${WHEEL}
 	${PYTHON} setup.py install --user --force --prefix=
 
@@ -34,6 +37,13 @@ pyspark: ${DIST-ASSEMBLY}
 	pyspark --jars ${DIST-ASSEMBLY} \
 		--conf spark.serializer=org.apache.spark.serializer.KryoSerializer \
 		--conf spark.kyro.registrator=geotrellis.spark.io.kyro.KryoRegistrator
+
+notebook: ${DIST-ASSEMBLY}
+	@echo "PYSPARK_PYTHON: $${PYSPARK_PYTHON}"
+	@echo "SPARK_HOME: $${SPARK_HOME}"
+	@echo "PYTHONPATH: $${PYTHONPATH}"
+	@echo "PYSPARK_SUBMIT_ARGS: $${PYSPARK_SUBMIT_ARGS}"
+	jupyter notebook --port 8000 --notebook-dir docker/notebooks/
 
 docker/archives/${ASSEMBLYNAME}: ${DIST-ASSEMBLY}
 	cp -f ${DIST-ASSEMBLY} docker/archives/${ASSEMBLYNAME}

--- a/README.rst
+++ b/README.rst
@@ -266,6 +266,32 @@ command:
 
 This will open up the jupyter hub and will allow you to work on your notebooks.
 
+It is also possible to develop with both GeoPySpark and GeoNotebook in editable mode.
+To do so you will need to re-install and re-register GeoNotebook with Jupyter.
+
+.. code:: console
+
+   pip uninstall geonotebook
+   git clone --branch feature/geotrellis https://github.com/geotrellis/geonotebook ~/geonotebook
+   pip install -e ~/geonotebook
+   jupyter serverextension enable --py geonotebook
+   jupyter nbextension enable --py geonotebook
+   make notebook
+
+The default `Geonotebook (Python 3)` kernel will require the following environment variables to be defined:
+
+.. code:: console
+
+   export PYSPARK_PYTHON="/usr/local/bin/python3"
+   export SPARK_HOME="/usr/local/apache-spark/2.1.1/libexec"
+   export PYTHONPATH="${SPARK_HOME}/python/lib/py4j-0.10.4-src.zip:${SPARK_HOME}/python/lib/pyspark.zip"
+
+Make sure to define them to values that are correct for your system.
+The `make notebook` command also makes used of `PYSPARK_SUBMIT_ARGS` variable defined in the `Makefile`.
+
+GeoNotebook/GeoTrellis integration in currently in active development and not part of GeoNotebook master.
+The latest development is on a `feature/geotrellis` branch at `<https://github.com/geotrellis/geonotebook>`.
+
 Side Note For Developers
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -278,7 +278,7 @@ To do so you will need to re-install and re-register GeoNotebook with Jupyter.
    jupyter nbextension enable --py geonotebook
    make notebook
 
-The default `Geonotebook (Python 3)` kernel will require the following environment variables to be defined:
+The default ``Geonotebook (Python 3)`` kernel will require the following environment variables to be defined:
 
 .. code:: console
 
@@ -287,10 +287,10 @@ The default `Geonotebook (Python 3)` kernel will require the following environme
    export PYTHONPATH="${SPARK_HOME}/python/lib/py4j-0.10.4-src.zip:${SPARK_HOME}/python/lib/pyspark.zip"
 
 Make sure to define them to values that are correct for your system.
-The `make notebook` command also makes used of `PYSPARK_SUBMIT_ARGS` variable defined in the `Makefile`.
+The ``make notebook`` command also makes used of ``PYSPARK_SUBMIT_ARGS`` variable defined in the ``Makefile``.
 
 GeoNotebook/GeoTrellis integration in currently in active development and not part of GeoNotebook master.
-The latest development is on a `feature/geotrellis` branch at `<https://github.com/geotrellis/geonotebook>`.
+The latest development is on a ``feature/geotrellis`` branch at ``<https://github.com/geotrellis/geonotebook>``.
 
 Side Note For Developers
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -273,6 +273,8 @@ To do so you will need to re-install and re-register GeoNotebook with Jupyter.
 
    pip uninstall geonotebook
    git clone --branch feature/geotrellis https://github.com/geotrellis/geonotebook ~/geonotebook
+   pip install -r ~/geonotebook/prerequirements.txt
+   pip install -r ~/geonotebook/requirements.txt
    pip install -e ~/geonotebook
    jupyter serverextension enable --py geonotebook
    jupyter nbextension enable --py geonotebook

--- a/README.rst
+++ b/README.rst
@@ -301,7 +301,7 @@ two lines of code at the top of your notebooks.
 .. code:: console
 
    %load_ext autoreload
-   $autoreload 2
+   %autoreload 2
 
 This will make it so that you don't have to leave the notebook for your changes
 to take affect. Rather, you just have to reimport the module and it will be


### PR DESCRIPTION
I've been able to verify these steps on OSX and the development process is glorious.

Combined with:

```
%load_ext autoreload
%autoreload 2
```

It is possible to make changes to GeoNotebook `ingest` methods and see effects on subsequent `M.add_layer` calls.

There doesn't seem to be a graceful way to setup all the environment variables since at this point they're highly system dependent. Getting all the requirements installed can also be a challenge.

Also note that it is important that `jupyter notebook` binds to port `8000`, as `jupyterhub` would, instead of default `8888` for the tile service routes to be discovered correctly.