### PR TITLE
Better Imports

### DIFF
--- a/docker/notebooks/Chattanooga Ingest.ipynb
+++ b/docker/notebooks/Chattanooga Ingest.ipynb
@@ -10,10 +10,9 @@
    "source": [
     "from pyspark import SparkContext\n",
     "from geopyspark.geopycontext import GeoPyContext\n",
+    "from geopyspark.geotrellis import SPATIAL, ZOOM, RasterRDD, TiledRasterRDD\n",
     "from geopyspark.geotrellis.catalog import read, read_value, query, write\n",
-    "from geopyspark.geotrellis.constants import SPATIAL, ZOOM, TILE\n",
     "from geopyspark.geotrellis.geotiff_rdd import get\n",
-    "from geopyspark.geotrellis.rdd import RasterRDD, TiledRasterRDD\n",
     "from geonotebook.vis.geotrellis.render_methods import single_band_render_from_color_map\n",
     "from geonotebook.wrappers import GeoTrellisCatalogLayerData, RddRasterData\n",
     "import numpy as np"
@@ -33,7 +32,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Gather GeoTiffs\n",
@@ -53,7 +54,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Get the mask\n",
@@ -64,7 +67,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from functools import partial\n",
@@ -144,7 +149,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "for layer in layers:\n",
@@ -167,7 +174,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "M.set_center(-85.2935099666654, 35.20529964318362, 9)"
@@ -176,7 +185,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "cmap = { 0 : \"#000000FF\", 1: \"#FF9D57FF\", -128: \"#00000000\" }\n",
@@ -194,7 +205,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "M.remove_layer(M.layers[0])"
@@ -203,7 +216,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# debug\n",
@@ -216,7 +231,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "M.layers"
@@ -234,9 +251,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "GeoNotebook + GeoPySpark (local)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "geonotebook3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -248,7 +265,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.5"
+   "version": "3.5.1+"
   }
  },
  "nbformat": 4,

--- a/docker/notebooks/Chattanooga Weighted Overlay.ipynb
+++ b/docker/notebooks/Chattanooga Weighted Overlay.ipynb
@@ -4,17 +4,17 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
     "from pyspark import SparkContext\n",
     "from geopyspark.geopycontext import GeoPyContext\n",
+    "from geopyspark.geotrellis import SPATIAL, ZOOM, RasterRDD, TiledRasterRDD, PngRDD\n",
+    "from geopyspark.geotrellis.constants import HEATMAP_YELLOW_TO_RED\n",
     "from geopyspark.geotrellis.catalog import read, read_value, query, write\n",
-    "from geopyspark.geotrellis.constants import SPATIAL, ZOOM, TILE, HEATMAP_YELLOW_TO_RED\n",
     "from geopyspark.geotrellis.geotiff_rdd import get\n",
-    "from geopyspark.geotrellis.rdd import RasterRDD, TiledRasterRDD\n",
-    "from geopyspark.geotrellis.render import PngRDD, get_hex\n",
+    "from geopyspark.geotrellis.render import get_hex\n",
     "from geonotebook.vis.geotrellis.render_methods import single_band_render_from_color_map\n",
     "from geonotebook.wrappers import GeoTrellisCatalogLayerData, RddRasterData\n",
     "from functools import reduce\n",

--- a/docker/notebooks/NLCD viewer.ipynb
+++ b/docker/notebooks/NLCD viewer.ipynb
@@ -10,10 +10,9 @@
    "source": [
     "from pyspark import SparkContext\n",
     "from geopyspark.geopycontext import GeoPyContext\n",
+    "from geopyspark.geotrellis import SPATIAL, ZOOM, RasterRDD, TiledRasterRDD\n",
     "from geopyspark.geotrellis.catalog import read, read_value, query, write\n",
-    "from geopyspark.geotrellis.constants import SPATIAL, ZOOM, TILE\n",
     "from geopyspark.geotrellis.geotiff_rdd import get\n",
-    "from geopyspark.geotrellis.rdd import RasterRDD, TiledRasterRDD\n",
     "from geonotebook.vis.geotrellis.render_methods import render_nlcd, single_band_render_from_color_map\n",
     "from geonotebook.wrappers import GeoTrellisCatalogLayerData, RddRasterData\n",
     "import numpy as np"
@@ -29,7 +28,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "M.set_center(-120.32, 47.84, 7)"
@@ -76,7 +77,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from geonotebook.vis.geotrellis.render_methods import render_nlcd\n",
@@ -94,7 +97,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def reclass(tile):\n",
@@ -116,7 +121,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "M.remove_layer(M.layers[0])"
@@ -125,7 +132,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "M.add_layer(data, render_tile=reclass_render)"
@@ -141,7 +150,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "!curl -o /tmp/mask.json https://s3.amazonaws.com/chattademo/chatta_mask.json"
@@ -150,7 +161,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from functools import partial\n",
@@ -176,7 +189,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "M.remove_layer(M.layers[0])"
@@ -185,7 +200,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from geonotebook.wrappers import VectorData\n",
@@ -197,7 +214,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "M.set_center(center.x, center.y, 9)"
@@ -226,7 +245,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "masked = converted_rdd.mask([chatta_poly])\n",
@@ -236,7 +257,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "M.remove_layer(M.layers[0])"
@@ -245,7 +268,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "M.add_layer(rd, render_tile=render_nlcd)"
@@ -261,7 +286,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "nprdd = converted_rdd.to_numpy_rdd()"
@@ -314,7 +341,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "M.remove_layer(M.layers[0])"
@@ -323,7 +352,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "M.add_layer(rd, render_tile=render_tile)"
@@ -362,7 +393,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "for layer_rdd in retiled.pyramid(retiled.zoom_level, 0):\n",
@@ -393,7 +426,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "M.remove_layer(M.layers[0])"
@@ -402,7 +437,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "M.add_layer(data, render_tile=render_tile)"
@@ -411,9 +448,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "GeoNotebook + GeoPySpark (local)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "geonotebook3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -425,7 +462,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.5"
+   "version": "3.5.1+"
   }
  },
  "nbformat": 4,

--- a/docker/notebooks/Park siting.ipynb
+++ b/docker/notebooks/Park siting.ipynb
@@ -9,10 +9,9 @@
    "outputs": [],
    "source": [
     "from geopyspark.geopycontext import GeoPyContext\n",
-    "from geopyspark.geotrellis.constants import SPATIAL, NODATAINT, MAX, SQUARE, EXACT, ZOOM\n",
-    "from geopyspark.geotrellis.rdd import TiledRasterRDD\n",
+    "from geopyspark.geotrellis import SPATIAL, TiledRasterRDD, PngRDD, ZOOM\n",
+    "from geopyspark.geotrellis.constants import NODATAINT, MAX, SQUARE, EXACT\n",
     "from geopyspark.geotrellis.geotiff_rdd import get\n",
-    "from geopyspark.geotrellis.render import PngRDD\n",
     "from geonotebook.wrappers import RddRasterData, VectorData"
    ]
   },
@@ -30,7 +29,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "M.set_center(-122.1, 37.75, 10)"
@@ -51,7 +52,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "!curl -o /tmp/bart.geojson https://s3.amazonaws.com/geopyspark-demo/bayarea/bart.geojson\n",
@@ -107,7 +110,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "bart_layer.persist(StorageLevel.MEMORY_AND_DISK)\n",
@@ -129,7 +134,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "weighted_layer.persist(StorageLevel.MEMORY_AND_DISK)"
@@ -150,7 +157,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "png_layer.cache()"
@@ -160,6 +169,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "scrolled": true
    },
    "outputs": [],
@@ -205,9 +215,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "GeoNotebook + GeoPySpark (local)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "geonotebook3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -219,7 +229,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.5"
+   "version": "3.5.1+"
   }
  },
  "nbformat": 4,

--- a/docker/notebooks/TMS Server Demo.ipynb
+++ b/docker/notebooks/TMS Server Demo.ipynb
@@ -2,15 +2,15 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
     "from geopyspark.geopycontext import GeoPyContext\n",
-    "from geopyspark.geotrellis.constants import SPATIAL, NODATAINT, MAX, SQUARE, EXACT\n",
-    "from geopyspark.geotrellis.rdd import TiledRasterRDD\n",
+    "from geopyspark.geotrellis import SPATIAL, TiledRasterRDD\n",
+    "from geopyspark.geotrellis.constants import NODATAINT, MAX, SQUARE, EXACT\n",
     "\n",
     "import json\n",
     "import shapely\n",
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -58,27 +58,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Added TMS server at port 60116\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<promise.promise.Promise at 0x7efffa800f98>"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
    "source": [
     "M.add_layer(TMSRasterData(nlcd), name=\"nlcd\")"
    ]
@@ -92,51 +76,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {
+    "collapsed": false,
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<promise.promise.Promise at 0x7efff93850b8>"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "M.set_center(-85.2934168635424, 35.02445474101138, 9)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
-      "                                 Dload  Upload   Total   Spent    Left  Speed\n",
-      "100  881k  100  881k    0     0  1258k      0 --:--:-- --:--:-- --:--:-- 1257k\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<promise.promise.Promise at 0x7f00261d2e10>"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
    "source": [
     "!curl -o /tmp/mask.json https://s3.amazonaws.com/chattademo/chatta_mask.json\n",
     "\n",
@@ -149,7 +105,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from functools import partial\n",
@@ -174,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -200,47 +158,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(12.0, 96.0)"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
    "source": [
     "chatta_rdd.get_min_max()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Extent(xmin=-14465321.514629832, ymin=2479844.762589966, xmax=-7084112.559414816, ymax=6960327.26565533)"
-      ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
    "source": [
     "chatta_rdd.layer_metadata.extent"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -252,7 +192,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "GeoNotebook + GeoPySpark (local)",
+   "display_name": "Geonotebook (Python 3)",
    "language": "python",
    "name": "geonotebook3"
   },
@@ -266,7 +206,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.5"
+   "version": "3.5.1+"
   }
  },
  "nbformat": 4,

--- a/docker/notebooks/mvp.ipynb
+++ b/docker/notebooks/mvp.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -24,9 +24,8 @@
     "from pyspark.conf import SparkConf\n",
     "from pyspark import StorageLevel\n",
     "from geopyspark.geopycontext import GeoPyContext\n",
-    "from geopyspark.geotrellis import Extent\n",
-    "from geopyspark.geotrellis.rdd import TiledRasterRDD, Pyramid\n",
-    "from geopyspark.geotrellis.color import get_breaks, ColorMap\n",
+    "from geopyspark.geotrellis import Extent, TiledRasterRDD, Pyramid, ColorMap\n",
+    "from geopyspark.geotrellis.color import get_breaks\n",
     "from geopyspark.geotrellis.constants import *\n",
     "import json\n",
     "import shapely\n",
@@ -52,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": true,
     "scrolled": true
@@ -69,20 +68,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Extent(xmin=640503.71, ymin=2086100.24, xmax=3047702.11, ymax=3998370.3)"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
    "source": [
     "# Try to be friedly with python libraries like shapely\n",
     "from geopyspark import geotrellis\n",
@@ -92,20 +82,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Bounds(minKey=SpatialKey(col=132, row=102), maxKey=SpatialKey(col=147, row=114))"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
    "source": [
     "# All execution time here is sending WKB over py4j socket\n",
     "from geopyspark.geotrellis.rdd import rasterize\n",
@@ -131,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -144,27 +125,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Added TMS server at port 60190\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<promise.promise.Promise at 0x7f6dc65bc9e8>"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
    "source": [
     "from geopyspark.geotrellis.tms import *\n",
     "from geonotebook.wrappers.raster import TMSRasterData\n",
@@ -197,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -214,7 +179,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# starting points for cost distance operation\n",
@@ -230,20 +197,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<promise.promise.Promise at 0x7f0ef12f27f0>"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
    "source": [
     "from geonotebook.wrappers import VectorData\n",
     "M.add_layer(VectorData(\"population.geojson\"), name=\"Population\")"
@@ -251,7 +209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -271,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -289,7 +247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -304,7 +262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -316,27 +274,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Added TMS server at port 64841\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<promise.promise.Promise at 0x7fac4daac0f0>"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
    "source": [
     "weighted_overlay = (con_pp * 0.0) + (pop_pp * 1.0)\n",
     "\n",
@@ -346,20 +288,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<promise.promise.Promise at 0x7fac4da5df28>"
-      ]
-     },
-     "execution_count": 29,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
    "source": [
     "# remove the next to last layer\n",
     "M.remove_layer(M.layers[-2])"
@@ -368,7 +301,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "GeoNotebook + GeoPySpark (local)",
+   "display_name": "Geonotebook (Python 3)",
    "language": "python",
    "name": "geonotebook3"
   },
@@ -382,7 +315,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.5"
+   "version": "3.5.1+"
   }
  },
  "nbformat": 4,

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -72,8 +72,6 @@ class Extent(namedtuple("Extent", 'xmin ymin xmax ymax')):
 class ProjectedExtent(namedtuple("ProjectedExtent", 'extent epsg proj4')):
     """Describes both the area on Earth a raster represents in addition to its CRS.
 
-    Args:
-        extent (:class:`~geopyspark.geotrellis.Extent`): The area the raster represents.
         epsg (int, optional): The EPSG code of the CRS.
         proj4 (str, optional): The Proj.4 string representation of the CRS.
 
@@ -347,3 +345,19 @@ class Metadata(object):
                 "layoutDefinition={})").format(self.bounds, self.cell_type,
                                                self.crs, self.extent,
                                                self.tile_layout, self.layout_definition)
+
+
+from geopyspark.geotrellis.constants import SPATIAL, SPACETIME, ZOOM
+from geopyspark.geotrellis.protobufserializer import ProtoBufSerializer
+from geopyspark.geotrellis.neighborhoods import (Square, Circle,
+                                                 Nesw, Wedge, Annulus)
+from geopyspark.geotrellis.rdd import RasterRDD, TiledRasterRDD
+from geopyspark.geotrellis.render import PngRDD
+
+
+__all__ = ["Extent", "ProjectedExtent", "TemporalProjectedExtent",
+           "TileLayout", "LayoutDefinition", "SpatialKey",
+           "SpaceTimeKey", "Bounds", "Metadata", "RasterRDD",
+           "TiledRasterRDD", "PngRDD", "ProtoBufSerializer",
+           "Square", "Circle", "Nesw", "Wedge", "Annulus",
+           "SPATIAL", "SPACETIME", "ZOOM"]

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -348,16 +348,17 @@ class Metadata(object):
 
 
 from geopyspark.geotrellis.constants import SPATIAL, SPACETIME, ZOOM
+from geopyspark.geotrellis.color import ColorMap
 from geopyspark.geotrellis.protobufserializer import ProtoBufSerializer
 from geopyspark.geotrellis.neighborhoods import (Square, Circle,
                                                  Nesw, Wedge, Annulus)
-from geopyspark.geotrellis.rdd import RasterRDD, TiledRasterRDD
+from geopyspark.geotrellis.rdd import RasterRDD, TiledRasterRDD, Pyramid
 from geopyspark.geotrellis.render import PngRDD
 
 
 __all__ = ["Extent", "ProjectedExtent", "TemporalProjectedExtent",
            "TileLayout", "LayoutDefinition", "SpatialKey",
            "SpaceTimeKey", "Bounds", "Metadata", "RasterRDD",
-           "TiledRasterRDD", "PngRDD", "ProtoBufSerializer",
-           "Square", "Circle", "Nesw", "Wedge", "Annulus",
-           "SPATIAL", "SPACETIME", "ZOOM"]
+           "TiledRasterRDD", "Pyramid", "PngRDD", "ColorMap",
+           "ProtoBufSerializer", "Square", "Circle", "Nesw",
+           "Wedge", "Annulus", "SPATIAL", "SPACETIME", "ZOOM"]

--- a/geopyspark/geotrellis/protobufcodecs.py
+++ b/geopyspark/geotrellis/protobufcodecs.py
@@ -6,7 +6,6 @@ check_environment()
 
 from geopyspark.geotrellis import (Extent, ProjectedExtent, TemporalProjectedExtent, SpatialKey,
                                    SpaceTimeKey)
-
 from geopyspark.geotrellis.protobuf.tileMessages_pb2 import (ProtoTile, ProtoMultibandTile,
                                                              ProtoCellType)
 from geopyspark.geotrellis.protobuf import keyMessages_pb2

--- a/geopyspark/geotrellis/render.py
+++ b/geopyspark/geotrellis/render.py
@@ -4,7 +4,7 @@ check_environment()
 from geopyspark.geotrellis.constants import RESAMPLE_METHODS, NEARESTNEIGHBOR, ZOOM, COLOR_RAMPS
 from .rdd import CachableRDD
 from pyspark.storagelevel import StorageLevel
-import geopyspark.geotrellis.color as color
+from geopyspark.geotrellis import color
 from geopyspark.geotrellis import deprecated
 
 @deprecated

--- a/geopyspark/tests/geotiff_raster_rdd_test.py
+++ b/geopyspark/tests/geotiff_raster_rdd_test.py
@@ -4,10 +4,10 @@ import rasterio
 import pytest
 import numpy as np
 
-from geopyspark.geotrellis.constants import SPATIAL, INT32, BOOLRAW
+from geopyspark.geotrellis import SPATIAL, RasterRDD
+from geopyspark.geotrellis.constants import INT32, BOOLRAW
 from geopyspark.tests.python_test_utils import geotiff_test_path
 from geopyspark.geotrellis.geotiff_rdd import get
-from geopyspark.geotrellis.rdd import RasterRDD
 from geopyspark.tests.base_test_class import BaseTestClass
 
 


### PR DESCRIPTION
This PR supersedes #255 . It is now possible to import `ProtoBufSerializer`, `SPATIAL`, `SPACETIME`, `ZOOM`, `RasterRDD`, `TiledRasterRDD`, `PngRDD`, `Square`, `Circle`, `Nesw`, `Wedge`, and `Annulus` directly from `geopyspark.geotrellis`.

Before:
```python
from geopyspark.geotrellis.constants import SPATIAL, ZOOM, SLOPE
from geopyspark.geotrellis.neighborhoods import Square
from geopyspark.geotrellis.rdd import TiledRasterRDD
from geopyspark.geotrellis.render import PngRDD
```

Now:
```python
from geopyspark.geotrellis import SPATIAL, ZOOM, Square, TiledRasterRDD, PngRDD
from geopyspark.geotrellis.constants import SLOPE
```

This PR should be merged after #245