### PR TITLE
Better checking in Reclassify

### DIFF
--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -58,12 +58,14 @@ def _reclassify(srdd, value_map, data_type, boundary_strategy, replace_nodata_wi
     new_dict = {}
 
     for key, value in value_map.items():
-        if not isinstance(key, data_type):
+        if isinstance(key, data_type):
+            new_dict[key] = value
+        elif isinstance(key, (list, tuple)):
             val = value_map[key]
             for k in key:
                 new_dict[k] = val
         else:
-            new_dict[key] = value
+            raise TypeError("Expected", data_type, "list, or tuple for the key, but the type was", type(key))
 
     if data_type is int:
         if not replace_nodata_with:


### PR DESCRIPTION
This PR adds better type checking to the `reclassify` method. Now, the inputted value will be checked to see if its type is either `data_type`, `tuple`, or `list`. If it's none of those, then a more helpful error message will be given.

This PR resolves #254 