### PR TITLE
User Definited NoData Value CellType Fix

### DIFF
--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -233,26 +233,36 @@ FLOAT32 = "float32"
 """Representes Double Cells with constant NoData values."""
 FLOAT64 = "float64"
 
-"""Representes Byte Cells with user defined NoData values."""
-INT8UD = "int8ud"
+def create_no_data_constant(cell_type, no_data_value):
+    """Creates a ``CellType`` that has a user defined NoData value.
 
-"""Representes UByte Cells with user defined NoData values."""
-UINT8UD = "uint8ud"
+    Cannot be used when the ``cell_type`` is either a boolean or contains raw values.
 
-"""Representes Short Cells with user defined NoData values."""
-INT16UD = "int16ud"
+    Args:
+        cell_type (str): The string representation of the ``CellType`` to convert to. It is
+            represented by a constant such as ``INT16``, ``FLOAT64``, etc.
+        no_data_value (int or float): The value that should be marked as NoData.
 
-"""Representes UShort Cells with user defined NoData values."""
-UINT16UD = "uint16ud"
+    Returns:
+        A user defined noData constant CellType (str)
 
-"""Representes Int Cells with user defined NoData values."""
-INT32UD = "int32ud"
+    Raises:
+        ValueError: If ``cell_type`` is a boolean.
+        ValueError: If the ``cell_type`` contains raw values.
+        ValueError: If the ``cell_type`` is not a known ``CellType``.
+    """
 
-"""Representes Float Cells with user defined NoData values."""
-FLOAT32UD = "float32ud"
+    if 'bool' in cell_type:
+        raise ValueError("Cannot add user defined types to Bool")
+    elif 'raw' in cell_type:
+        raise ValueError("Cannot add user defined types to raw values")
+    elif cell_type not in CELL_TYPES:
+        raise ValueError(cell_type, "Is not a known CellType")
+    else:
+        no_data_constant = cell_type + "ud" + str(no_data_value)
+        CELL_TYPES.append(no_data_constant)
 
-"""Representes Double Cells with user defined NoData values."""
-FLOAT64UD = "float64ud"
+        return no_data_constant
 
 
 CELL_TYPES = [
@@ -271,14 +281,7 @@ CELL_TYPES = [
     UINT16,
     INT32,
     FLOAT32,
-    FLOAT64,
-    INT8UD,
-    UINT8UD,
-    INT16UD,
-    UINT16UD,
-    INT32UD,
-    FLOAT32UD,
-    FLOAT64UD
+    FLOAT64
 ]
 
 

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -233,38 +233,6 @@ FLOAT32 = "float32"
 """Representes Double Cells with constant NoData values."""
 FLOAT64 = "float64"
 
-def create_no_data_constant(cell_type, no_data_value):
-    """Creates a ``CellType`` that has a user defined NoData value.
-
-    Cannot be used when the ``cell_type`` is either a boolean or contains raw values.
-
-    Args:
-        cell_type (str): The string representation of the ``CellType`` to convert to. It is
-            represented by a constant such as ``INT16``, ``FLOAT64``, etc.
-        no_data_value (int or float): The value that should be marked as NoData.
-
-    Returns:
-        A user defined noData constant CellType (str)
-
-    Raises:
-        ValueError: If ``cell_type`` is a boolean.
-        ValueError: If the ``cell_type`` contains raw values.
-        ValueError: If the ``cell_type`` is not a known ``CellType``.
-    """
-
-    if 'bool' in cell_type:
-        raise ValueError("Cannot add user defined types to Bool")
-    elif 'raw' in cell_type:
-        raise ValueError("Cannot add user defined types to raw values")
-    elif cell_type not in CELL_TYPES:
-        raise ValueError(cell_type, "Is not a known CellType")
-    else:
-        no_data_constant = cell_type + "ud" + str(no_data_value)
-        CELL_TYPES.append(no_data_constant)
-
-        return no_data_constant
-
-
 CELL_TYPES = [
     BOOLRAW,
     INT8RAW,

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -217,24 +217,38 @@ class RasterRDD(CachableRDD):
         return self.tile_to_layout(self.collect_metadata(extent, layout, crs, tile_size),
                                    resample_method)
 
-    def convert_data_type(self, new_type):
+    def convert_data_type(self, new_type, no_data_value=None):
         """Converts the underlying, raster values to a new ``CellType``.
 
         Args:
             new_type (str): The string representation of the ``CellType`` to convert to. It is
-                represented by a constant such as ``INT16``, ``FLOAT64UD``, etc.
+                represented by a constant such as ``INT16``, ``FLOAT64``, etc.
+            no_data_value (int or float, optional): The value that should be marked as NoData.
 
         Returns:
             :class:`~geopyspark.geotrellis.rdd.RasterRDD`
 
         Raises:
             ValueError: When an unsupported cell type is entered.
+            ValueError: If ``no_data_value`` is set and the ``new_type`` contains raw values.
+            ValueError: If ``no_data_value`` is set and ``new_type`` is a boolean.
         """
 
         if new_type not in CELL_TYPES:
             raise ValueError(new_type, "Is not a know Cell Type")
 
-        return RasterRDD(self.geopysc, self.rdd_type, self.srdd.convertDataType(new_type))
+        if no_data_value:
+            if 'bool' in new_type:
+                raise ValueError("Cannot add user defined types to Bool")
+            elif 'raw' in new_type:
+                raise ValueError("Cannot add user defined types to raw values")
+
+            no_data_constant = new_type + "ud" + str(no_data_value)
+
+            return RasterRDD(self.geopysc, self.rdd_type,
+                             self.srdd.convertDataType(no_data_constant))
+        else:
+            return RasterRDD(self.geopysc, self.rdd_type, self.srdd.convertDataType(new_type))
 
     def collect_metadata(self, extent=None, layout=None, crs=None, tile_size=256):
         """Iterate over RDD records and generates layer metadata desribing the contained
@@ -571,16 +585,38 @@ class TiledRasterRDD(CachableRDD):
                                                    value_type=TILE)
         return self.geopysc.create_python_rdd(result._1(), ser)
 
-    def convert_data_type(self, new_type):
+    def convert_data_type(self, new_type, no_data_value=None):
         """Converts the underlying, raster values to a new ``CellType``.
 
         Args:
             new_type (str): The string representation of the ``CellType`` to convert to. It is
-                represented by a constant such as ``INT16``, ``FLOAT64UD``, etc.
+                represented by a constant such as ``INT16``, ``FLOAT64``, etc.
+            no_data_value (int or float, optional): The value that should be marked as NoData.
+
         Returns:
             :class:`~geopyspark.geotrellis.rdd.TiledRasterRDD`
+
+        Raises:
+            ValueError: When an unsupported cell type is entered.
+            ValueError: If ``no_data_value`` is set and the ``new_type`` contains raw values.
+            ValueError: If ``no_data_value`` is set and ``new_type`` is a boolean.
         """
-        return TiledRasterRDD(self.geopysc, self.rdd_type, self.srdd.convertDataType(new_type))
+
+        if new_type not in CELL_TYPES:
+            raise ValueError(new_type, "Is not a know Cell Type")
+
+        if no_data_value:
+            if 'bool' in new_type:
+                raise ValueError("Cannot add user defined types to Bool")
+            elif 'raw' in new_type:
+                raise ValueError("Cannot add user defined types to raw values")
+
+            no_data_constant = new_type + "ud" + str(no_data_value)
+
+            return TiledRasterRDD(self.geopysc, self.rdd_type,
+                                  self.srdd.convertDataType(no_data_constant))
+        else:
+            return TiledRasterRDD(self.geopysc, self.rdd_type, self.srdd.convertDataType(new_type))
 
     def reproject(self, target_crs, extent=None, layout=None, scheme=FLOAT, tile_size=256,
                   resolution_threshold=0.1, resample_method=NEARESTNEIGHBOR):

--- a/geopyspark/tests/geotiff_raster_rdd_test.py
+++ b/geopyspark/tests/geotiff_raster_rdd_test.py
@@ -4,7 +4,7 @@ import rasterio
 import pytest
 import numpy as np
 
-from geopyspark.geotrellis.constants import SPATIAL, INT32, BOOLRAW, create_no_data_constant, UINT8
+from geopyspark.geotrellis.constants import SPATIAL, INT32, BOOLRAW, UINT8
 from geopyspark.tests.python_test_utils import geotiff_test_path
 from geopyspark.geotrellis.geotiff_rdd import get
 from geopyspark.geotrellis.rdd import RasterRDD
@@ -120,8 +120,7 @@ class Multiband(GeoTiffIOTest, BaseTestClass):
         rdd = BaseTestClass.geopysc.pysc.parallelize([(projected_extent, tile)])
         raster_rdd = RasterRDD.from_numpy_rdd(BaseTestClass.geopysc, SPATIAL, rdd)
 
-        no_data_const = create_no_data_constant(UINT8, -1)
-        converted = raster_rdd.convert_data_type(no_data_const)
+        converted = raster_rdd.convert_data_type(UINT8, no_data_value=-1)
         tile = converted.to_numpy_rdd().first()
         no_data = tile[1]['no_data_value']
 


### PR DESCRIPTION
This PR adds a function, `create_no_data_constant` that lets users create a user defined NoData `CellType`.

This PR resolves #232 