### PR TITLE
Updated Spark Version to 2.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 branches:
   only:
@@ -41,9 +42,9 @@ cache:
   - $HOME/.cache/pip
 
 script:
-  - "if [ ! -f archives/spark-2.1.0-bin-hadoop2.7.tgz ]; then pushd archives ; wget http://d3kbcqa49mib13.cloudfront.net/spark-2.1.0-bin-hadoop2.7.tgz; popd; fi"
-  - "tar -xvf archives/spark-2.1.0-bin-hadoop2.7.tgz"
-  - "export SPARK_HOME=./spark-2.1.0-bin-hadoop2.7/"
+  - "if [ ! -f archives/spark-2.1.1-bin-hadoop2.7.tgz ]; then pushd archives ; wget http://d3kbcqa49mib13.cloudfront.net/spark-2.1.1-bin-hadoop2.7.tgz; popd; fi"
+  - "tar -xvf archives/spark-2.1.1-bin-hadoop2.7.tgz"
+  - "export SPARK_HOME=./spark-2.1.1-bin-hadoop2.7/"
   - "export JAVA_HOME=/usr/lib/jvm/java-8-oracle"
   - pytest -k "schema" geopyspark/tests/schema_tests/
   - pytest -k "not schema" geopyspark/tests/*test.py

--- a/README.rst
+++ b/README.rst
@@ -115,8 +115,8 @@ Requirement  Version
 ============ ============
 Java         >=1.8
 Scala        2.11.8
-Python       3.3 - 3.5
-Hadoop       >=2.0.1
+Python       3.3 - 3.6
+Hadoop       >=2.1.1
 ============ ============
 
 Java 8 and Scala 2.11 are needed for GeoPySpark to work; as they are required by

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,10 +23,10 @@ import sys
 import subprocess
 
 if 'SPARK_HOME' not in os.environ.keys():
-    spark_url = 'http://d3kbcqa49mib13.cloudfront.net/spark-2.1.0-bin-hadoop2.7.tgz'
+    spark_url = 'http://d3kbcqa49mib13.cloudfront.net/spark-2.1.1-bin-hadoop2.7.tgz'
     subprocess.call(['curl', '-L', spark_url, '-O'])
-    subprocess.call(['tar', '-xvf', 'spark-2.1.0-bin-hadoop2.7.tgz'])
-    os.environ['SPARK_HOME'] = './spark-2.1.0-bin-hadoop2.7/'
+    subprocess.call(['tar', '-xvf', 'spark-2.1.1-bin-hadoop2.7.tgz'])
+    os.environ['SPARK_HOME'] = './spark-2.1.1-bin-hadoop2.7/'
 
 jar = 'geotrellis-backend-assembly-0.1.0.jar'
 url = 'https://github.com/locationtech-labs/geopyspark/releases/download/v0.1.0/'

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup_args = dict(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ]
 )
 


### PR DESCRIPTION
This PR updates the Spark version used in GeoPySpark to 2.1.1. The biggest benefit this brings is the ability to use GeoPySpark with Python 3.6; as this [error](https://issues.apache.org/jira/browse/SPARK-19019) has been resolved in this version.