### PR TITLE
Keys Are Now namedtuples

### DIFF
--- a/docs/guides/core_concepts.rst
+++ b/docs/guides/core_concepts.rst
@@ -33,19 +33,11 @@ The fields used to represent rasters:
 **Note**: All rasters in GeoPySpark are represented as having multiple bands,
 even if the original raster just contained one.
 
-.. _projected_extent:
-
 ProjectedExtent
 ---------------
 
 Describes both the area on Earth a raster represents in addition to its CRS.
-In GeoPySpark, this is represented as a ``dict``.
-
-The fields used to represent ``ProjectedExtent``:
- - **extent** (:obj:`~geopyspark.geotrellis.data_structures.Extent`): The area the raster
-   represents.
- - **epsg** (int, optional): The EPSG code of the CRS.
- - **proj4** (str, optional): The Proj.4 string representation of the CRS.
+In GeoPySpark, this is represented by :cls:`geopyspark.geotrellis.ProjectedExtent`.
 
 Example:
 
@@ -55,29 +47,18 @@ Example:
 
    # using epsg
    epsg_code = 3857
-   projected_extent = {'extent': extent, 'epsg': epsg}
+   projected_extent = ProjectedExtent(extent, epsg=epsg)
 
    # using proj4
    proj4 = "+proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +a=6378137 +b=6378137 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs "
-   projected_extent = {'extent': extent, 'proj4': proj4}
-
-
-**Note**: Either ``epsg`` or ``proj4`` must be defined.
-
-.. _temporal_extent:
+   projected_extent = ProjectedExtent(extent, proj4=proj4)
 
 TemporalProjectedExtent
 -----------------------
 
 Describes the area on Earth the raster represents, its CRS, and the time the
-data was collected. In GeoPySpark, this is represented as a ``dict``.
-
-The fields used to represent ``TemporalProjectedExtent``.
- - **extent** (:obj:`~geopyspark.geotrellis.data_structures.Extent`): The area the raster
-   represents.
- - **epsg** (int, optional): The EPSG code of the CRS.
- - **proj4** (str, optional): The Proj.4 string representation of the CRS.
- - **instance** (int): The time stamp of the raster.
+data was collected. In GeoPySpark, this is represented by
+:cls:`geopyspark.geotrellis.TemporalProjectedExtent`.
 
 Example:
 
@@ -87,48 +68,34 @@ Example:
 
    epsg_code = 3857
    instance = 1.0
-   projected_extent = {'extent': extent, 'epsg': epsg, 'instance': instance}
-
-**Note**: Either ``epsg`` or ``proj4`` must be defined.
-
-.. _spatial-key:
+   temporal_projected_extent = TemporalProjectedExtent(extent, instance, epsg=epsg)
 
 SpatialKey
 ----------
 
 Represents the position of a raster within a grid. This grid is a 2D plane
 where raster positions are represented by a pair of coordinates. In GeoPySpark,
-this is represented as a ``dict``.
-
-The fields used to represent ``SpatialKey``:
- - **col** (int): The column of the grid, the numbers run east to west.
- - **row** (int): The row of the grid, the numbers run north to south.
+this is represented by :cls:`geopyspark.geotrellis.SpatialKey`.
 
 Example:
 
 .. code:: python
 
-   spatial_key = {'col': 0, 'row': 0}
-
-.. _space-time-key:
+   spatial_key = SpatialKey(0, 0)
 
 SpaceTimeKey
 ------------
 
 Represents the position of a raster within a grid. This grid is a 3D plane
 where raster positions are represented by a pair of coordinates as well as a z
-value that represents time. In GeoPySpark, this is represented as a ``dict``.
-
-The fields used to reprsent ``SpaceTimeKey``:
- - **col** (int): The column of the grid, the numbers run east to west.
- - **row** (int): The row of the grid, the numbers run north to south.
- - **instance** (int): The time stamp of the raster.
+value that represents time. In GeoPySpark, this is represented by
+:cls:`geopyspark.geotrellis.SpaceTimeKey`.
 
 Example:
 
 .. code:: python
 
-   spatial_key = {'col': 0, 'row': 0, 'instant': 0.0}
+   space_time_key = SpaceTimeKey(0, 0, 0.0)
 
 
 .. _data_rep:

--- a/geopyspark/avroregistry.py
+++ b/geopyspark/avroregistry.py
@@ -179,6 +179,9 @@ class AvroRegistry(object):
         if not isinstance(obj, dict):
             obj = obj._asdict()
 
+        if not isinstance(obj['extent'], dict):
+            obj['extent'] = obj['extent']._asdict()
+
         if obj.get('epsg'):
             obj['proj4'] = 'null'
         else:

--- a/geopyspark/geopycontext.py
+++ b/geopyspark/geopycontext.py
@@ -97,7 +97,7 @@ class GeoPyContext(object):
 
         return self._jvm.geopyspark.geotrellis.SchemaProducer.getSchema(key_type)
 
-    def create_tuple_serializer(self, schema, key_type=None, value_type=None):
+    def create_tuple_serializer(self, schema, key_type, value_type):
         decoder = \
                 self.avroregistry.create_partial_tuple_decoder(key_type=key_type,
                                                                value_type=value_type)

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -157,7 +157,7 @@ Returns:
 """
 
 
-SpaceTimeKey = namedtuple("SpaceTimeKey", 'col, row instant')
+SpaceTimeKey = namedtuple("SpaceTimeKey", 'col row instant')
 """Represents the position of a raster within a grid.
 This grid is a 3D plane where raster positions are represented by a pair of coordinates as well as
 a z value that represents time.

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -52,6 +52,22 @@ class Extent(namedtuple("Extent", 'xmin ymin xmax ymax')):
 
 
 class ProjectedExtent(namedtuple("ProjectedExtent", 'extent epsg proj4')):
+    """Describes both the area on Earth a raster represents in addition to its CRS.
+
+    Args:
+        extent (:cls:~geopyspark.geotrellis.Extent): The area the raster represents.
+        epsg (int, optional): The EPSG code of the CRS.
+        proj4 (str, optional): The Proj.4 string representation of the CRS.
+
+    Attributes:
+        extent (:cls:~geopyspark.geotrellis.Extent): The area the raster represents.
+        epsg (int, optional): The EPSG code of the CRS.
+        proj4 (str, optional): The Proj.4 string representation of the CRS.
+
+    Note:
+        Either ``epsg`` or ``proj4`` must be defined.
+    """
+
     __slots__ = []
 
     def __new__(cls, extent, epsg=None, proj4=None):
@@ -65,6 +81,25 @@ class ProjectedExtent(namedtuple("ProjectedExtent", 'extent epsg proj4')):
 
 
 class TemporalProjectedExtent(namedtuple("TemporalProjectedExtent", 'extent instant epsg proj4')):
+    """Describes the area on Earth the raster represents, its CRS, and the time the data was
+    collected.
+
+    Args:
+        extent (:cls:`~geopyspark.geotrellis.Extent`): The area the raster represents.
+        instance (int): The time stamp of the raster.
+        epsg (int, optional): The EPSG code of the CRS.
+        proj4 (str, optional): The Proj.4 string representation of the CRS.
+
+    Attributes:
+        extent (:cls:~geopyspark.geotrellis.Extent): The area the raster represents.
+        instance (int): The time stamp of the raster.
+        epsg (int, optional): The EPSG code of the CRS.
+        proj4 (str, optional): The Proj.4 string representation of the CRS.
+
+    Note:
+        Either ``epsg`` or ``proj4`` must be defined.
+    """
+
     __slots__ = []
 
     def __new__(cls, extent, instant, epsg=None, proj4=None):
@@ -93,6 +128,7 @@ Returns:
     :obj:`~geopyspark.geotrellis.TileLayout`
 """
 
+
 LayoutDefinition = namedtuple("LayoutDefinition", 'extent tileLayout')
 """
 Describes the layout of the rasters within a RDD and how they are projected.
@@ -106,10 +142,34 @@ Returns:
     :obj:`~geopyspark.geotrellis.LayoutDefinition`
 """
 
+
 SpatialKey = namedtuple("SpatialKey", 'col row')
+"""Represents the position of a raster within a grid.
+
+This grid is a 2D plane where raster positions are represented by a pair of coordinates.
+
+Args:
+    col (int): The column of the grid, the numbers run east to west.
+    row (int): The row of the grid, the numbers run north to south.
+
+Returns:
+    :obj:`~geopyspark.geotrellis.SpatialKey`
+"""
 
 
 SpaceTimeKey = namedtuple("SpaceTimeKey", 'col, row instant')
+"""Represents the position of a raster within a grid.
+This grid is a 3D plane where raster positions are represented by a pair of coordinates as well as
+a z value that represents time.
+
+Args:
+    col (int): The column of the grid, the numbers run east to west.
+    row (int): The row of the grid, the numbers run north to south.
+    instance (int): The time stamp of the raster.
+
+Returns:
+    :obj:`~geopyspark.geotrellis.SpaceTimeKey`
+"""
 
 
 class Bounds(namedtuple("Bounds", 'minKey maxKey')):
@@ -117,10 +177,10 @@ class Bounds(namedtuple("Bounds", 'minKey maxKey')):
     Represents the grid that covers the area of the rasters in a RDD on a grid.
 
     Args:
-        minKey (:ref:`spatial-key` or :ref:`space-time-key`): The smallest ``SpatialKey`` or
-            ``SpaceTimeKey``.
-        maxKey (:ref:`spatial-key` or :ref:`space-time-key`): The largest ``SpatialKey`` or
-            ``SpaceTimeKey``.
+        minKey (:obj:`~geopyspark.geotrellis.SpatialKey` or :obj:`~geopyspark.geotrellis.SpaceTimeKey`):
+            The smallest ``SpatialKey`` or ``SpaceTimeKey``.
+        minKey (:obj:`~geopyspark.geotrellis.SpatialKey` or :obj:`~geopyspark.geotrellis.SpaceTimeKey`):
+            The largest ``SpatialKey`` or ``SpaceTimeKey``.
 
     Returns:
         :cls:`~geopyspark.geotrellis.Bounds`

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -18,7 +18,6 @@ _mapped_serializers = {}
 _cached = namedtuple('Cached', ('store', 'reader', 'value_reader', 'writer'))
 
 _mapped_bounds = {}
-_bounds = namedtuple('Bounds', ('col_min', 'row_min', 'col_max', 'row_max'))
 
 
 def _construct_catalog(geopysc, new_uri, options):
@@ -121,16 +120,13 @@ def _construct_catalog(geopysc, new_uri, options):
 def _in_bounds(geopysc, rdd_type, uri, layer_name, zoom_level, col, row):
     if (layer_name, zoom_level) not in _mapped_bounds:
         layer_metadata = read_layer_metadata(geopysc, rdd_type, uri, layer_name, zoom_level)
-        bounds_dict = layer_metadata.bounds
-        min_key = bounds_dict.minKey
-        max_key = bounds_dict.maxKey
-        bounds = _bounds(min_key['col'], min_key['row'], max_key['col'], max_key['row'])
+        bounds = layer_metadata.bounds
         _mapped_bounds[(layer_name, zoom_level)] = bounds
     else:
         bounds = _mapped_bounds[(layer_name, zoom_level)]
 
-    mins = col < bounds.col_min or row < bounds.row_min
-    maxs = col > bounds.col_max or row > bounds.row_max
+    mins = col < bounds.minKey.col or row < bounds.minKey.row
+    maxs = col > bounds.maxKey.col or row > bounds.maxKey.row
 
     if mins or maxs:
         return False

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -144,7 +144,7 @@ def read_layer_metadata(geopysc,
     """Reads the metadata from a saved layer without reading in the whole layer.
 
     Args:
-        geopysc (geopyspark.GeoPyContext): The ``GeoPyContext`` being used this session.
+        geopysc (:cls:`~geopyspark.GeoPyContext`): The ``GeoPyContext`` being used this session.
         rdd_type (str): What the spatial type of the geotiffs are. This is
             represented by the constants: ``SPATIAL`` and ``SPACETIME``.
         uri (str): The Uniform Resource Identifier used to point towards the desired GeoTrellis
@@ -187,7 +187,7 @@ def get_layer_ids(geopysc,
     name and zoom of a given layer.
 
     Args:
-        geopysc (geopyspark.GeoPyContext): The ``GeoPyContext`` being used this session.
+        geopysc (:cls:`~geopyspark.GeoPyContext`): The ``GeoPyContext`` being used this session.
         uri (str): The Uniform Resource Identifier used to point towards the desired GeoTrellis
             catalog to be read from. The shape of this string varies depending on backend.
         options (dict, optional): Additional parameters for reading the layer for specific backends.
@@ -232,7 +232,7 @@ def read(geopysc,
         use :func:`query` instead.
 
     Args:
-        geopysc (GeoPyContext): The GeoPyContext being used this session.
+        geopysc (:cls:`~geopyspark.GeoPyContext`): The ``GeoPyContext`` being used this session.
         rdd_type (str): What the spatial type of the geotiffs are. This is
             represented by the constants: ``SPATIAL`` and ``SPACETIME``.
         uri (str): The Uniform Resource Identifier used to point towards the desired GeoTrellis
@@ -289,7 +289,7 @@ def read_value(geopysc,
         When requesting a tile that does not exist, ``None`` will be returned.
 
     Args:
-        geopysc (geopyspark.GeoPyContext): The ``GeoPyContext`` being used this session.
+        geopysc (:cls:`~geopyspark.GeoPyContext`): The ``GeoPyContext`` being used this session.
         rdd_type (str): What the spatial type of the geotiffs are. This is
             represented by the constants: ``SPATIAL`` and ``SPACETIME``.
         uri (str): The Uniform Resource Identifier used to point towards the desired GeoTrellis
@@ -364,7 +364,7 @@ def query(geopysc,
         been set, or if the querried region contains the entire layer.
 
     Args:
-        geopysc (GeoPyContext): The GeoPyContext being used this session.
+        geopysc (:cls:`~geopyspark.GeoPyContext`): The ``GeoPyContext`` being used this session.
         rdd_type (str): What the spatial type of the geotiffs are. This is
             represented by the constants: ``SPATIAL`` and ``SPACETIME``. Note: All of the
             GeoTiffs must have the same saptial type.

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -158,7 +158,7 @@ class RasterRDD(CachableRDD):
         key = geopysc.map_key_input(rdd_type, False)
 
         schema = geopysc.create_schema(key)
-        ser = geopysc.create_tuple_serializer(schema, key_type="Projected", value_type=TILE)
+        ser = geopysc.create_tuple_serializer(schema, key_type=key, value_type=TILE)
         reserialized_rdd = numpy_rdd._reserialize(ser)
 
         if rdd_type == SPATIAL:
@@ -184,7 +184,8 @@ class RasterRDD(CachableRDD):
         """
 
         result = self.srdd.toAvroRDD()
-        ser = self.geopysc.create_tuple_serializer(result._2(), key_type="Projected",
+        key = self.geopysc.map_key_input(self.rdd_type, False)
+        ser = self.geopysc.create_tuple_serializer(result._2(), key_type=key,
                                                    value_type=TILE)
         return self.geopysc.create_python_rdd(result._1(), ser)
 
@@ -457,7 +458,7 @@ class TiledRasterRDD(CachableRDD):
         key = geopysc.map_key_input(rdd_type, True)
 
         schema = geopysc.create_schema(key)
-        ser = geopysc.create_tuple_serializer(schema, key_type=None, value_type=TILE)
+        ser = geopysc.create_tuple_serializer(schema, key_type=key, value_type=TILE)
         reserialized_rdd = numpy_rdd._reserialize(ser)
 
         if isinstance(metadata, Metadata):
@@ -567,7 +568,8 @@ class TiledRasterRDD(CachableRDD):
             ``pyspark.RDD``
         """
         result = self.srdd.toAvroRDD()
-        ser = self.geopysc.create_tuple_serializer(result._2(), key_type=None,
+        key = self.geopysc.map_key_input(self.rdd_type, True)
+        ser = self.geopysc.create_tuple_serializer(result._2(), key_type=key,
                                                    value_type=TILE)
         return self.geopysc.create_python_rdd(result._1(), ser)
 
@@ -656,10 +658,10 @@ class TiledRasterRDD(CachableRDD):
         if self.rdd_type != SPATIAL:
             raise ValueError("Only TiledRasterRDDs with a rdd_type of Spatial can use lookup()")
         bounds = self.layer_metadata.bounds
-        min_col = bounds.minKey['col']
-        min_row = bounds.minKey['row']
-        max_col = bounds.maxKey['col']
-        max_row = bounds.maxKey['row']
+        min_col = bounds.minKey.col
+        min_row = bounds.minKey.row
+        max_col = bounds.maxKey.col
+        max_row = bounds.maxKey.row
 
         if col < min_col or col > max_col:
             raise IndexError("column out of bounds")

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -108,9 +108,10 @@ class CachableRDD(object):
 class RasterRDD(CachableRDD):
     """A wrapper of a RDD that contains GeoTrellis rasters.
 
-    Represents a RDD that contains ``(K, V)``. Where ``K`` is either :ref:`projected_extent` or
-    :ref:`temporal_extent` depending on the ``rdd_type`` of the RDD, and ``V`` being a
-    :ref:`raster`.
+    Represents a RDD that contains ``(K, V)``. Where ``K`` is either
+    :cls:`~geopyspark.geotrellis.ProjectedExtent` or
+    :cls:`~geopyspark.geotrellis.TemporalProjectedExtent` depending on the ``rdd_type`` of the RDD,
+    and ``V`` being a :ref:`raster`.
 
     The data held within the RDD has not been tiled. Meaning the data has yet to be
     modified to fit a certain layout. See :ref:`raster_rdd` for more information.
@@ -397,9 +398,9 @@ class RasterRDD(CachableRDD):
 class TiledRasterRDD(CachableRDD):
     """Wraps a RDD of tiled, GeoTrellis rasters.
 
-    Represents a RDD that contains ``(K, V)``. Where ``K`` is either :ref:`spatial-key` or
-    :ref:`space-time-key` depending on the ``rdd_type`` of the RDD, and ``V`` being a
-    :ref:`raster`.
+    Represents a RDD that contains ``(K, V)``. Where ``K`` is either
+    :cls:`~geopyspark.geotrellis.SpatialKey` or :cls:`~geopyspark.geotrellis.SpaceTimeKey`
+    depending on the ``rdd_type`` of the RDD, and ``V`` being a :ref:`raster`.
 
     The data held within the RDD is tiled. This means that the rasters have been modified to fit
     a larger layout. For more information, see :ref:`tiled-raster-rdd`.

--- a/geopyspark/tests/base_test_class.py
+++ b/geopyspark/tests/base_test_class.py
@@ -24,11 +24,9 @@ class BaseTestClass(unittest.TestCase):
     value = rdd.to_numpy_rdd().collect()[0]
 
     projected_extent = value[0]
-
-    extent = Extent(**projected_extent['extent'])
+    extent = projected_extent.extent
 
     expected_tile = value[1]['data']
-
     (_, rows, cols) = expected_tile.shape
 
     layout = TileLayout(1, 1, cols, rows)

--- a/geopyspark/tests/catalog_test.py
+++ b/geopyspark/tests/catalog_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from shapely.geometry import box
 
+from geopyspark.geotrellis import SpatialKey
 from geopyspark.geotrellis.catalog import read, read_value, query, read_layer_metadata, get_layer_ids
 from geopyspark.geotrellis.constants import SPATIAL, ZOOM
 from geopyspark.geotrellis.geotiff_rdd import get
@@ -62,19 +63,20 @@ class CatalogTest(BaseTestClass):
         intersection = box(8348915.46680623, 543988.943201519, 8348915.4669, 543988.943201520)
         queried = query(BaseTestClass.geopysc, SPATIAL, self.uri, self.layer_name, 11, intersection)
 
-        self.assertDictEqual(queried.to_numpy_rdd().first()[0], {'col': 1450, 'row': 996})
+        self.assertEqual(queried.to_numpy_rdd().first()[0], SpatialKey(1450, 996))
 
     def test_query_partitions(self):
         intersection = box(8348915.46680623, 543988.943201519, 8348915.4669, 543988.943201520)
-        queried = query(BaseTestClass.geopysc, SPATIAL, self.uri, self.layer_name, 11, intersection, numPartitions = 2)
-        self.assertDictEqual(queried.to_numpy_rdd().first()[0], {'col': 1450, 'row': 996})
+        queried = query(BaseTestClass.geopysc, SPATIAL, self.uri, self.layer_name, 11, intersection,
+                        numPartitions=2)
+        self.assertEqual(queried.to_numpy_rdd().first()[0], SpatialKey(1450, 996))
 
     def test_query_crs(self):
         intersection = box(8348915.46680623, 543988.943201519, 8348915.4669, 543988.943201520)
         queried = query(BaseTestClass.geopysc, SPATIAL, self.uri, self.layer_name, 11, intersection,
                         proj_query=3857)
 
-        self.assertDictEqual(queried.to_numpy_rdd().first()[0], {'col': 1450, 'row': 996})
+        self.assertEqual(queried.to_numpy_rdd().first()[0], SpatialKey(1450, 996))
 
     def test_read_metadata(self):
         layer = read(BaseTestClass.geopysc, SPATIAL, self.uri, self.layer_name, 5)
@@ -83,7 +85,7 @@ class CatalogTest(BaseTestClass):
         expected_metadata = read_layer_metadata(BaseTestClass.geopysc, SPATIAL, self.uri,
                                                 self.layer_name, 5)
 
-        self.assertDictEqual(actual_metadata.to_dict(), expected_metadata.to_dict())
+        self.assertEqual(actual_metadata.to_dict(), expected_metadata.to_dict())
 
     def test_layer_ids(self):
         ids = get_layer_ids(BaseTestClass.geopysc, self.uri)

--- a/geopyspark/tests/costdistance_test.py
+++ b/geopyspark/tests/costdistance_test.py
@@ -46,7 +46,7 @@ class CostDistanceTest(BaseTestClass):
     def test_costdistance_finite(self):
         def zero_one(kv):
             k = kv[0]
-            return (k['col'] == 0 and k['row'] == 1)
+            return (k.col == 0 and k.row == 1)
 
         result = self.raster_rdd.cost_distance(geometries=[Point(13, 13)], max_distance=144000.0)
 
@@ -57,7 +57,7 @@ class CostDistanceTest(BaseTestClass):
     def test_costdistance_finite_int(self):
         def zero_one(kv):
             k = kv[0]
-            return (k['col'] == 0 and k['row'] == 1)
+            return (k.col == 0 and k.row == 1)
 
         result = self.raster_rdd.cost_distance(geometries=[Point(13, 13)], max_distance=144000)
 
@@ -68,7 +68,7 @@ class CostDistanceTest(BaseTestClass):
     def test_costdistance_infinite(self):
         def zero_one(kv):
             k = kv[0]
-            return (k['col'] == 0 and k['row'] == 1)
+            return (k.col == 0 and k.row == 1)
 
         result = self.raster_rdd.cost_distance(geometries=[Point(13, 13)], max_distance=float('inf'))
 

--- a/geopyspark/tests/focal_test.py
+++ b/geopyspark/tests/focal_test.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 import pytest
 
+from geopyspark.geotrellis import SpatialKey, Extent
 from geopyspark.geotrellis.rdd import TiledRasterRDD
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis.constants import SPATIAL, SUM, MIN, SQUARE, ANNULUS
@@ -17,10 +18,17 @@ class FocalTest(BaseTestClass):
         [1.0, 1.0, 1.0, 1.0, 1.0],
         [1.0, 1.0, 1.0, 1.0, 0.0]]])
 
+    '''
     layer = [({'row': 0, 'col': 0}, {'no_data_value': -1.0, 'data': data}),
              ({'row': 1, 'col': 0}, {'no_data_value': -1.0, 'data': data}),
              ({'row': 0, 'col': 1}, {'no_data_value': -1.0, 'data': data}),
              ({'row': 1, 'col': 1}, {'no_data_value': -1.0, 'data': data})]
+    '''
+
+    layer = [(SpatialKey(0, 0), {'no_data_value': -1.0, 'data': data}),
+             (SpatialKey(0, 1), {'no_data_value': -1.0, 'data': data}),
+             (SpatialKey(1, 0), {'no_data_value': -1.0, 'data': data}),
+             (SpatialKey(1, 1), {'no_data_value': -1.0, 'data': data})]
     rdd = BaseTestClass.geopysc.pysc.parallelize(layer)
 
     extent = {'xmin': 0.0, 'ymin': 0.0, 'xmax': 33.0, 'ymax': 33.0}

--- a/geopyspark/tests/geotiff_raster_rdd_test.py
+++ b/geopyspark/tests/geotiff_raster_rdd_test.py
@@ -53,7 +53,6 @@ class Multiband(GeoTiffIOTest, BaseTestClass):
     def test_to_numpy_rdd(self, option=None):
         pyrdd = self.result.to_numpy_rdd()
         (key, tile) = pyrdd.first()
-        self.assertTrue('extent' in key.keys())
         self.assertEqual(tile['data'].shape, (2, 512, 512))
 
     def test_collect_metadata(self, options=None):

--- a/geopyspark/tests/schema_tests/key_value_schema_test.py
+++ b/geopyspark/tests/schema_tests/key_value_schema_test.py
@@ -14,11 +14,11 @@ def decoder(x):
     tup_decoder = AvroRegistry.tuple_decoder
 
     tuples = x['pairs']
-    return [tup_decoder(tup) for tup in tuples]
+    return [tup_decoder(tup, AvroRegistry.tile_decoder, lambda x: x) for tup in tuples]
 
 def encoder(xs):
     tup_encoder = AvroRegistry.tuple_encoder
-    return {'pairs': [tup_encoder(x) for x in xs]}
+    return {'pairs': [tup_encoder(x, AvroRegistry.tile_encoder, lambda x: x) for x in xs]}
 
 
 class KeyValueRecordSchemaTest(unittest.TestCase):

--- a/geopyspark/tests/schema_tests/tuple_schema_test.py
+++ b/geopyspark/tests/schema_tests/tuple_schema_test.py
@@ -14,13 +14,19 @@ def decoder(x):
     tup_decoder = AvroRegistry.tuple_decoder
     tile_decoder = AvroRegistry.tile_decoder
 
-    return tup_decoder(x, key_decoder=tile_decoder)
+    def value_decoder(val):
+        return val
+
+    return tup_decoder(x, key_decoder=tile_decoder, value_decoder=value_decoder)
 
 def encoder(x):
     tup_encoder = AvroRegistry.tuple_encoder
     tile_encoder = AvroRegistry.tile_encoder
 
-    return tup_encoder(x, key_encoder=tile_encoder)
+    def value_encoder(val):
+        return val
+
+    return tup_encoder(x, key_encoder=tile_encoder, value_encoder=value_encoder)
 
 
 class TupleSchemaTest(BaseTestClass):


### PR DESCRIPTION
This PR changes the key type in `(K, V)` so that is either an instance or subtype of `namedtuple`. This will allow the user to do `join`s on the `RDD`s as `namedtuple`s are hashable.

This resolves #227 