### PR TITLE
Euclidean distance optimization

### DIFF
--- a/docker/notebooks/Park siting.ipynb
+++ b/docker/notebooks/Park siting.ipynb
@@ -143,6 +143,7 @@
    },
    "outputs": [],
    "source": [
+    "# The following operation takes about 90 seconds on a reasonably capable 4-core laptop\n",
     "png_layer = PngRDD.makePyramid(weighted_layer, \"viridis\", end_zoom=8)"
    ]
   },
@@ -171,17 +172,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "M.add_layer(VectorData(\"/tmp/bart.geojson\"), name=\"BART stops\", colors=[0xff0000])\n",
-    "M.add_layer(VectorData(\"/tmp/parks.geojson\"), name=\"Parks\", colors=[0xffff00])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "M.layers"

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
@@ -636,7 +636,8 @@ object SpatialTiledRasterRDD {
     SpatialTiledRasterRDD(None, MultibandTileLayerRDD(rdd.tileToLayout(metadata), metadata))
   }
 
-  def euclideanDistance(sc: SparkContext, geomWKT: String, geomCRSStr: String, cellType: CellType, requestedZoom: Int): TiledRasterRDD[SpatialKey]= {
+  def euclideanDistance(sc: SparkContext, geomWKT: String, geomCRSStr: String, cellTypeString: String, requestedZoom: Int): TiledRasterRDD[SpatialKey]= {
+    val cellType = CellType.fromName(cellTypeString)
     val geom = geotrellis.vector.io.wkt.WKT.read(geomWKT)
     val srcCRS = TileRDD.getCRS(geomCRSStr).get
     val LayoutLevel(z, ld) = ZoomedLayoutScheme(srcCRS).levelForZoom(requestedZoom)

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
@@ -636,19 +636,18 @@ object SpatialTiledRasterRDD {
     SpatialTiledRasterRDD(None, MultibandTileLayerRDD(rdd.tileToLayout(metadata), metadata))
   }
 
-  def euclideanDistance(sc: SparkContext, geomWKT: String, srcCRSStr: String, requestedZoom: Int): TiledRasterRDD[SpatialKey]= {
+  def euclideanDistance(sc: SparkContext, geomWKT: String, geomCRSStr: String, cellType: CellType, requestedZoom: Int): TiledRasterRDD[SpatialKey]= {
     val geom = geotrellis.vector.io.wkt.WKT.read(geomWKT)
-    val srcCRS = TileRDD.getCRS(srcCRSStr).get
-    val LayoutLevel(z, ld) = ZoomedLayoutScheme(WebMercator).levelForZoom(requestedZoom)
+    val srcCRS = TileRDD.getCRS(geomCRSStr).get
+    val LayoutLevel(z, ld) = ZoomedLayoutScheme(srcCRS).levelForZoom(requestedZoom)
     val maptrans = ld.mapTransform
-    val reprojected = geom.reproject(srcCRS, WebMercator)
-    val GridBounds(cmin, rmin, cmax, rmax) = maptrans(reprojected.envelope)
+    val gb @ GridBounds(cmin, rmin, cmax, rmax) = maptrans(geom.envelope)
 
     val keys = for (r <- rmin to rmax; c <- cmin to cmax) yield SpatialKey(c, r)
 
     val pts = 
-      if (reprojected.isInstanceOf[MultiPoint]) {
-        reprojected.asInstanceOf[MultiPoint].points.map(_.jtsGeom.getCoordinate)
+      if (geom.isInstanceOf[MultiPoint]) {
+        geom.asInstanceOf[MultiPoint].points.map(_.jtsGeom.getCoordinate)
       } else {
         val coords = collection.mutable.ListBuffer.empty[Coordinate]
 
@@ -662,11 +661,10 @@ object SpatialTiledRasterRDD {
             coords += coord
           }
 
-          Rasterizer.foreachCellByGeometry(reprojected, re)(rasterizeToPoints)
-                                                           (sk, coords.toArray)
+          Rasterizer.foreachCellByGeometry(geom, re)(rasterizeToPoints)
         }
-        keys.foreach(createPoints)
 
+        keys.foreach(createPoints)
         coords.toArray
       }
 
@@ -675,19 +673,15 @@ object SpatialTiledRasterRDD {
     val mbtileRDD: RDD[(SpatialKey, MultibandTile)] = skRDD.mapPartitions({ skiter => skiter.map { sk =>
       val ex = maptrans(sk)
       val re = RasterExtent(ex, ld.tileCols, ld.tileRows)
-      val tile = DoubleArrayTile.empty(re.cols, re.rows)
+      val tile = ArrayTile.empty(cellType, re.cols, re.rows)
       val vd = new VoronoiDiagram(dt.value, ex)
       vd.voronoiCellsWithPoints.foreach(EuclideanDistanceTile.rasterizeDistanceCell(re, tile)(_))
       (sk, MultibandTile(tile))
     } }, preservesPartitioning=true)
 
-    val projectedRDD: RDD[(ProjectedExtent, MultibandTile)] = mbtileRDD.map{ case (sk, mbtile) => {
-      val ex = maptrans(sk)
-      val projEx = ProjectedExtent(ex, WebMercator)
-      (projEx, mbtile)
-    }}
+    val metadata = TileLayerMetadata(cellType, ld, maptrans(gb), srcCRS, KeyBounds(gb))
 
-    SpatialTiledRasterRDD(Some(z), MultibandTileLayerRDD(mbtileRDD, projectedRDD.collectMetadata[SpatialKey](ld)))
+    SpatialTiledRasterRDD(Some(z), MultibandTileLayerRDD(mbtileRDD, metadata))
   }
 
 }

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -532,7 +532,7 @@ class TiledRasterRDD(CachableRDD):
         return cls(geopysc, rdd_type, srdd)
 
     @classmethod
-    def euclidean_distance(cls, geopysc, geometry, source_crs, zoom):
+    def euclidean_distance(cls, geopysc, geometry, source_crs, zoom, cellType='float64'):
         """Calculates the Euclidean distance of a Shapely geometry.
 
         Args:
@@ -553,7 +553,7 @@ class TiledRasterRDD(CachableRDD):
         if isinstance(source_crs, int):
             source_crs = str(source_crs)
 
-        srdd = geopysc._jvm.geopyspark.geotrellis.SpatialTiledRasterRDD.euclideanDistance(geopysc.sc, dumps(geometry), source_crs, zoom)
+        srdd = geopysc._jvm.geopyspark.geotrellis.SpatialTiledRasterRDD.euclideanDistance(geopysc.sc, dumps(geometry), source_crs, cellType, zoom)
         return cls(geopysc, SPATIAL, srdd)
 
     def to_numpy_rdd(self):


### PR DESCRIPTION
The euclideanDistance operation was inefficient.  Due to the way we chose to build the metadata for the layer, the Euclidean distance operation was actually performed twice.  Moreover, it was not possible to compute the Euclidean distance in any CRS other then WebMercator or to produce tiles that were anything other than DoubleArrayTiles.  It is now possible to compute the distance layers efficiently, in whatever projection the geometry is in, and to whichever output cell type that is desired.