### PR TITLE
WKB for Sending Geometries to Scala instead of WKT

### DIFF
--- a/docs/docs/geopyspark.geotrellis.rst
+++ b/docs/docs/geopyspark.geotrellis.rst
@@ -9,7 +9,7 @@ geopyspark.geotrellis package
 geopyspark.geotrellis.ProtoBufCodecs module
 ----------------------------------------------
 
-.. autoclass:: geopyspark.geotrellis.protobufcodecs
+.. autoclass:: geopyspark.geotrellis.protobuf
    :members:
 
 geopyspark.geotrellis.ProtoBufSerializer module

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -371,19 +371,20 @@ def query(geopysc,
             catalog to be read from. The shape of this string varies depending on backend.
         layer_name (str): The name of the GeoTrellis catalog to be querried.
         layer_zoom (int): The zoom level of the layer that is to be querried.
-        intersects (str or Polygon or :class:`~geopyspark.geotrellis.data_structures.Extent`): The
-            desired spatial area to be returned. Can either be a string, a shapely Polygon, or an
-            instance of ``Extent``. If the value is a string, it must be the WKT string, geometry
-            format.
+        intersects (bytes or shapely.geometry or :class:`~geopyspark.geotrellis.data_structures.Extent`):
+            The desired spatial area to be returned. Can either be a string, a shapely geometry, or
+            instance of ``Extent``, or a WKB verson of the geometry.
 
-            The types of Polygons supported:
+            Note:
+                Not all shapely geometires are supported. The following is are the types that are
+                supported:
                 * Point
                 * Polygon
                 * MultiPolygon
 
             Note:
-                Only layers that were made from spatial, singleband GeoTiffs can query a Point.
-                All other types are restricted to Polygon and MulitPolygon.
+                Only layers that were made from spatial, singleband GeoTiffs can query a ``Point``.
+                All other types are restricted to ``Polygon`` and ``MulitPolygon``.
         time_intervals (list, optional): A list of strings that time intervals to query.
             The strings must be in a valid date-time format. This parameter is only used when
             querying spatial-temporal data. The default value is, None. If None, then only the

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -12,6 +12,7 @@ from geopyspark.geotrellis.constants import TILE, ZORDER, SPATIAL
 
 from shapely.geometry import Polygon, MultiPolygon, Point
 from shapely.wkt import dumps
+import shapely.wkb
 
 
 _mapped_cached = {}
@@ -420,14 +421,13 @@ def query(geopysc,
         proj_query = "EPSG:" + str(proj_query)
 
     if numPartitions is None:
-        numPartitions  = geopysc.pysc.defaultMinPartitions
+        numPartitions = geopysc.pysc.defaultMinPartitions
 
-    if isinstance(intersects, Polygon) or isinstance(intersects, MultiPolygon) \
-       or isinstance(intersects, Point):
+    if isinstance(intersects, (Polygon, MultiPolygon, Point)):
         srdd = cached.reader.query(key,
                                    layer_name,
                                    layer_zoom,
-                                   dumps(intersects),
+                                   shapely.wkb.dumps(intersects),
                                    time_intervals,
                                    proj_query,
                                    numPartitions)
@@ -436,12 +436,12 @@ def query(geopysc,
         srdd = cached.reader.query(key,
                                    layer_name,
                                    layer_zoom,
-                                   dumps(intersects.to_poly),
+                                   shapely.wkb.dumps(intersects.to_poly),
                                    time_intervals,
                                    proj_query,
                                    numPartitions)
 
-    elif isinstance(intersects, str):
+    elif isinstance(intersects, bytes):
         srdd = cached.reader.query(key,
                                    layer_name,
                                    layer_zoom,

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -4,7 +4,6 @@ wrappers of their Scala counterparts. These will be used in leau of actual PySpa
 when performing operations.
 '''
 import json
-import shapely.wkt
 import shapely.wkb
 from geopyspark.geotrellis.protobufcodecs import multibandtile_decoder
 from geopyspark.geotrellis.protobufserializer import ProtoBufSerializer
@@ -13,7 +12,6 @@ check_environment()
 
 from pyspark.storagelevel import StorageLevel
 from shapely.geometry import Polygon, MultiPolygon
-from shapely.wkt import dumps
 from geopyspark.geotrellis import Metadata
 from geopyspark.geotrellis.constants import (RESAMPLE_METHODS,
                                              OPERATIONS,
@@ -522,7 +520,11 @@ class TiledRasterRDD(CachableRDD):
         if isinstance(source_crs, int):
             source_crs = str(source_crs)
 
-        srdd = geopysc._jvm.geopyspark.geotrellis.SpatialTiledRasterRDD.euclideanDistance(geopysc.sc, dumps(geometry), source_crs, cellType, zoom)
+        srdd = geopysc._jvm.geopyspark.geotrellis.SpatialTiledRasterRDD.euclideanDistance(geopysc.sc,
+                                                                                          shapely.wkb.dumps(geometry),
+                                                                                          source_crs,
+                                                                                          cellType,
+                                                                                          zoom)
         return cls(geopysc, SPATIAL, srdd)
 
     def to_numpy_rdd(self):
@@ -805,8 +807,8 @@ class TiledRasterRDD(CachableRDD):
 
         if not isinstance(geometries, list):
             geometries = [geometries]
-        wkts = [shapely.wkt.dumps(g) for g in geometries]
-        srdd = self.srdd.mask(wkts)
+        wkbs = [shapely.wkb.dumps(g) for g in geometries]
+        srdd = self.srdd.mask(wkbs)
 
         return TiledRasterRDD(self.geopysc, self.rdd_type, srdd)
 
@@ -826,8 +828,8 @@ class TiledRasterRDD(CachableRDD):
             :class:`~geopyspark.geotrellis.rdd.TiledRasterRDD`
         """
 
-        wkts = [shapely.wkt.dumps(g) for g in geometries]
-        srdd = self.srdd.costDistance(self.geopysc.sc, wkts, float(max_distance))
+        wkbs = [shapely.wkb.dumps(g) for g in geometries]
+        srdd = self.srdd.costDistance(self.geopysc.sc, wkbs, float(max_distance))
 
         return TiledRasterRDD(self.geopysc, self.rdd_type, srdd)
 
@@ -898,9 +900,7 @@ class TiledRasterRDD(CachableRDD):
     @staticmethod
     def _process_polygonal_summary(geometry, operation):
         if isinstance(geometry, Polygon) or isinstance(geometry, MultiPolygon):
-            geometry = dumps(geometry)
-        if not isinstance(geometry, str):
-            raise ValueError("geometry must be either a Polygon, MultiPolygon, or a String")
+            geometry = shapely.wkb.dumps(geometry)
 
         return operation(geometry)
 

--- a/geopyspark/geotrellis/rdd.py
+++ b/geopyspark/geotrellis/rdd.py
@@ -35,7 +35,7 @@ def rasterize(geopysc, geoms, crs, zoom, fill_value, cell_type='float64', option
 
     Args:
         geopysc (:class:`~geopyspark.GeoPyContext`): The ``GeoPyContext`` instance.
-        geoms (shapely.geometry): List of geometries to rasterize.
+        geoms ([shapely.geometry]): List of shapely geometries to rasterize.
         crs (str or int): The CRS of the input geometry.
         zoom (int): The zoom level of the output raster.
         fill_value: Value to burn into pixels intersectiong geometry
@@ -795,8 +795,8 @@ class TiledRasterRDD(CachableRDD):
         be available.
 
         Args:
-            geometries (list):
-                A list of shapely geometries to use as masks.
+            geometries (shapely.geometry or [shapely.geometry]): Either a list of, or a single
+                shapely geometry/ies to use for the mask/s.
 
                 Note:
                     All geometries must be in the same CRS as the TileLayer.
@@ -899,8 +899,10 @@ class TiledRasterRDD(CachableRDD):
 
     @staticmethod
     def _process_polygonal_summary(geometry, operation):
-        if isinstance(geometry, Polygon) or isinstance(geometry, MultiPolygon):
+        if isinstance(geometry, (Polygon, MultiPolygon)):
             geometry = shapely.wkb.dumps(geometry)
+        if not isinstance(geometry, bytes):
+            raise TypeError("Expected geometry to be bytes but given this instead", type(geometry))
 
         return operation(geometry)
 
@@ -908,9 +910,9 @@ class TiledRasterRDD(CachableRDD):
         """Finds the min value that is contained within the given geometry.
 
         Args:
-            geometry (`shapely.geometry.Polygon` or `shapely.geometry.MultiPolygon` or str): A
+            geometry (shapely.geometry.Polygon or shapely.geometry.MultiPolygon or bytes): A
                 Shapely ``Polygon`` or ``MultiPolygon`` that represents the area where the summary
-                should be computed; or a WKT string representation of the geometry.
+                should be computed; or a WKB representation of the geometry.
             data_type (type): The type of the values within the rasters. Can either be ``int`` or
                 ``float``.
 
@@ -932,9 +934,9 @@ class TiledRasterRDD(CachableRDD):
         """Finds the max value that is contained within the given geometry.
 
         Args:
-            geometry (`shapely.geometry.Polygon` or `shapely.geometry.MultiPolygon` or str): A
+            geometry (shapely.geometry.Polygon or shapely.geometry.MultiPolygon or bytes): A
                 Shapely ``Polygon`` or ``MultiPolygon`` that represents the area where the summary
-                should be computed; or a WKT string representation of the geometry.
+                should be computed; or a WKB representation of the geometry.
             data_type (type): The type of the values within the rasters. Can either be ``int`` or
                 ``float``.
 
@@ -956,9 +958,9 @@ class TiledRasterRDD(CachableRDD):
         """Finds the sum of all of the values that are contained within the given geometry.
 
         Args:
-            geometry (`shapely.geometry.Polygon` or `shapely.geometry.MultiPolygon` or str): A
+            geometry (shapely.geometry.Polygon or shapely.geometry.MultiPolygon or bytes): A
                 Shapely ``Polygon`` or ``MultiPolygon`` that represents the area where the summary
-                should be computed; or a WKT string representation of the geometry.
+                should be computed; or a WKB representation of the geometry.
             data_type (type): The type of the values within the rasters. Can either be ``int`` or
                 ``float``.
 
@@ -980,9 +982,9 @@ class TiledRasterRDD(CachableRDD):
         """Finds the mean of all of the values that are contained within the given geometry.
 
         Args:
-            geometry (`shapely.geometry.Polygon` or `shapely.geometry.MultiPolygon` or str): A
+            geometry (shapely.geometry.Polygon or shapely.geometry.MultiPolygon or bytes): A
                 Shapely ``Polygon`` or ``MultiPolygon`` that represents the area where the summary
-                should be computed; or a WKT string representation of the geometry.
+                should be computed; or a WKB representation of the geometry.
 
         Returns:
             ``float``


### PR DESCRIPTION
As pointed out in this issue #256, sending dumped, `shapely.wkb` bytes is faster than sending dumped, `shapely.wkt` strings to Scala. This Pr implements this change throughout the entire library.

This Pr resolves #256 