### PR TITLE
Metadata Print Formatting

### DIFF
--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -293,3 +293,20 @@ class Metadata(object):
             }
 
         return self._metadata_dict
+
+    def __repr__(self):
+        return "Metadata({}, {}, {}, {}, {}, {})".format(self.bounds, self.cell_type,
+                                                         self.crs, self.extent,
+                                                         self.tile_layout, self.layout_definition)
+
+
+    def __str__(self):
+        return ("Metadata("
+                "bounds={}"
+                "cellType={}"
+                "crs={}"
+                "extent={}"
+                "tileLayout={}"
+                "layoutDefinition={})").format(self.bounds, self.cell_type,
+                                               self.crs, self.extent,
+                                               self.tile_layout, self.layout_definition)


### PR DESCRIPTION
This Pr makes it so that `Metadata` is now properly formatted when either `print`ing it, or having it returned in the console.

What it looked like before:

```
In [6]: rdd.layer_metadata
Out[6]: <geopyspark.geotrellis.Metadata at 0x7fec773c6e10>

In [7]: print(rdd.layer_metadata)
<geopyspark.geotrellis.Metadata object at 0x7fec8cec5080>
```

What it looks like with this Pr:

```
In [5]: rdd.layer_metadata
Out[5]: Metadata(Bounds(minKey=SpatialKey(col=1479, row=984), maxKey=SpatialKey(col=1485, row=996)), int16, +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs , Extent(xmin=8905559.263461886, ymin=542452.4856863784, xmax=9024345.159093022, ymax=781182.2141882492), TileLayout(layoutCols=2048, layoutRows=2048, tileCols=256, tileRows=256), LayoutDefinition(extent=Extent(xmin=-20037508.342789244, ymin=-20037508.342789244, xmax=20037508.342789244, ymax=20037508.342789244), tileLayout=TileLayout(layoutCols=2048, layoutRows=2048, tileCols=256, tileRows=256)))

In [6]: print(rdd.layer_metadata)
Metadata(bounds=Bounds(minKey=SpatialKey(col=1479, row=984), maxKey=SpatialKey(col=1485, row=996))cellType=int16crs=+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs extent=Extent(xmin=8905559.263461886, ymin=542452.4856863784, xmax=9024345.159093022, ymax=781182.2141882492)tileLayout=TileLayout(layoutCols=2048, layoutRows=2048, tileCols=256, tileRows=256)layoutDefinition=LayoutDefinition(extent=Extent(xmin=-20037508.342789244, ymin=-20037508.342789244, xmax=20037508.342789244, ymax=20037508.342789244), tileLayout=TileLayout(layoutCols=2048, layoutRows=2048, tileCols=256, tileRows=256)))
```