### PR TITLE
start_zoom is Now Optional When Pyramiding

### DIFF
--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -701,14 +701,15 @@ class TiledRasterRDD(CachableRDD):
 
         return TiledRasterRDD(self.geopysc, self.rdd_type, srdd)
 
-    def pyramid(self, start_zoom, end_zoom, resample_method=NEARESTNEIGHBOR):
+    def pyramid(self, end_zoom, start_zoom=None, resample_method=NEARESTNEIGHBOR):
         """Creates a pyramid of GeoTrellis layers where each layer reprsents a given zoom.
 
         Args:
-            start_zoom (int): The zoom level where pyramiding should begin. Represents
-                the level that is most zoomed in.
             end_zoom (int): The zoom level where pyramiding should end. Represents
                 the level that is most zoomed out.
+            start_zoom (int, Optional): The zoom level where pyramiding should begin. Represents
+                the level that is most zoomed in. If None, then will use the zoom level from
+                :meth:`~geopyspark.geotrellis.rdd.TiledRasterRDD.zoom_level`.
             resample_method (str, optional): The resample method to use for the reprojection.
                 This is represented by the following constants: ``NEARESTNEIGHBOR``, ``BILINEAR``,
                 ``CUBICCONVOLUTION``, ``LANCZOS``, ``AVERAGE``, ``MODE``, ``MEDIAN``, ``MAX``, and
@@ -730,6 +731,13 @@ class TiledRasterRDD(CachableRDD):
 
         if (num_cols & (num_cols - 1)) != 0 or (num_rows & (num_rows - 1)) != 0:
             raise ValueError("Tiles must have a col and row count that is a power of 2")
+
+        if start_zoom:
+            start_zoom = start_zoom
+        elif self.zoom_level:
+            start_zoom = self.zoom_level
+        else:
+            raise ValueError("No start_zoom given.")
 
         result = self.srdd.pyramid(start_zoom, end_zoom, resample_method)
 

--- a/geopyspark/tests/pyramiding_test.py
+++ b/geopyspark/tests/pyramiding_test.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from geopyspark.geotrellis import Extent, TileLayout
-from geopyspark.geotrellis.constants import SPATIAL
+from geopyspark.geotrellis.constants import SPATIAL, ZOOM
 from geopyspark.geotrellis.rdd import RasterRDD
 from geopyspark.tests.base_test_class import BaseTestClass
 
@@ -35,6 +35,28 @@ class PyramidingTest(BaseTestClass):
         laid_out = raster_rdd.tile_to_layout(metadata)
 
         result = laid_out.pyramid(start_zoom=5, end_zoom=1)
+
+        self.pyramid_building_check(result)
+
+    def test_no_start_zoom(self):
+        arr = np.zeros((1, 16, 16))
+        epsg_code = 3857
+        extent = Extent(0.0, 0.0, 10.0, 10.0)
+
+        tile = {'data': arr, 'no_data_value': False}
+        projected_extent = {'extent': extent, 'epsg': epsg_code}
+
+        rdd = BaseTestClass.geopysc.pysc.parallelize([(projected_extent, tile)])
+        raster_rdd = RasterRDD.from_numpy_rdd(BaseTestClass.geopysc, SPATIAL, rdd)
+        tile_layout = TileLayout(32, 32, 16, 16)
+        new_extent = Extent(-20037508.342789244, -20037508.342789244, 20037508.342789244,
+                            20037508.342789244)
+
+        metadata = raster_rdd.collect_metadata(extent=new_extent, layout=tile_layout)
+        laid_out = raster_rdd.tile_to_layout(metadata)
+        reprojected = laid_out.reproject(3857, scheme=ZOOM)
+
+        result = reprojected.pyramid(end_zoom=1)
 
         self.pyramid_building_check(result)
 


### PR DESCRIPTION
This PR makes it so that a use doesn't have to input a `start_zoom` when pyramiding if their particular instance of `TiledRasterRDD` already has a `zoom_level`.

This Pr resolves #251 