### PR TITLE
Save Stitched and Normalize Methods

### DIFF
--- a/geopyspark-backend/project/Version.scala
+++ b/geopyspark-backend/project/Version.scala
@@ -1,14 +1,8 @@
 object Version {
   val geopyspark = "0.1.0"
-<<<<<<< 5c9d487da75c4c6611616b3ea668afe887d8681c
   val geotrellis = "1.2.0-M1-SNAPSHOT"
-  val scala       = "2.11.8"
-  val crossScala  = Seq("2.11.8", "2.10.6")
-=======
-  val geotrellis = "1.1.0-RC6"
   val scala       = "2.11.11"
   val crossScala  = Seq("2.11.11", "2.10.6")
->>>>>>> Added save_stitched
   val scalaTest   = "2.2.0"
   val akka        = "2.4.3"
 }

--- a/geopyspark-backend/project/Version.scala
+++ b/geopyspark-backend/project/Version.scala
@@ -1,8 +1,14 @@
 object Version {
   val geopyspark = "0.1.0"
+<<<<<<< 5c9d487da75c4c6611616b3ea668afe887d8681c
   val geotrellis = "1.2.0-M1-SNAPSHOT"
   val scala       = "2.11.8"
   val crossScala  = Seq("2.11.8", "2.10.6")
+=======
+  val geotrellis = "1.1.0-RC6"
+  val scala       = "2.11.11"
+  val crossScala  = Seq("2.11.11", "2.10.6")
+>>>>>>> Added save_stitched
   val scalaTest   = "2.2.0"
   val akka        = "2.4.3"
 }

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -788,6 +788,30 @@ class TiledRasterRDD(CachableRDD):
         ser = ProtoBufSerializer.create_value_serializer(TILE)
         return ser.loads(value)[0]
 
+    def save_stitched(self, path, crop_bounds=None):
+        """Stitch all of the rasters within the RDD into one raster.
+
+        Args:
+            path: The path of the geotiff to save.
+            crop_bounds: Optional bounds with which to crop the raster before saving.
+
+        Note:
+            This can only be used on `SPATIAL` TiledRasterRDDs.
+
+        Returns:
+            None
+        """
+
+        if self.rdd_type != SPATIAL:
+            raise ValueError("Only TiledRasterRDDs with a rdd_type of Spatial can use stitch()")
+
+        if crop_bounds:
+            self.srdd.save_stitched(path, list(crop_bounds))
+        else:
+            self.srdd.save_stitched(path)
+
+        return None
+
     def mask(self, geometries):
         """Masks the ``TiledRasterRDD`` so that only values that intersect the geometries will
         be available.

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -419,7 +419,6 @@ class RasterRDD(CachableRDD):
         min_max = self.srdd.getMinMax()
         return (min_max._1(), min_max._2())
 
-
 class TiledRasterRDD(CachableRDD):
     """Wraps a RDD of tiled, GeoTrellis rasters.
 
@@ -788,12 +787,13 @@ class TiledRasterRDD(CachableRDD):
         ser = ProtoBufSerializer.create_value_serializer(TILE)
         return ser.loads(value)[0]
 
-    def save_stitched(self, path, crop_bounds=None):
+    def save_stitched(self, path, crop_bounds=None, crop_dimensions=None):
         """Stitch all of the rasters within the RDD into one raster.
 
         Args:
             path: The path of the geotiff to save.
             crop_bounds: Optional bounds with which to crop the raster before saving.
+            crop_dimensions: Optional cols and rows of the image to save
 
         Note:
             This can only be used on `SPATIAL` TiledRasterRDDs.
@@ -806,7 +806,12 @@ class TiledRasterRDD(CachableRDD):
             raise ValueError("Only TiledRasterRDDs with a rdd_type of Spatial can use stitch()")
 
         if crop_bounds:
-            self.srdd.save_stitched(path, list(crop_bounds))
+            if crop_dimensions:
+                self.srdd.save_stitched(path, list(crop_bounds), list(crop_dimensions))
+            else:
+                self.srdd.save_stitched(path, list(crop_bounds))
+        elif crop_dimensions:
+            raise Exception("crop_dimensions requires crop_bounds")
         else:
             self.srdd.save_stitched(path)
 
@@ -918,6 +923,21 @@ class TiledRasterRDD(CachableRDD):
         """
         min_max = self.srdd.getMinMax()
         return (min_max._1(), min_max._2())
+
+    def normalize(self, old_min, old_max, new_min, new_max):
+        """Finds the min value that is contained within the given geometry.
+
+        Args:
+            old_min (float): Old minimum.
+            old_max (float): Old maximum.
+            new_min (float): New minimum to normalize to.
+            new_max (float): New maximum to normalize to.
+        Returns:
+            :class:`~geopyspark.geotrellis.rdd.TiledRasterRDD`
+        """
+        srdd = self.srdd.normalize(old_min, old_max, new_min, new_max)
+
+        return TiledRasterRDD(self.geopysc, self.rdd_type, srdd)
 
     @staticmethod
     def _process_polygonal_summary(geometry, operation):


### PR DESCRIPTION
This PR supersedes #218. The `save_stitched` and `normalize` methods have been taken from the aforementioned PR and placed into this one with the other changes being discarded.