### PR TITLE
Fixed Error Message in _create_catalog

### DIFF
--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -110,7 +110,7 @@ def _construct_catalog(geopysc, new_uri, options):
                                                   split_parameters[2])
 
         else:
-            raise ValueError("Cannot find Attribute Store for, {}".format(backend))
+            raise ValueError("Cannot find Attribute Store for", backend)
 
         _mapped_cached[new_uri] = _cached(store=store,
                                           reader=reader,


### PR DESCRIPTION
This PR fixes the output of the `ValueError` message in the `_create_catalog` function.

What it showed before:

```
ValueError("Cannot find Attribute Store for, {}")
```

What it shows now:

```
ValueError("Cannot find Attribute Store for, fiel")
```