### PR TITLE
Constants Orginization

### DIFF
--- a/docs/docs/geopyspark.geotrellis.rst
+++ b/docs/docs/geopyspark.geotrellis.rst
@@ -30,6 +30,7 @@ geopyspark.geotrellis.constants module
 
 .. automodule:: geopyspark.geotrellis.constants
    :members:
+   :undoc-members:
    :inherited-members:
 
 geopyspark.geotrellis.geotiff module

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Coloring.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Coloring.scala
@@ -7,12 +7,12 @@ import geotrellis.raster.render._
 object Coloring {
   def getColorRamp(name: String): ColorRamp = {
     name match {
-      case "hot" => ColorRamps.HeatmapDarkRedToYellowWhite
-      case "coolwarm" => ColorRamps.BlueToRed
-      case "magma" => ColorRamps.Magma
-      case "inferno" => ColorRamps.Inferno
-      case "plasma" => ColorRamps.Plasma
-      case "viridis" => ColorRamps.Viridis
+      case "Hot" => ColorRamps.HeatmapDarkRedToYellowWhite
+      case "CoolWarm" => ColorRamps.BlueToRed
+      case "Magma" => ColorRamps.Magma
+      case "Inferno" => ColorRamps.Inferno
+      case "Plasma" => ColorRamps.Plasma
+      case "Viridis" => ColorRamps.Viridis
 
       case "BlueToOrange" => ColorRamps.BlueToOrange
       case "LightYellowToOrange" => ColorRamps.LightYellowToOrange

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Coloring.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Coloring.scala
@@ -26,10 +26,6 @@ object Coloring {
       case "HeatmapLightPurpleToDarkPurpleToWhite" => ColorRamps.HeatmapLightPurpleToDarkPurpleToWhite
       case "ClassificationBoldLandUse" => ColorRamps.ClassificationBoldLandUse
       case "ClassificationMutedTerrain" => ColorRamps.ClassificationMutedTerrain
-      case "Magma" => ColorRamps.Magma
-      case "Inferno" => ColorRamps.Inferno
-      case "Plasma" => ColorRamps.Plasma
-      case "Viridis" => ColorRamps.Viridis
     }
   }
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Constants.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Constants.scala
@@ -29,11 +29,11 @@ object Constants {
   final val SLOPE = "Slope"
   final val ASPECT = "Aspect"
 
-  final val ANNULUS = "annulus"
-  final val NESW = "nesw"
-  final val SQUARE = "square"
-  final val WEDGE = "wedge"
-  final val CIRCLE = "circle"
+  final val ANNULUS = "Annulus"
+  final val NESW = "Nesw"
+  final val SQUARE = "Square"
+  final val WEDGE = "Wedge"
+  final val CIRCLE = "Circle"
 
   final val GREATERTHAN = "GreaterThan"
   final val GREATERTHANOREQUALTO = "GreaterThanOrEqualTo"

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -4,7 +4,7 @@ from shapely.geometry import box
 import warnings
 import functools
 
-from geopyspark.geotrellis import constants
+from geopyspark.geotrellis.constants import CellType, NO_DATA_INT
 
 
 def deprecated(func):
@@ -308,14 +308,14 @@ class Metadata(object):
             else:
                 self.no_data_value = int(value)
         else:
-            if self.cell_type == constants.INT8:
+            if self.cell_type == CellType.INT8.value:
                 self.no_data_value = -128
-            elif self.cell_type == constants.UINT8 or self.cell_type == constants.UINT16:
+            elif self.cell_type == CellType.UINT8.value or self.cell_type == CellType.UINT16.value:
                 self.no_data_value = 0
-            elif self.cell_type == constants.INT16:
+            elif self.cell_type == CellType.INT16.value:
                 self.no_data_value = -32768
-            elif self.cell_type == constants.INT32:
-                self.no_data_value = constants.NODATAINT
+            elif self.cell_type == CellType.INT32.value:
+                self.no_data_value = NO_DATA_INT
             else:
                 self.no_data_value = float('nan')
 

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -6,10 +6,10 @@ from collections import namedtuple
 from urllib.parse import urlparse
 
 from geopyspark import map_key_input
+from geopyspark.geotrellis.constants import LayerType, IndexingMethod
 from geopyspark.geotrellis.protobufcodecs import multibandtile_decoder
 from geopyspark.geotrellis import Metadata, Extent, deprecated
 from geopyspark.geotrellis.layer import TiledRasterLayer
-from geopyspark.geotrellis.constants import ZORDER, SPATIAL
 
 from shapely.geometry import Polygon, MultiPolygon, Point
 from shapely.wkt import dumps
@@ -175,7 +175,7 @@ def read_layer_metadata(pysc,
     _construct_catalog(pysc, uri, options)
     cached = _mapped_cached[uri]
 
-    if rdd_type == SPATIAL:
+    if rdd_type == LayerType.SPATIAL:
         metadata = cached.store.metadataSpatial(layer_name, layer_zoom)
     else:
         metadata = cached.store.metadataSpaceTime(layer_name, layer_zoom)
@@ -293,7 +293,7 @@ def read_value(pysc,
         if not zdt:
             zdt = ""
 
-        key = map_key_input(rdd_type, True)
+        key = map_key_input(LayerType(rdd_type).value, True)
 
         values = cached.value_reader.readTile(key,
                                               layer_name,
@@ -375,7 +375,7 @@ def query(pysc,
 
     cached = _mapped_cached[uri]
 
-    key = map_key_input(rdd_type, True)
+    key = map_key_input(LayerType(rdd_type).value, True)
 
     if numPartitions is None:
         numPartitions = pysc.defaultMinPartitions
@@ -427,7 +427,7 @@ def query(pysc,
 def write(uri,
           layer_name,
           tiled_raster_rdd,
-          index_strategy=ZORDER,
+          index_strategy=IndexingMethod.ZORDER,
           time_unit=None,
           options=None,
           **kwargs):
@@ -468,7 +468,7 @@ def write(uri,
     if not time_unit:
         time_unit = ""
 
-    if tiled_raster_rdd.rdd_type == SPATIAL:
+    if tiled_raster_rdd.rdd_type == LayerType.SPATIAL:
         cached.writer.writeSpatial(layer_name,
                                    tiled_raster_rdd.srdd,
                                    index_strategy)

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -9,7 +9,7 @@ from geopyspark import map_key_input
 from geopyspark.geotrellis.protobufcodecs import multibandtile_decoder
 from geopyspark.geotrellis import Metadata, Extent, deprecated
 from geopyspark.geotrellis.layer import TiledRasterLayer
-from geopyspark.geotrellis.constants import TILE, ZORDER, SPATIAL
+from geopyspark.geotrellis.constants import ZORDER, SPATIAL
 
 from shapely.geometry import Polygon, MultiPolygon, Point
 from shapely.wkt import dumps

--- a/geopyspark/geotrellis/color.py
+++ b/geopyspark/geotrellis/color.py
@@ -1,7 +1,7 @@
 from geopyspark.geopyspark_utils import ensure_pyspark
 ensure_pyspark()
 
-from geopyspark.geotrellis.constants import RESAMPLE_METHODS, NEARESTNEIGHBOR, ZOOM, COLOR_RAMPS, LESSTHANOREQUALTO
+from geopyspark.geotrellis.constants import ClassificationStrategies
 
 import struct
 
@@ -124,7 +124,8 @@ class ColorMap(object):
         self.cmap = cmap
 
     @classmethod
-    def from_break_map(cls, pysc, break_map, no_data_color=0x00000000, fallback=0x00000000, class_boundary_type=LESSTHANOREQUALTO):
+    def from_break_map(cls, pysc, break_map, no_data_color=0x00000000, fallback=0x00000000,
+                       class_boundary_type=ClassificationStrategies.LESSTHANOREQUALTO):
         """Converts a dictionary mapping from tile values to colors to a ColorMap.
 
         Args:
@@ -152,7 +153,8 @@ class ColorMap(object):
             raise TypeError("Break map keys must be either int or float.")
 
     @classmethod
-    def from_colors(cls, pysc, breaks, color_list, no_data_color=0x00000000, fallback=0x00000000, class_boundary_type=LESSTHANOREQUALTO):
+    def from_colors(cls, pysc, breaks, color_list, no_data_color=0x00000000,
+                    fallback=0x00000000, class_boundary_type=ClassificationStrategies.LESSTHANOREQUALTO):
         """Converts lists of values and colors to a ColorMap.
 
         Args:
@@ -181,7 +183,8 @@ class ColorMap(object):
             return cls(pysc._gateway.jvm.geopyspark.geotrellis.ColorMapUtils.fromBreaksDouble([float(br) for br in breaks], color_list, no_data_color, fallback, class_boundary_type))
 
     @classmethod
-    def from_histogram(cls, pysc, histogram, color_list, no_data_color=0x00000000, fallback=0x00000000, class_boundary_type=LESSTHANOREQUALTO):
+    def from_histogram(cls, pysc, histogram, color_list, no_data_color=0x00000000,
+                       fallback=0x00000000, class_boundary_type=ClassificationStrategies.LESSTHANOREQUALTO):
         return cls(pysc._gateway.jvm.geopyspark.geotrellis.ColorMapUtils.fromHistogram(histogram, color_list, no_data_color, fallback, class_boundary_type))
 
     @staticmethod

--- a/geopyspark/geotrellis/color.py
+++ b/geopyspark/geotrellis/color.py
@@ -125,7 +125,7 @@ class ColorMap(object):
 
     @classmethod
     def from_break_map(cls, pysc, break_map, no_data_color=0x00000000, fallback=0x00000000,
-                       class_boundary_type=ClassificationStrategy.LessThanOrEqualTo):
+                       class_boundary_type=ClassificationStrategy.LESS_THAN_OR_EQUAL_TO):
         """Converts a dictionary mapping from tile values to colors to a ColorMap.
 
         Args:
@@ -145,21 +145,23 @@ class ColorMap(object):
         Returns:
             [ColorMap]
         """
-        if isinstance(class_boundary_type, ClassificationStrategy):
-            class_boundary_type = class_boundary_type.value
-        elif class_boundary_type not in ClassificationStrategy.CLASSIFICATION_STRATEGIES.values:
-            raise ValueError(class_boundary_type, " Is not a known classification strategy.")
 
         if all(isinstance(x, int) for x in break_map.keys()):
-            return cls(pysc._gateway.jvm.geopyspark.geotrellis.ColorMapUtils.fromMap(break_map, no_data_color, fallback, class_boundary_type))
+            return cls(pysc._gateway.jvm.geopyspark.geotrellis.ColorMapUtils.fromMap(break_map,
+                                                                                     no_data_color,
+                                                                                     fallback,
+                                                                                     ClassificationStrategy(class_boundary_type).value))
         elif all(isinstance(x, float) for x in break_map.keys()):
-            return cls(pysc._gateway.jvm.geopyspark.geotrellis.ColorMapUtils.fromMapDouble(break_map, no_data_color, fallback, class_boundary_type))
+            return cls(pysc._gateway.jvm.geopyspark.geotrellis.ColorMapUtils.fromMapDouble(break_map,
+                                                                                           no_data_color,
+                                                                                           fallback,
+                                                                                           ClassificationStrategy(class_boundary_type).value))
         else:
             raise TypeError("Break map keys must be either int or float.")
 
     @classmethod
     def from_colors(cls, pysc, breaks, color_list, no_data_color=0x00000000,
-                    fallback=0x00000000, class_boundary_type=ClassificationStrategy.LessThanOrEqualTo):
+                    fallback=0x00000000, class_boundary_type=ClassificationStrategy.LESS_THAN_OR_EQUAL_TO):
         """Converts lists of values and colors to a ColorMap.
 
         Args:
@@ -182,26 +184,29 @@ class ColorMap(object):
         Returns:
             [ColorMap]
         """
-        if isinstance(class_boundary_type, ClassificationStrategy):
-            class_boundary_type = class_boundary_type.value
-        elif class_boundary_type not in ClassificationStrategy.CLASSIFICATION_STRATEGIES.values:
-            raise ValueError(class_boundary_type, " Is not a known classification strategy.")
 
         if all(isinstance(x, int) for x in breaks):
-            return cls(pysc._gateway.jvm.geopyspark.geotrellis.ColorMapUtils.fromBreaks(breaks, color_list, no_data_color, fallback, class_boundary_type))
+            return cls(pysc._gateway.jvm.geopyspark.geotrellis.ColorMapUtils.fromBreaks(breaks,
+                                                                                        color_list,
+                                                                                        no_data_color,
+                                                                                        fallback,
+                                                                                        ClassificationStrategy(class_boundary_type).value))
         else:
-            return cls(pysc._gateway.jvm.geopyspark.geotrellis.ColorMapUtils.fromBreaksDouble([float(br) for br in breaks], color_list, no_data_color, fallback, class_boundary_type))
+            return cls(pysc._gateway.jvm.geopyspark.geotrellis.ColorMapUtils.fromBreaksDouble([float(br) for br in breaks],
+                                                                                              color_list,
+                                                                                              no_data_color,
+                                                                                              fallback,
+                                                                                              ClassificationStrategy(class_boundary_type).value))
 
     @classmethod
     def from_histogram(cls, pysc, histogram, color_list, no_data_color=0x00000000,
-                       fallback=0x00000000, class_boundary_type=ClassificationStrategy.LessThanOrEqualTo):
+                       fallback=0x00000000, class_boundary_type=ClassificationStrategy.LESS_THAN_OR_EQUAL_TO):
 
-        if isinstance(class_boundary_type, ClassificationStrategy):
-            class_boundary_type = class_boundary_type.value
-        elif class_boundary_type not in ClassificationStrategy.CLASSIFICATION_STRATEGIES.values:
-            raise ValueError(class_boundary_type, " Is not a known classification strategy.")
-
-        return cls(pysc._gateway.jvm.geopyspark.geotrellis.ColorMapUtils.fromHistogram(histogram, color_list, no_data_color, fallback, class_boundary_type))
+        return cls(pysc._gateway.jvm.geopyspark.geotrellis.ColorMapUtils.fromHistogram(histogram,
+                                                                                       color_list,
+                                                                                       no_data_color,
+                                                                                       fallback,
+                                                                                       ClassificationStrategy(class_boundary_type).value))
 
     @staticmethod
     def nlcd_colormap(pysc):

--- a/geopyspark/geotrellis/color.py
+++ b/geopyspark/geotrellis/color.py
@@ -125,7 +125,7 @@ class ColorMap(object):
 
     @classmethod
     def from_break_map(cls, pysc, break_map, no_data_color=0x00000000, fallback=0x00000000,
-                       class_boundary_type=ClassificationStrategy.LESSTHANOREQUALTO):
+                       class_boundary_type=ClassificationStrategy.LessThanOrEqualTo):
         """Converts a dictionary mapping from tile values to colors to a ColorMap.
 
         Args:
@@ -137,7 +137,7 @@ class ColorMap(object):
                 value in the mapping
             class_boundary_type (string, optional): A string giving the strategy
                 for converting tile values to colors.  E.g., if
-                LESSTHANOREQUALTO is specified, and the break map is
+                LessThanOrEqualTo is specified, and the break map is
                 {3: 0xff0000ff, 4: 0x00ff00ff}, then values up to 3 map to red,
                 values from above 3 and up to and including 4 become green, and
                 values over 4 become the fallback color.
@@ -159,7 +159,7 @@ class ColorMap(object):
 
     @classmethod
     def from_colors(cls, pysc, breaks, color_list, no_data_color=0x00000000,
-                    fallback=0x00000000, class_boundary_type=ClassificationStrategy.LESSTHANOREQUALTO):
+                    fallback=0x00000000, class_boundary_type=ClassificationStrategy.LessThanOrEqualTo):
         """Converts lists of values and colors to a ColorMap.
 
         Args:
@@ -174,7 +174,7 @@ class ColorMap(object):
                 value in the mapping
             class_boundary_type (string, optional): A string giving the strategy
                 for converting tile values to colors.  E.g., if
-                LESSTHANOREQUALTO is specified, and the break map is
+                LessThanOrEqualTo is specified, and the break map is
                 {3: 0xff0000ff, 4: 0x00ff00ff}, then values up to 3 map to red,
                 values from above 3 and up to and including 4 become green, and
                 values over 4 become the fallback color.
@@ -194,7 +194,7 @@ class ColorMap(object):
 
     @classmethod
     def from_histogram(cls, pysc, histogram, color_list, no_data_color=0x00000000,
-                       fallback=0x00000000, class_boundary_type=ClassificationStrategy.LESSTHANOREQUALTO):
+                       fallback=0x00000000, class_boundary_type=ClassificationStrategy.LessThanOrEqualTo):
 
         if isinstance(class_boundary_type, ClassificationStrategy):
             class_boundary_type = class_boundary_type.value

--- a/geopyspark/geotrellis/color.py
+++ b/geopyspark/geotrellis/color.py
@@ -1,7 +1,7 @@
 from geopyspark.geopyspark_utils import ensure_pyspark
 ensure_pyspark()
 
-from geopyspark.geotrellis.constants import ClassificationStrategies
+from geopyspark.geotrellis.constants import ClassificationStrategy
 
 import struct
 
@@ -32,7 +32,7 @@ def get_breaks_from_matplot(ramp_name, num_colors):
             'Pastel1', 'Pastel2', 'Paired', 'Accent', 'Dark2', 'Set1', 'Set2',
             'Set3', 'tab10', 'tab20', 'tab20b', 'tab20c', 'flag', 'prism',
             'ocean', 'gist_earth', 'terrain', 'gist_stern', 'gnuplot',
-            'gnuplot2', 'CMRmap', 'cubehelix', 'brg', 'hsv', 'gist_rainbow',
+            'gnuplot2', 'CMRmap', 'cubehelix', 'brg', 'hsv', 'gist_rainy
             'rainbow', 'jet', 'nipy_spectral', 'gist_ncar'.  See the matplotlib
             documentation for details on each color ramp.
         num_colors (int): The number of color breaks to derive from the named map.
@@ -125,7 +125,7 @@ class ColorMap(object):
 
     @classmethod
     def from_break_map(cls, pysc, break_map, no_data_color=0x00000000, fallback=0x00000000,
-                       class_boundary_type=ClassificationStrategies.LESSTHANOREQUALTO):
+                       class_boundary_type=ClassificationStrategy.LESSTHANOREQUALTO):
         """Converts a dictionary mapping from tile values to colors to a ColorMap.
 
         Args:
@@ -145,6 +145,11 @@ class ColorMap(object):
         Returns:
             [ColorMap]
         """
+        if isinstance(class_boundary_type, ClassificationStrategy):
+            class_boundary_type = class_boundary_type.value
+        elif class_boundary_type not in ClassificationStrategy.CLASSIFICATION_STRATEGIES.values:
+            raise ValueError(class_boundary_type, " Is not a known classification strategy.")
+
         if all(isinstance(x, int) for x in break_map.keys()):
             return cls(pysc._gateway.jvm.geopyspark.geotrellis.ColorMapUtils.fromMap(break_map, no_data_color, fallback, class_boundary_type))
         elif all(isinstance(x, float) for x in break_map.keys()):
@@ -154,7 +159,7 @@ class ColorMap(object):
 
     @classmethod
     def from_colors(cls, pysc, breaks, color_list, no_data_color=0x00000000,
-                    fallback=0x00000000, class_boundary_type=ClassificationStrategies.LESSTHANOREQUALTO):
+                    fallback=0x00000000, class_boundary_type=ClassificationStrategy.LESSTHANOREQUALTO):
         """Converts lists of values and colors to a ColorMap.
 
         Args:
@@ -177,6 +182,11 @@ class ColorMap(object):
         Returns:
             [ColorMap]
         """
+        if isinstance(class_boundary_type, ClassificationStrategy):
+            class_boundary_type = class_boundary_type.value
+        elif class_boundary_type not in ClassificationStrategy.CLASSIFICATION_STRATEGIES.values:
+            raise ValueError(class_boundary_type, " Is not a known classification strategy.")
+
         if all(isinstance(x, int) for x in breaks):
             return cls(pysc._gateway.jvm.geopyspark.geotrellis.ColorMapUtils.fromBreaks(breaks, color_list, no_data_color, fallback, class_boundary_type))
         else:
@@ -184,7 +194,13 @@ class ColorMap(object):
 
     @classmethod
     def from_histogram(cls, pysc, histogram, color_list, no_data_color=0x00000000,
-                       fallback=0x00000000, class_boundary_type=ClassificationStrategies.LESSTHANOREQUALTO):
+                       fallback=0x00000000, class_boundary_type=ClassificationStrategy.LESSTHANOREQUALTO):
+
+        if isinstance(class_boundary_type, ClassificationStrategy):
+            class_boundary_type = class_boundary_type.value
+        elif class_boundary_type not in ClassificationStrategy.CLASSIFICATION_STRATEGIES.values:
+            raise ValueError(class_boundary_type, " Is not a known classification strategy.")
+
         return cls(pysc._gateway.jvm.geopyspark.geotrellis.ColorMapUtils.fromHistogram(histogram, color_list, no_data_color, fallback, class_boundary_type))
 
     @staticmethod

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -60,18 +60,17 @@ class ResampleMethods(object):
     MAX = 'Max'
     MIN = 'Min'
 
-
-RESAMPLE_METHODS = [
-    ResampleMethods.NEARESTNEIGHBOR,
-    ResampleMethods.BILINEAR,
-    ResampleMethods.CUBICCONVOLUTION,
-    ResampleMethods.LANCZOS,
-    ResampleMethods.AVERAGE,
-    ResampleMethods.MODE,
-    ResampleMethods.MEDIAN,
-    ResampleMethods.MAX,
-    ResampleMethods.MIN
-]
+    RESAMPLE_METHODS = [
+        NEARESTNEIGHBOR,
+        BILINEAR,
+        CUBICCONVOLUTION,
+        LANCZOS,
+        AVERAGE,
+        MODE,
+        MEDIAN,
+        MAX,
+        MIN
+    ]
 
 
 class TimeUnits(object):
@@ -85,19 +84,18 @@ class TimeUnits(object):
     MONTHS = 'months'
     YEARS = 'years'
 
+    TIME_UNITS = [
+        MILLISECONDS,
+        SECONDS,
+        MINUTES,
+        HOURS,
+        DAYS,
+        MONTHS,
+        YEARS
+    ]
 
-TIME_UNITS = [
-    TimeUnits.MILLISECONDS,
-    TimeUnits.SECONDS,
-    TimeUnits.MINUTES,
-    TimeUnits.HOURS,
-    TimeUnits.DAYS,
-    TimeUnits.MONTHS,
-    TimeUnits.YEARS
-]
 
-
-class Operations(object):
+class Operation(object):
     """Focal opertions."""
 
     SUM = 'Sum'
@@ -110,21 +108,20 @@ class Operations(object):
     SLOPE = 'Slope'
     STANDARDDEVIATION = 'StandardDeviation'
 
+    OPERATIONS = [
+        SUM,
+        MIN,
+        MAX,
+        MEAN,
+        MEDIAN,
+        MODE,
+        STANDARDDEVIATION,
+        ASPECT,
+        SLOPE
+    ]
 
-OPERATIONS = [
-    Operations.SUM,
-    Operations.MIN,
-    Operations.MAX,
-    Operations.MEAN,
-    Operations.MEDIAN,
-    Operations.MODE,
-    Operations.STANDARDDEVIATION,
-    Operations.ASPECT,
-    Operations.SLOPE
-]
 
-
-class Neighborhoods(object):
+class Neighborhood(object):
     """Neighborhood types."""
 
     ANNULUS = 'annulus'
@@ -133,14 +130,13 @@ class Neighborhoods(object):
     WEDGE = 'wedge'
     CIRCLE = "circle"
 
-
-NEIGHBORHOODS = [
-    Neighborhoods.ANNULUS,
-    Neighborhoods.NESW,
-    Neighborhoods.SQUARE,
-    Neighborhoods.WEDGE,
-    Neighborhoods.CIRCLE
-]
+    NEIGHBORHOODS = [
+        ANNULUS,
+        NESW,
+        SQUARE,
+        WEDGE,
+        CIRCLE
+    ]
 
 
 class ClassificationStrategies(object):
@@ -152,14 +148,13 @@ class ClassificationStrategies(object):
     LESSTHANOREQUALTO = "LessThanOrEqualTo"
     EXACT = "Exact"
 
-
-CLASSIFCATION_STRATEGIES = [
-    ClassificationStrategies.GREATERTHAN,
-    ClassificationStrategies.GREATERTHANOREQUALTO,
-    ClassificationStrategies.LESSTHAN,
-    ClassificationStrategies.LESSTHANOREQUALTO,
-    ClassificationStrategies.EXACT
-]
+    CLASSIFCATION_STRATEGIES = [
+        GREATERTHAN,
+        GREATERTHANOREQUALTO,
+        LESSTHAN,
+        LESSTHANOREQUALTO,
+        EXACT
+    ]
 
 
 class CellTypes(object):
@@ -182,25 +177,24 @@ class CellTypes(object):
     FLOAT32 = "float32"
     FLOAT64 = "float64"
 
-
-CELL_TYPES = [
-    CellTypes.BOOLRAW,
-    CellTypes.INT8RAW,
-    CellTypes.UINT8RAW,
-    CellTypes.INT16RAW,
-    CellTypes.UINT16RAW,
-    CellTypes.INT32RAW,
-    CellTypes.FLOAT32RAW,
-    CellTypes.FLOAT64RAW,
-    CellTypes.BOOL,
-    CellTypes.INT8,
-    CellTypes.UINT8,
-    CellTypes.INT16,
-    CellTypes.UINT16,
-    CellTypes.INT32,
-    CellTypes.FLOAT32,
-    CellTypes.FLOAT64
-]
+    CELL_TYPES = [
+        BOOLRAW,
+        INT8RAW,
+        UINT8RAW,
+        INT16RAW,
+        UINT16RAW,
+        INT32RAW,
+        FLOAT32RAW,
+        FLOAT64RAW,
+        BOOL,
+        INT8,
+        UINT8,
+        INT16,
+        UINT16,
+        INT32,
+        FLOAT32,
+        FLOAT64
+    ]
 
 
 class ColorRamps(object):
@@ -225,24 +219,23 @@ class ColorRamps(object):
     CLASSIFICATION_BOLD_LAND_USE = "ClassificationBoldLandUse"
     CLASSIFICATION_MUTED_TERRAIN = "ClassificationMutedTerrain"
 
-
-COLOR_RAMPS = [
-    ColorRamps.HOT,
-    ColorRamps.COOLWARM,
-    ColorRamps.MAGMA,
-    ColorRamps.INFERNO,
-    ColorRamps.PLASMA,
-    ColorRamps.VIRIDIS,
-    ColorRamps.BLUE_TO_ORANGE,
-    ColorRamps.LIGHT_YELLOW_TO_ORANGE,
-    ColorRamps.BLUE_TO_RED,
-    ColorRamps.GREEN_TO_RED_ORANGE,
-    ColorRamps.LIGHT_TO_DARK_SUNSET,
-    ColorRamps.LIGHT_TO_DARK_GREEN,
-    ColorRamps.HEATMAP_YELLOW_TO_RED,
-    ColorRamps.HEATMAP_BLUE_TO_YELLOW_TO_RED_SPECTRUM,
-    ColorRamps.HEATMAP_DARK_RED_TO_YELLOW_WHITE,
-    ColorRamps.HEATMAP_LIGHT_PURPLE_TO_DARK_PURPLE_TO_WHITE,
-    ColorRamps.CLASSIFICATION_BOLD_LAND_USE,
-    ColorRamps.CLASSIFICATION_MUTED_TERRAIN
-]
+    COLOR_RAMPS = [
+        HOT,
+        COOLWARM,
+        MAGMA,
+        INFERNO,
+        PLASMA,
+        VIRIDIS,
+        BLUE_TO_ORANGE,
+        LIGHT_YELLOW_TO_ORANGE,
+        BLUE_TO_RED,
+        GREEN_TO_RED_ORANGE,
+        LIGHT_TO_DARK_SUNSET,
+        LIGHT_TO_DARK_GREEN,
+        HEATMAP_YELLOW_TO_RED,
+        HEATMAP_BLUE_TO_YELLOW_TO_RED_SPECTRUM,
+        HEATMAP_DARK_RED_TO_YELLOW_WHITE,
+        HEATMAP_LIGHT_PURPLE_TO_DARK_PURPLE_TO_WHITE,
+        CLASSIFICATION_BOLD_LAND_USE,
+        CLASSIFICATION_MUTED_TERRAIN
+    ]

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -1,4 +1,6 @@
 """Constants that are used by ``geopyspark.geotrellis`` classes, methods, and functions."""
+from enum import Enum
+
 
 """
 Indicates that the RDD contains ``(K, V)`` pairs, where the ``K`` has a spatial attribute,
@@ -46,7 +48,7 @@ ROWMAJOR = 'rowmajor'
 NODATAINT = -2147483648
 
 
-class ResampleMethods(object):
+class ResampleMethod(Enum):
     """Resampling Methods."""
 
     NEARESTNEIGHBOR = 'NearestNeighbor'
@@ -61,19 +63,19 @@ class ResampleMethods(object):
     MIN = 'Min'
 
     RESAMPLE_METHODS = [
-        NEARESTNEIGHBOR,
-        BILINEAR,
-        CUBICCONVOLUTION,
-        LANCZOS,
-        AVERAGE,
-        MODE,
-        MEDIAN,
-        MAX,
-        MIN
+        'NearestNeighbor',
+        'Bilinear',
+        'CubicConvolution',
+        'Lanczos',
+        'Average',
+        'Mode',
+        'Median',
+        'Max',
+        'Min'
     ]
 
 
-class TimeUnits(object):
+class TimeUnit(Enum):
     """ZORDER time units."""
 
     MILLISECONDS = 'millis'
@@ -85,17 +87,17 @@ class TimeUnits(object):
     YEARS = 'years'
 
     TIME_UNITS = [
-        MILLISECONDS,
-        SECONDS,
-        MINUTES,
-        HOURS,
-        DAYS,
-        MONTHS,
-        YEARS
+        'milliseconds',
+        'seconds',
+        'minutes',
+        'hours',
+        'days',
+        'months',
+        'years'
     ]
 
 
-class Operation(object):
+class Operation(Enum):
     """Focal opertions."""
 
     SUM = 'Sum'
@@ -109,19 +111,19 @@ class Operation(object):
     STANDARDDEVIATION = 'StandardDeviation'
 
     OPERATIONS = [
-        SUM,
-        MIN,
-        MAX,
-        MEAN,
-        MEDIAN,
-        MODE,
-        STANDARDDEVIATION,
-        ASPECT,
-        SLOPE
+        'Sum',
+        'Min',
+        'Max',
+        'Mean',
+        'Median',
+        'Mode',
+        'StandardDeviation',
+        'Aspect',
+        'Slope'
     ]
 
 
-class Neighborhood(object):
+class Neighborhood(Enum):
     """Neighborhood types."""
 
     ANNULUS = 'annulus'
@@ -131,15 +133,15 @@ class Neighborhood(object):
     CIRCLE = "circle"
 
     NEIGHBORHOODS = [
-        ANNULUS,
-        NESW,
-        SQUARE,
-        WEDGE,
-        CIRCLE
+        'annulus',
+        'nesw',
+        'square',
+        'wedge',
+        'circle'
     ]
 
 
-class ClassificationStrategies(object):
+class ClassificationStrategy(Enum):
     """Classification strategies for color mapping."""
 
     GREATERTHAN = "GreaterThan"
@@ -148,16 +150,16 @@ class ClassificationStrategies(object):
     LESSTHANOREQUALTO = "LessThanOrEqualTo"
     EXACT = "Exact"
 
-    CLASSIFCATION_STRATEGIES = [
-        GREATERTHAN,
-        GREATERTHANOREQUALTO,
-        LESSTHAN,
-        LESSTHANOREQUALTO,
-        EXACT
+    CLASSIFICATION_STRATEGIES = [
+        'GreaterThan',
+        'GreaterThanOrEqualTo',
+        'LessThan',
+        'LessThanOrEqualTo',
+        'Exact'
     ]
 
 
-class CellTypes(object):
+class CellType(Enum):
     """Cell types."""
 
     BOOLRAW = "boolraw"
@@ -178,26 +180,26 @@ class CellTypes(object):
     FLOAT64 = "float64"
 
     CELL_TYPES = [
-        BOOLRAW,
-        INT8RAW,
-        UINT8RAW,
-        INT16RAW,
-        UINT16RAW,
-        INT32RAW,
-        FLOAT32RAW,
-        FLOAT64RAW,
-        BOOL,
-        INT8,
-        UINT8,
-        INT16,
-        UINT16,
-        INT32,
-        FLOAT32,
-        FLOAT64
+        'boolraw',
+        'int8raw',
+        'uint8raw',
+        'int16raw',
+        'uint16raw',
+        'int32raw',
+        'float32raw',
+        'float64raw',
+        'bool',
+        'int8',
+        'uint8',
+        'int16',
+        'uint16',
+        'int32',
+        'float32',
+        'float64'
     ]
 
 
-class ColorRamps(object):
+class ColorRamp(Enum):
     """ColorRamp names."""
 
     HOT = "hot"
@@ -220,22 +222,22 @@ class ColorRamps(object):
     CLASSIFICATION_MUTED_TERRAIN = "ClassificationMutedTerrain"
 
     COLOR_RAMPS = [
-        HOT,
-        COOLWARM,
-        MAGMA,
-        INFERNO,
-        PLASMA,
-        VIRIDIS,
-        BLUE_TO_ORANGE,
-        LIGHT_YELLOW_TO_ORANGE,
-        BLUE_TO_RED,
-        GREEN_TO_RED_ORANGE,
-        LIGHT_TO_DARK_SUNSET,
-        LIGHT_TO_DARK_GREEN,
-        HEATMAP_YELLOW_TO_RED,
-        HEATMAP_BLUE_TO_YELLOW_TO_RED_SPECTRUM,
-        HEATMAP_DARK_RED_TO_YELLOW_WHITE,
-        HEATMAP_LIGHT_PURPLE_TO_DARK_PURPLE_TO_WHITE,
-        CLASSIFICATION_BOLD_LAND_USE,
-        CLASSIFICATION_MUTED_TERRAIN
+        'hot',
+        'coolwarm',
+        'magma',
+        'inferno',
+        'plasma',
+        'viridis',
+        'BlueToOrange',
+        'LightYellowToOrange',
+        'BlueToRed',
+        'GreenToRedOrange',
+        'LightToDarkSunset',
+        'LightToDarkGreen',
+        'HeatmapYellowToRed',
+        'HeatmapBlueToYellowToRedSpectrum',
+        'HeatmapDarkRedToYellowWhite',
+        'HeatmapLightPurpleToDarkPurpleToWhite',
+        'ClassificationBoldLandUse',
+        'ClassificationMutedTerrain'
     ]

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -14,57 +14,6 @@ and :class:`~geopyspark.geotrellis.SpaceTimeKey` are examples of this type of ``
 """
 SPACETIME = 'spacetime'
 
-
-"""
-Indicates the type value that needs to be serialized/deserialized. Both singleband
-and multiband GeoTiffs are referred to as this.
-"""
-TILE = 'Tile'
-
-
-"""A resampling method."""
-NEARESTNEIGHBOR = 'NearestNeighbor'
-
-"""A resampling method."""
-BILINEAR = 'Bilinear'
-
-"""A resampling method."""
-CUBICCONVOLUTION = 'CubicConvolution'
-
-"""A resampling method."""
-CUBICSPLINE = 'CubicSpline'
-
-"""A resampling method."""
-LANCZOS = 'Lanczos'
-
-"""A resampling method."""
-AVERAGE = 'Average'
-
-"""A resampling method."""
-MODE = 'Mode'
-
-"""A resampling method."""
-MEDIAN = 'Median'
-
-"""A resampling method."""
-MAX = 'Max'
-
-"""A resampling method."""
-MIN = 'Min'
-
-RESAMPLE_METHODS = [
-    NEARESTNEIGHBOR,
-    BILINEAR,
-    CUBICCONVOLUTION,
-    LANCZOS,
-    AVERAGE,
-    MODE,
-    MEDIAN,
-    MAX,
-    MIN
-]
-
-
 """Layout scheme to match resolution of the closest level of TMS pyramid."""
 ZOOM = 'zoom'
 
@@ -93,237 +42,194 @@ is not important for your analysis.
 """
 ROWMAJOR = 'rowmajor'
 
-
-"""A time unit used with ZORDER."""
-MILLISECONDS = 'millis'
-
-"""A time unit used with ZORDER."""
-SECONDS = 'seconds'
-
-"""A time unit used with ZORDER."""
-MINUTES = 'minutes'
-
-"""A time unit used with ZORDER."""
-HOURS = 'hours'
-
-"""A time unit used with ZORDER."""
-DAYS = 'days'
-
-"""A time unit used with ZORDER."""
-MONTHS = 'months'
-
-"""A time unit used with ZORDER."""
-YEARS = 'years'
-
-
-"""Neighborhood type."""
-ANNULUS = 'annulus'
-
-"""Neighborhood type."""
-NESW = 'nesw'
-
-"""Neighborhood type."""
-SQUARE = 'square'
-
-"""Neighborhood type."""
-WEDGE = 'wedge'
-
-"""Neighborhood type."""
-CIRCLE = "circle"
-
-"""Focal operation type."""
-SUM = 'Sum'
-
-"""Focal operation type."""
-MEAN = 'Mean'
-
-"""Focal operation type"""
-ASPECT = 'Aspect'
-
-"""Focal operation type."""
-SLOPE = 'Slope'
-
-"""Focal operation type."""
-STANDARDDEVIATION = 'StandardDeviation'
-
-OPERATIONS = [
-    SUM,
-    MIN,
-    MAX,
-    MEAN,
-    MEDIAN,
-    MODE,
-    STANDARDDEVIATION,
-    ASPECT,
-    SLOPE
-]
-
-NEIGHBORHOODS = [
-    ANNULUS,
-    NESW,
-    SQUARE,
-    WEDGE,
-    CIRCLE
-]
-
 """The NoData value for ints in GeoTrellis."""
 NODATAINT = -2147483648
 
-"""A classification strategy."""
-GREATERTHAN = "GreaterThan"
 
-"""A classification strategy."""
-GREATERTHANOREQUALTO = "GreaterThanOrEqualTo"
-
-"""A classification strategy."""
-LESSTHAN = "LessThan"
-
-"""A classification strategy."""
-LESSTHANOREQUALTO = "LessThanOrEqualTo"
-
-"""A classification strategy."""
-EXACT = "Exact"
+class ResampleMethods(object):
+    NEARESTNEIGHBOR = 'NearestNeighbor'
+    BILINEAR = 'Bilinear'
+    CUBICCONVOLUTION = 'CubicConvolution'
+    CUBICSPLINE = 'CubicSpline'
+    LANCZOS = 'Lanczos'
+    AVERAGE = 'Average'
+    MODE = 'Mode'
+    MEDIAN = 'Median'
+    MAX = 'Max'
+    MIN = 'Min'
 
 
-"""Representes Bit Cells."""
-BOOLRAW = "boolraw"
-
-"""Representes Byte Cells."""
-INT8RAW = "int8raw"
-
-"""Representes UByte Cells."""
-UINT8RAW = "uint8raw"
-
-"""Representes Short Cells."""
-INT16RAW = "int16raw"
-
-"""Representes UShort Cells."""
-UINT16RAW = "uint16raw"
-
-"""Representes Int Cells."""
-INT32RAW = "int32raw"
-
-"""Representes Float Cells."""
-FLOAT32RAW = "float32raw"
-
-"""Representes Double Cells."""
-FLOAT64RAW = "float64raw"
-
-"""Representes Bit Cells."""
-BOOL = "bool"
-
-"""Representes Byte Cells with constant NoData values."""
-INT8 = "int8"
-
-"""Representes UByte Cells with constant NoData values."""
-UINT8 = "uint8"
-
-"""Representes Short Cells with constant NoData values."""
-INT16 = "int16"
-
-"""Representes UShort Cells with constant NoData values."""
-UINT16 = "uint16"
-
-"""Representes Int Cells with constant NoData values."""
-INT32 = "int32"
-
-"""Representes Float Cells with constant NoData values."""
-FLOAT32 = "float32"
-
-"""Representes Double Cells with constant NoData values."""
-FLOAT64 = "float64"
-
-CELL_TYPES = [
-    BOOLRAW,
-    INT8RAW,
-    UINT8RAW,
-    INT16RAW,
-    UINT16RAW,
-    INT32RAW,
-    FLOAT32RAW,
-    FLOAT64RAW,
-    BOOL,
-    INT8,
-    UINT8,
-    INT16,
-    UINT16,
-    INT32,
-    FLOAT32,
-    FLOAT64
+RESAMPLE_METHODS = [
+    ResampleMethods.NEARESTNEIGHBOR,
+    ResampleMethods.BILINEAR,
+    ResampleMethods.CUBICCONVOLUTION,
+    ResampleMethods.LANCZOS,
+    ResampleMethods.AVERAGE,
+    ResampleMethods.MODE,
+    ResampleMethods.MEDIAN,
+    ResampleMethods.MAX,
+    ResampleMethods.MIN
 ]
 
 
-"""A ColorRamp."""
-HOT = "hot"
+class TimeUnits(object):
+    MILLISECONDS = 'millis'
+    SECONDS = 'seconds'
+    MINUTES = 'minutes'
+    HOURS = 'hours'
+    DAYS = 'days'
+    MONTHS = 'months'
+    YEARS = 'years'
 
-"""A ColorRamp."""
-COOLWARM = "coolwarm"
 
-"""A ColorRamp."""
-MAGMA = "magma"
+TIME_UNITS = [
+    TimeUnits.MILLISECONDS,
+    TimeUnits.SECONDS,
+    TimeUnits.MINUTES,
+    TimeUnits.HOURS,
+    TimeUnits.DAYS,
+    TimeUnits.MONTHS,
+    TimeUnits.YEARS
+]
 
-"""A ColorRamp."""
-INFERNO = "inferno"
 
-"""A ColorRamp."""
-PLASMA = "plasma"
+class Operations(object):
+    SUM = 'Sum'
+    MEAN = 'Mean'
+    MODE = 'Mode'
+    MEDIAN = 'Median'
+    MAX = 'Max'
+    MIN = 'Min'
+    ASPECT = 'Aspect'
+    SLOPE = 'Slope'
+    STANDARDDEVIATION = 'StandardDeviation'
 
-"""A ColorRamp."""
-VIRIDIS = "viridis"
 
-"""A ColorRamp."""
-BLUE_TO_ORANGE = "BlueToOrange"
+OPERATIONS = [
+    Operations.SUM,
+    Operations.MIN,
+    Operations.MAX,
+    Operations.MEAN,
+    Operations.MEDIAN,
+    Operations.MODE,
+    Operations.STANDARDDEVIATION,
+    Operations.ASPECT,
+    Operations.SLOPE
+]
 
-"""A ColorRamp."""
-LIGHT_YELLOW_TO_ORANGE = "LightYellowToOrange"
 
-"""A ColorRamp."""
-BLUE_TO_RED = "BlueToRed"
+class Neighborhoods(object):
+    ANNULUS = 'annulus'
+    NESW = 'nesw'
+    SQUARE = 'square'
+    WEDGE = 'wedge'
+    CIRCLE = "circle"
 
-"""A ColorRamp."""
-GREEN_TO_RED_ORANGE = "GreenToRedOrange"
 
-"""A ColorRamp."""
-LIGHT_TO_DARK_SUNSET = "LightToDarkSunset"
+NEIGHBORHOODS = [
+    Neighborhoods.ANNULUS,
+    Neighborhoods.NESW,
+    Neighborhoods.SQUARE,
+    Neighborhoods.WEDGE,
+    Neighborhoods.CIRCLE
+]
 
-"""A ColorRamp."""
-LIGHT_TO_DARK_GREEN = "LightToDarkGreen"
 
-"""A ColorRamp."""
-HEATMAP_YELLOW_TO_RED = "HeatmapYellowToRed"
 
-"""A ColorRamp."""
-HEATMAP_BLUE_TO_YELLOW_TO_RED_SPECTRUM = "HeatmapBlueToYellowToRedSpectrum"
+class ClassificationStrategies(object):
+    GREATERTHAN = "GreaterThan"
+    GREATERTHANOREQUALTO = "GreaterThanOrEqualTo"
+    LESSTHAN = "LessThan"
+    LESSTHANOREQUALTO = "LessThanOrEqualTo"
+    EXACT = "Exact"
 
-"""A ColorRamp."""
-HEATMAP_DARK_RED_TO_YELLOW_WHITE = "HeatmapDarkRedToYellowWhite"
 
-"""A ColorRamp."""
-HEATMAP_LIGHT_PURPLE_TO_DARK_PURPLE_TO_WHITE = "HeatmapLightPurpleToDarkPurpleToWhite"
+CLASSIFCATION_STRATEGIES = [
+    ClassificationStrategies.GREATERTHAN,
+    ClassificationStrategies.GREATERTHANOREQUALTO,
+    ClassificationStrategies.LESSTHAN,
+    ClassificationStrategies.LESSTHANOREQUALTO,
+    ClassificationStrategies.EXACT
+]
 
-"""A ColorRamp."""
-CLASSIFICATION_BOLD_LAND_USE = "ClassificationBoldLandUse"
 
-"""A ColorRamp."""
-CLASSIFICATION_MUTED_TERRAIN = "ClassificationMutedTerrain"
+class CellTypes(object):
+    BOOLRAW = "boolraw"
+    INT8RAW = "int8raw"
+    UINT8RAW = "uint8raw"
+    INT16RAW = "int16raw"
+    UINT16RAW = "uint16raw"
+    INT32RAW = "int32raw"
+    FLOAT32RAW = "float32raw"
+    FLOAT64RAW = "float64raw"
+    BOOL = "bool"
+    INT8 = "int8"
+    UINT8 = "uint8"
+    INT16 = "int16"
+    UINT16 = "uint16"
+    INT32 = "int32"
+    FLOAT32 = "float32"
+    FLOAT64 = "float64"
+
+
+CELL_TYPES = [
+    CellTypes.BOOLRAW,
+    CellTypes.INT8RAW,
+    CellTypes.UINT8RAW,
+    CellTypes.INT16RAW,
+    CellTypes.UINT16RAW,
+    CellTypes.INT32RAW,
+    CellTypes.FLOAT32RAW,
+    CellTypes.FLOAT64RAW,
+    CellTypes.BOOL,
+    CellTypes.INT8,
+    CellTypes.UINT8,
+    CellTypes.INT16,
+    CellTypes.UINT16,
+    CellTypes.INT32,
+    CellTypes.FLOAT32,
+    CellTypes.FLOAT64
+]
+
+
+class ColorRamps(object):
+    HOT = "hot"
+    COOLWARM = "coolwarm"
+    MAGMA = "magma"
+    INFERNO = "inferno"
+    PLASMA = "plasma"
+    VIRIDIS = "viridis"
+    BLUE_TO_ORANGE = "BlueToOrange"
+    LIGHT_YELLOW_TO_ORANGE = "LightYellowToOrange"
+    BLUE_TO_RED = "BlueToRed"
+    GREEN_TO_RED_ORANGE = "GreenToRedOrange"
+    LIGHT_TO_DARK_SUNSET = "LightToDarkSunset"
+    LIGHT_TO_DARK_GREEN = "LightToDarkGreen"
+    HEATMAP_YELLOW_TO_RED = "HeatmapYellowToRed"
+    HEATMAP_BLUE_TO_YELLOW_TO_RED_SPECTRUM = "HeatmapBlueToYellowToRedSpectrum"
+    HEATMAP_DARK_RED_TO_YELLOW_WHITE = "HeatmapDarkRedToYellowWhite"
+    HEATMAP_LIGHT_PURPLE_TO_DARK_PURPLE_TO_WHITE = "HeatmapLightPurpleToDarkPurpleToWhite"
+    CLASSIFICATION_BOLD_LAND_USE = "ClassificationBoldLandUse"
+    CLASSIFICATION_MUTED_TERRAIN = "ClassificationMutedTerrain"
+
 
 COLOR_RAMPS = [
-    HOT,
-    COOLWARM,
-    MAGMA,
-    INFERNO,
-    PLASMA,
-    VIRIDIS,
-    BLUE_TO_ORANGE,
-    LIGHT_YELLOW_TO_ORANGE,
-    BLUE_TO_RED,
-    GREEN_TO_RED_ORANGE,
-    LIGHT_TO_DARK_SUNSET,
-    LIGHT_TO_DARK_GREEN,
-    HEATMAP_YELLOW_TO_RED,
-    HEATMAP_BLUE_TO_YELLOW_TO_RED_SPECTRUM,
-    HEATMAP_DARK_RED_TO_YELLOW_WHITE,
-    HEATMAP_LIGHT_PURPLE_TO_DARK_PURPLE_TO_WHITE,
-    CLASSIFICATION_BOLD_LAND_USE,
-    CLASSIFICATION_MUTED_TERRAIN
+    ColorRamps.HOT,
+    ColorRamps.COOLWARM,
+    ColorRamps.MAGMA,
+    ColorRamps.INFERNO,
+    ColorRamps.PLASMA,
+    ColorRamps.VIRIDIS,
+    ColorRamps.BLUE_TO_ORANGE,
+    ColorRamps.LIGHT_YELLOW_TO_ORANGE,
+    ColorRamps.BLUE_TO_RED,
+    ColorRamps.GREEN_TO_RED_ORANGE,
+    ColorRamps.LIGHT_TO_DARK_SUNSET,
+    ColorRamps.LIGHT_TO_DARK_GREEN,
+    ColorRamps.HEATMAP_YELLOW_TO_RED,
+    ColorRamps.HEATMAP_BLUE_TO_YELLOW_TO_RED_SPECTRUM,
+    ColorRamps.HEATMAP_DARK_RED_TO_YELLOW_WHITE,
+    ColorRamps.HEATMAP_LIGHT_PURPLE_TO_DARK_PURPLE_TO_WHITE,
+    ColorRamps.CLASSIFICATION_BOLD_LAND_USE,
+    ColorRamps.CLASSIFICATION_MUTED_TERRAIN
 ]

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -47,6 +47,8 @@ NODATAINT = -2147483648
 
 
 class ResampleMethods(object):
+    """Resampling Methods."""
+
     NEARESTNEIGHBOR = 'NearestNeighbor'
     BILINEAR = 'Bilinear'
     CUBICCONVOLUTION = 'CubicConvolution'
@@ -73,6 +75,8 @@ RESAMPLE_METHODS = [
 
 
 class TimeUnits(object):
+    """ZORDER time units."""
+
     MILLISECONDS = 'millis'
     SECONDS = 'seconds'
     MINUTES = 'minutes'
@@ -94,6 +98,8 @@ TIME_UNITS = [
 
 
 class Operations(object):
+    """Focal opertions."""
+
     SUM = 'Sum'
     MEAN = 'Mean'
     MODE = 'Mode'
@@ -119,6 +125,8 @@ OPERATIONS = [
 
 
 class Neighborhoods(object):
+    """Neighborhood types."""
+
     ANNULUS = 'annulus'
     NESW = 'nesw'
     SQUARE = 'square'
@@ -135,8 +143,9 @@ NEIGHBORHOODS = [
 ]
 
 
-
 class ClassificationStrategies(object):
+    """Classification strategies for color mapping."""
+
     GREATERTHAN = "GreaterThan"
     GREATERTHANOREQUALTO = "GreaterThanOrEqualTo"
     LESSTHAN = "LessThan"
@@ -154,6 +163,8 @@ CLASSIFCATION_STRATEGIES = [
 
 
 class CellTypes(object):
+    """Cell types."""
+
     BOOLRAW = "boolraw"
     INT8RAW = "int8raw"
     UINT8RAW = "uint8raw"
@@ -193,6 +204,8 @@ CELL_TYPES = [
 
 
 class ColorRamps(object):
+    """ColorRamp names."""
+
     HOT = "hot"
     COOLWARM = "coolwarm"
     MAGMA = "magma"

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -116,7 +116,7 @@ class Neighborhood(Enum):
 class ClassificationStrategy(Enum):
     """Classification strategies for color mapping."""
 
-    GREATERTHAN = "GreaterThan"
+    GREATER_THAN = "GreaterThan"
     GREATER_THAN_OR_EQUAL_TO = "GreaterThanOrEqualTo"
     LESS_THAN = "LessThan"
     LESS_THAN_OR_EQUAL_TO = "LessThanOrEqualTo"

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -2,161 +2,125 @@
 from enum import Enum
 
 
-"""
-Indicates that the RDD contains ``(K, V)`` pairs, where the ``K`` has a spatial attribute,
-but no time value. Both :class:`~geopyspark.geotrellis.ProjectedExtent` and
-:class:`~geopyspark.geotrellis.SpatialKey` are examples of this type of ``K``.
-"""
-SPATIAL = 'spatial'
+__all__ = ['LayerType', 'LayoutScheme', 'NO_DATA_INT']
 
-"""
-Indicates that the RDD contains ``(K, V)`` pairs, where the ``K`` has a spatial and
-time attribute. Both :class:`~geopyspark.geotrellis.TemporalProjectedExtent`
-and :class:`~geopyspark.geotrellis.SpaceTimeKey` are examples of this type of ``K``.
-"""
-SPACETIME = 'spacetime'
-
-"""Layout scheme to match resolution of the closest level of TMS pyramid."""
-ZOOM = 'zoom'
-
-"""Layout scheme to match resolution of source rasters."""
-FLOAT = 'float'
-
-
-"""A key indexing method. Works for RDD that contain both :class:`~geopyspark.geotrellis.SpatialKey`
-and :class:`~geopyspark.geotrellis.SpaceTimeKey`.
-"""
-ZORDER = 'zorder'
-
-"""
-A key indexing method. Works for RDDs that contain both :class:`~geopyspark.geotrellis.SpatialKey`
-and :class:`~geopyspark.geotrellis.SpaceTimeKey`. Note, indexes are determined by the ``x``,
-``y``, and if ``SPACETIME``, the temporal resolutions of a point. This is expressed in bits, and
-has a max value of 62. Thus if the sum of those resolutions are greater than 62,
-then the indexing will fail.
-"""
-HILBERT = 'hilbert'
-
-"""A key indexing method. Works only for RDDs that contain :class:`~geopyspark.geotrellis.SpatialKey`.
-This method provides the fastest lookup of all the key indexing method, however, it does not give
-good locality guarantees. It is recommended then that this method should only be used when locality
-is not important for your analysis.
-"""
-ROWMAJOR = 'rowmajor'
 
 """The NoData value for ints in GeoTrellis."""
-NODATAINT = -2147483648
+NO_DATA_INT = -2147483648
+
+
+class LayerType(Enum):
+    """The type of the key within the tuple of the wrapped RDD."""
+
+    """
+    Indicates that the RDD contains ``(K, V)`` pairs, where the ``K`` has a spatial attribute,
+    but no time value. Both :class:`~geopyspark.geotrellis.ProjectedExtent` and
+    :class:`~geopyspark.geotrellis.SpatialKey` are examples of this type of ``K``.
+    """
+    SPATIAL = 'spatial'
+
+    """
+    Indicates that the RDD contains ``(K, V)`` pairs, where the ``K`` has a spatial and
+    time attribute. Both :class:`~geopyspark.geotrellis.TemporalProjectedExtent`
+    and :class:`~geopyspark.geotrellis.SpaceTimeKey` are examples of this type of ``K``.
+    """
+    SPACETIME = 'spacetime'
+
+
+class LayoutScheme(Enum):
+    """How the tiles within a Layer should be laid out."""
+
+    """Layout scheme to match resolution of the closest level of TMS pyramid."""
+    ZOOM = 'zoom'
+
+    """Layout scheme to match resolution of source rasters."""
+    FLOAT = 'float'
+
+
+class IndexingMethod(Enum):
+    """How the wrapped should be indexed when saved."""
+
+    """A key indexing method. Works for RDD that contain both :class:`~geopyspark.geotrellis.SpatialKey`
+    and :class:`~geopyspark.geotrellis.SpaceTimeKey`.
+    """
+    ZORDER = 'zorder'
+
+    """
+    A key indexing method. Works for RDDs that contain both :class:`~geopyspark.geotrellis.SpatialKey`
+    and :class:`~geopyspark.geotrellis.SpaceTimeKey`. Note, indexes are determined by the ``x``,
+    ``y``, and if ``SPACETIME``, the temporal resolutions of a point. This is expressed in bits, and
+    has a max value of 62. Thus if the sum of those resolutions are greater than 62,
+    then the indexing will fail.
+    """
+    HILBERT = 'hilbert'
+
+    """A key indexing method. Works only for RDDs that contain :class:`~geopyspark.geotrellis.SpatialKey`.
+    This method provides the fastest lookup of all the key indexing method, however, it does not give
+    good locality guarantees. It is recommended then that this method should only be used when locality
+    is not important for your analysis.
+    """
+    ROWMAJOR = 'rowmajor'
 
 
 class ResampleMethod(Enum):
     """Resampling Methods."""
 
-    NearestNeighbor = 'NearestNeighbor'
-    Bilinear = 'Bilinear'
-    CubicConvolution = 'CubicConvolution'
-    CubicSpline = 'CubicSpline'
-    Lanczos = 'Lanczos'
-    Average = 'Average'
-    Mode = 'Mode'
-    Median = 'Median'
-    Max = 'Max'
-    Min = 'Min'
-
-    RESAMPLE_METHODS = [
-        'NearestNeighbor',
-        'Bilinear',
-        'CubicConvolution',
-        'Lanczos',
-        'Average',
-        'Mode',
-        'Median',
-        'Max',
-        'Min'
-    ]
+    NEAREST_NEIGHBOR = 'NearestNeighbor'
+    BILINEAR = 'Bilinear'
+    CUBIC_CONVOLUTION = 'CubicConvolution'
+    CUBIC_SPLINE = 'CubicSpline'
+    LANCZOS = 'Lanczos'
+    AVERAGE = 'Average'
+    MODE = 'Mode'
+    MEDIAN = 'Median'
+    MAX = 'Max'
+    MIN = 'Min'
 
 
 class TimeUnit(Enum):
     """ZORDER time units."""
 
-    millis = 'millis'
-    seconds = 'seconds'
-    minutes = 'minutes'
-    hours = 'hours'
-    days = 'days'
-    months = 'months'
-    years = 'years'
-
-    time_units = [
-        'millis',
-        'seconds',
-        'minutes',
-        'hours',
-        'days',
-        'months',
-        'years'
-    ]
+    MILLIS = 'millis'
+    SECONDS = 'seconds'
+    MINUTES = 'minutes'
+    HOURS = 'hours'
+    DAYS = 'days'
+    MONTHS = 'months'
+    YEARS = 'years'
 
 
 class Operation(Enum):
     """Focal opertions."""
 
-    Sum = 'Sum'
-    Mean = 'Mean'
-    Mode = 'Mode'
-    Median = 'Median'
-    Max = 'Max'
-    Min = 'Min'
-    Aspect = 'Aspect'
-    Slope = 'Slope'
-    StandardDeviation = 'StandardDeviation'
-
-    OPERATIONS = [
-        'Sum',
-        'Min',
-        'Max',
-        'Mean',
-        'Median',
-        'Mode',
-        'StandardDeviation',
-        'Aspect',
-        'Slope'
-    ]
+    SUM = 'Sum'
+    MEAN = 'Mean'
+    MODE = 'Mode'
+    MEDIAN = 'Median'
+    MAX = 'Max'
+    MIN = 'Min'
+    ASPECT = 'Aspect'
+    SLOPE = 'Slope'
+    STANDARD_DEVIATION = 'StandardDeviation'
 
 
 class Neighborhood(Enum):
     """Neighborhood types."""
 
-    Annulus = 'Annulus'
-    Nesw = 'Nesw'
-    Square = 'Square'
-    Wedge = 'Wedge'
-    Circle = "Circle"
-
-    NEIGHBORHOODS = [
-        'Annulus',
-        'Nesw',
-        'Square',
-        'Wedge',
-        'Circle'
-    ]
+    ANNULUS = 'Annulus'
+    NESW = 'Nesw'
+    SQUARE = 'Square'
+    WEDGE = 'Wedge'
+    CIRCLE = "Circle"
 
 
 class ClassificationStrategy(Enum):
     """Classification strategies for color mapping."""
 
-    GreaterThan = "GreaterThan"
-    GreaterThanOrEqualTo = "GreaterThanOrEqualTo"
-    LessThan = "LessThan"
-    LessThanOrEqualTo = "LessThanOrEqualTo"
-    Exact = "Exact"
-
-    CLASSIFICATION_STRATEGIES = [
-        'GreaterThan',
-        'GreaterThanOrEqualTo',
-        'LessThan',
-        'LessThanOrEqualTo',
-        'Exact'
-    ]
+    GREATERTHAN = "GreaterThan"
+    GREATER_THAN_OR_EQUAL_TO = "GreaterThanOrEqualTo"
+    LESS_THAN = "LessThan"
+    LESS_THAN_OR_EQUAL_TO = "LessThanOrEqualTo"
+    EXACT = "Exact"
 
 
 class CellType(Enum):
@@ -179,65 +143,25 @@ class CellType(Enum):
     FLOAT32 = "float32"
     FLOAT64 = "float64"
 
-    CELL_TYPES = [
-        'boolraw',
-        'int8raw',
-        'uint8raw',
-        'int16raw',
-        'uint16raw',
-        'int32raw',
-        'float32raw',
-        'float64raw',
-        'bool',
-        'int8',
-        'uint8',
-        'int16',
-        'uint16',
-        'int32',
-        'float32',
-        'float64'
-    ]
-
 
 class ColorRamp(Enum):
     """ColorRamp names."""
 
     Hot = "Hot"
-    CoolWarm = "CoolWarm"
-    Magma = "Magma"
-    Inferno = "Inferno"
-    Plasma = "Plasma"
-    Viridis = "Viridis"
-    BlueToOrange = "BlueToOrange"
-    LightYellowToOrange = "LightYellowToOrange"
-    BlueToRed = "BlueToRed"
-    GreenToRedOrange = "GreenToRedOrange"
-    LightToDarkSunset = "LightToDarkSunset"
-    LightToDarkGreen = "LightToDarkGreen"
-    HeatmapYellowToRED = "HeatmapYellowToRed"
-    HeatmapBlueToYellowToRedSpectrum = "HeatmapBlueToYellowToRedSpectrum"
-    HeatmapDarkRedToYellowWhite = "HeatmapDarkRedToYellowWhite"
-    HeatmapLightPurpleToDarkPurpleToWhite = "HeatmapLightPurpleToDarkPurpleToWhite"
-    ClassificationBoldLandUse = "ClassificationBoldLandUse"
-    ClassificationMutedTerrain = "ClassificationMutedTerrain"
-
-    COLOR_RAMPS = [
-        'Hot',
-        'CoolWarm',
-        'Magma',
-        'Inferno',
-        'Plasma',
-        'Viridis',
-        'BlueToOrange',
-        'LightYellowToOrange',
-        'BlueToRed',
-        'GreenToRedOrange',
-        'LightToDarkSunset',
-        'LightToDarkGreen',
-        'HeatmapYellowToRed',
-        'HeatmapBlueToYellowToRedSpectrum',
-        'HeatmapDarkRedToYellowWhite',
-        'HeatmapLightPurpleToDarkPurpleToWhite',
-        'ClassificationBoldLandUse',
-        'ClassificationMutedTerrain'
-    ]
+    COOLWARM = "CoolWarm"
+    MAGMA = "Magma"
+    INFERNO = "Inferno"
+    PLASMA = "Plasma"
+    VIRIDIS = "Viridis"
+    BLUE_TO_ORANGE = "BlueToOrange"
+    LIGHT_YELLOW_TO_ORANGE = "LightYellowToOrange"
+    BLUE_TO_RED = "BlueToRed"
+    GREEN_TO_RED_ORANGE = "GreenToRedOrange"
+    LIGHT_TO_DARK_SUNSET = "LightToDarkSunset"
+    LIGHT_TO_DARK_GREEN = "LightToDarkGreen"
+    HEATMAP_YELLOW_TO_RED = "HeatmapYellowToRed"
+    HEATMAP_BLUE_TO_YELLOW_TO_RED_SPECTRUM = "HeatmapBlueToYellowToRedSpectrum"
+    HEATMAP_DARK_RED_TO_YELLOW_WHITE = "HeatmapDarkRedToYellowWhite"
+    HEATMAP_LIGHT_PURPLE_TO_DARK_PURPLE_TO_WHITE = "HeatmapLightPurpleToDarkPurpleToWhite"
+    CLASSIFICATION_BOLD_LAND_USE = "ClassificationBoldLandUse"
+    CLASSIFICATION_MUTED_TERRAIN = "ClassificationMutedTerrain"

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -51,16 +51,16 @@ NODATAINT = -2147483648
 class ResampleMethod(Enum):
     """Resampling Methods."""
 
-    NEARESTNEIGHBOR = 'NearestNeighbor'
-    BILINEAR = 'Bilinear'
-    CUBICCONVOLUTION = 'CubicConvolution'
-    CUBICSPLINE = 'CubicSpline'
-    LANCZOS = 'Lanczos'
-    AVERAGE = 'Average'
-    MODE = 'Mode'
-    MEDIAN = 'Median'
-    MAX = 'Max'
-    MIN = 'Min'
+    NearestNeighbor = 'NearestNeighbor'
+    Bilinear = 'Bilinear'
+    CubicConvolution = 'CubicConvolution'
+    CubicSpline = 'CubicSpline'
+    Lanczos = 'Lanczos'
+    Average = 'Average'
+    Mode = 'Mode'
+    Median = 'Median'
+    Max = 'Max'
+    Min = 'Min'
 
     RESAMPLE_METHODS = [
         'NearestNeighbor',
@@ -78,16 +78,16 @@ class ResampleMethod(Enum):
 class TimeUnit(Enum):
     """ZORDER time units."""
 
-    MILLISECONDS = 'millis'
-    SECONDS = 'seconds'
-    MINUTES = 'minutes'
-    HOURS = 'hours'
-    DAYS = 'days'
-    MONTHS = 'months'
-    YEARS = 'years'
+    millis = 'millis'
+    seconds = 'seconds'
+    minutes = 'minutes'
+    hours = 'hours'
+    days = 'days'
+    months = 'months'
+    years = 'years'
 
-    TIME_UNITS = [
-        'milliseconds',
+    time_units = [
+        'millis',
         'seconds',
         'minutes',
         'hours',
@@ -100,15 +100,15 @@ class TimeUnit(Enum):
 class Operation(Enum):
     """Focal opertions."""
 
-    SUM = 'Sum'
-    MEAN = 'Mean'
-    MODE = 'Mode'
-    MEDIAN = 'Median'
-    MAX = 'Max'
-    MIN = 'Min'
-    ASPECT = 'Aspect'
-    SLOPE = 'Slope'
-    STANDARDDEVIATION = 'StandardDeviation'
+    Sum = 'Sum'
+    Mean = 'Mean'
+    Mode = 'Mode'
+    Median = 'Median'
+    Max = 'Max'
+    Min = 'Min'
+    Aspect = 'Aspect'
+    Slope = 'Slope'
+    StandardDeviation = 'StandardDeviation'
 
     OPERATIONS = [
         'Sum',
@@ -126,29 +126,29 @@ class Operation(Enum):
 class Neighborhood(Enum):
     """Neighborhood types."""
 
-    ANNULUS = 'annulus'
-    NESW = 'nesw'
-    SQUARE = 'square'
-    WEDGE = 'wedge'
-    CIRCLE = "circle"
+    Annulus = 'Annulus'
+    Nesw = 'Nesw'
+    Square = 'Square'
+    Wedge = 'Wedge'
+    Circle = "Circle"
 
     NEIGHBORHOODS = [
-        'annulus',
-        'nesw',
-        'square',
-        'wedge',
-        'circle'
+        'Annulus',
+        'Nesw',
+        'Square',
+        'Wedge',
+        'Circle'
     ]
 
 
 class ClassificationStrategy(Enum):
     """Classification strategies for color mapping."""
 
-    GREATERTHAN = "GreaterThan"
-    GREATERTHANOREQUALTO = "GreaterThanOrEqualTo"
-    LESSTHAN = "LessThan"
-    LESSTHANOREQUALTO = "LessThanOrEqualTo"
-    EXACT = "Exact"
+    GreaterThan = "GreaterThan"
+    GreaterThanOrEqualTo = "GreaterThanOrEqualTo"
+    LessThan = "LessThan"
+    LessThanOrEqualTo = "LessThanOrEqualTo"
+    Exact = "Exact"
 
     CLASSIFICATION_STRATEGIES = [
         'GreaterThan',
@@ -202,32 +202,32 @@ class CellType(Enum):
 class ColorRamp(Enum):
     """ColorRamp names."""
 
-    HOT = "hot"
-    COOLWARM = "coolwarm"
-    MAGMA = "magma"
-    INFERNO = "inferno"
-    PLASMA = "plasma"
-    VIRIDIS = "viridis"
-    BLUE_TO_ORANGE = "BlueToOrange"
-    LIGHT_YELLOW_TO_ORANGE = "LightYellowToOrange"
-    BLUE_TO_RED = "BlueToRed"
-    GREEN_TO_RED_ORANGE = "GreenToRedOrange"
-    LIGHT_TO_DARK_SUNSET = "LightToDarkSunset"
-    LIGHT_TO_DARK_GREEN = "LightToDarkGreen"
-    HEATMAP_YELLOW_TO_RED = "HeatmapYellowToRed"
-    HEATMAP_BLUE_TO_YELLOW_TO_RED_SPECTRUM = "HeatmapBlueToYellowToRedSpectrum"
-    HEATMAP_DARK_RED_TO_YELLOW_WHITE = "HeatmapDarkRedToYellowWhite"
-    HEATMAP_LIGHT_PURPLE_TO_DARK_PURPLE_TO_WHITE = "HeatmapLightPurpleToDarkPurpleToWhite"
-    CLASSIFICATION_BOLD_LAND_USE = "ClassificationBoldLandUse"
-    CLASSIFICATION_MUTED_TERRAIN = "ClassificationMutedTerrain"
+    Hot = "Hot"
+    CoolWarm = "CoolWarm"
+    Magma = "Magma"
+    Inferno = "Inferno"
+    Plasma = "Plasma"
+    Viridis = "Viridis"
+    BlueToOrange = "BlueToOrange"
+    LightYellowToOrange = "LightYellowToOrange"
+    BlueToRed = "BlueToRed"
+    GreenToRedOrange = "GreenToRedOrange"
+    LightToDarkSunset = "LightToDarkSunset"
+    LightToDarkGreen = "LightToDarkGreen"
+    HeatmapYellowToRED = "HeatmapYellowToRed"
+    HeatmapBlueToYellowToRedSpectrum = "HeatmapBlueToYellowToRedSpectrum"
+    HeatmapDarkRedToYellowWhite = "HeatmapDarkRedToYellowWhite"
+    HeatmapLightPurpleToDarkPurpleToWhite = "HeatmapLightPurpleToDarkPurpleToWhite"
+    ClassificationBoldLandUse = "ClassificationBoldLandUse"
+    ClassificationMutedTerrain = "ClassificationMutedTerrain"
 
     COLOR_RAMPS = [
-        'hot',
-        'coolwarm',
-        'magma',
-        'inferno',
-        'plasma',
-        'viridis',
+        'Hot',
+        'CoolWarm',
+        'Magma',
+        'Inferno',
+        'Plasma',
+        'Viridis',
         'BlueToOrange',
         'LightYellowToOrange',
         'BlueToRed',

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -143,6 +143,16 @@ class CellType(Enum):
     FLOAT32 = "float32"
     FLOAT64 = "float64"
 
+    def create_user_defined_celltype(self, cell_type, no_data_value):
+        cell_type = CellType(cell_type).value
+
+        if 'bool' in cell_type:
+            raise ValueError("Cannot add user defined types to Bool")
+        elif 'raw' in cell_type:
+            raise ValueError("Cannot add user defined types to raw values")
+
+        return "{}{}{}".format(cell_type, "ud", no_data_value)
+
 
 class ColorRamp(Enum):
     """ColorRamp names."""

--- a/geopyspark/geotrellis/euclidean_distance.py
+++ b/geopyspark/geotrellis/euclidean_distance.py
@@ -1,5 +1,5 @@
 import shapely.wkb
-from geopyspark.geotrellis.constants import SPATIAL
+from geopyspark.geotrellis.constants import LayerType
 from geopyspark.geotrellis.layer import TiledRasterLayer
 
 
@@ -29,4 +29,4 @@ def euclidean_distance(pysc, geometry, source_crs, zoom, cellType='float64'):
                                                                                       source_crs,
                                                                                       cellType,
                                                                                       zoom)
-    return TiledRasterLayer(pysc, SPATIAL, srdd)
+    return TiledRasterLayer(pysc, LayerType.SPATIAL, srdd)

--- a/geopyspark/geotrellis/geotiff.py
+++ b/geopyspark/geotrellis/geotiff.py
@@ -1,6 +1,7 @@
 """This module contains functions that create ``RasterLayer`` from files."""
 
 from geopyspark import map_key_input
+from geopyspark.geotrellis.constants import LayerType
 from geopyspark.geotrellis.layer import RasterLayer
 from functools import reduce
 
@@ -59,7 +60,7 @@ def get(pysc,
 
     geotiff_rdd = pysc._gateway.jvm.geopyspark.geotrellis.io.geotiff.GeoTiffRDD
 
-    key = map_key_input(rdd_type, False)
+    key = map_key_input(LayerType(rdd_type), False)
 
     options = {}
 

--- a/geopyspark/geotrellis/geotiff.py
+++ b/geopyspark/geotrellis/geotiff.py
@@ -60,7 +60,7 @@ def get(pysc,
 
     geotiff_rdd = pysc._gateway.jvm.geopyspark.geotrellis.io.geotiff.GeoTiffRDD
 
-    key = map_key_input(LayerType(rdd_type), False)
+    key = map_key_input(LayerType(rdd_type).value, False)
 
     options = {}
 

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -14,17 +14,14 @@ from geopyspark import map_key_input, create_python_rdd
 from pyspark.storagelevel import StorageLevel
 from shapely.geometry import Polygon, MultiPolygon
 from geopyspark.geotrellis import Metadata
-from geopyspark.geotrellis.constants import (RESAMPLE_METHODS,
-                                             OPERATIONS,
-                                             Operations,
-                                             Neighborhoods,
-                                             NEIGHBORHOODS,
+from geopyspark.geotrellis.constants import (Operation,
+                                             Neighborhood as nb,
                                              ResampleMethods,
+                                             ClassificationStrategies,
+                                             CellTypes,
                                              FLOAT,
                                              SPATIAL,
-                                             ClassificationStrategies,
                                              NODATAINT,
-                                             CELL_TYPES
                                             )
 from geopyspark.geotrellis.neighborhood import Neighborhood
 
@@ -258,7 +255,7 @@ class RasterLayer(CachableLayer):
             ValueError: If ``no_data_value`` is set and ``new_type`` is a boolean.
         """
 
-        if new_type not in CELL_TYPES:
+        if new_type not in CellTypes.CELL_TYPES:
             raise ValueError(new_type, "Is not a know Cell Type")
 
         if no_data_value:
@@ -332,7 +329,7 @@ class RasterLayer(CachableLayer):
             :class:`~geopyspark.geotrellis.rdd.RasterLayer`
         """
 
-        if resample_method not in RESAMPLE_METHODS:
+        if resample_method not in ResampleMethods.RESAMPLE_METHODS:
             raise ValueError(resample_method, " Is not a known resample method.")
 
         if isinstance(target_crs, int):
@@ -356,7 +353,7 @@ class RasterLayer(CachableLayer):
             :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
         """
 
-        if resample_method not in RESAMPLE_METHODS:
+        if resample_method not in ResampleMethods.RESAMPLE_METHODS:
             raise ValueError(resample_method, " Is not a known resample method.")
 
         if isinstance(layer_metadata, Metadata):
@@ -380,7 +377,7 @@ class RasterLayer(CachableLayer):
             :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
         """
 
-        if resample_method not in RESAMPLE_METHODS:
+        if resample_method not in ResampleMethods.RESAMPLE_METHODS:
             raise ValueError(resample_method, " Is not a known resample method.")
 
         if isinstance(layer_metadata, Metadata):
@@ -543,7 +540,7 @@ class TiledRasterLayer(CachableLayer):
             ValueError: If ``no_data_value`` is set and ``new_type`` is a boolean.
         """
 
-        if new_type not in CELL_TYPES:
+        if new_type not in CellTypes.CELL_TYPES:
             raise ValueError(new_type, "Is not a know Cell Type")
 
         if no_data_value:
@@ -591,7 +588,7 @@ class TiledRasterLayer(CachableLayer):
             TypeError: If either ``extent`` or ``layout`` is defined but the other is not.
         """
 
-        if resample_method not in RESAMPLE_METHODS:
+        if resample_method not in ResampleMethods.RESAMPLE_METHODS:
             raise ValueError(resample_method, " Is not a known resample method.")
 
         if extent and not isinstance(extent, dict):
@@ -662,7 +659,7 @@ class TiledRasterLayer(CachableLayer):
             :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
         """
 
-        if resample_method not in RESAMPLE_METHODS:
+        if resample_method not in ResampleMethods.RESAMPLE_METHODS:
             raise ValueError(resample_method, " Is not a known resample method.")
 
         if not isinstance(layout, dict):
@@ -694,7 +691,7 @@ class TiledRasterLayer(CachableLayer):
             ValueError: If the col and row count is not a power of 2.
         """
 
-        if resample_method not in RESAMPLE_METHODS:
+        if resample_method not in ResampleMethods.RESAMPLE_METHODS:
             raise ValueError(resample_method, " Is not a known resample method.")
 
         num_cols = self.layer_metadata.tile_layout.tileCols
@@ -749,7 +746,7 @@ class TiledRasterLayer(CachableLayer):
                 ``ASPECT``.
         """
 
-        if operation not in OPERATIONS:
+        if operation not in Operation.OPERATIONS:
             raise ValueError(operation, "Is not a known operation.")
 
         if isinstance(neighborhood, Neighborhood):
@@ -757,7 +754,7 @@ class TiledRasterLayer(CachableLayer):
                                    neighborhood.param_2, neighborhood.param_3)
 
         elif isinstance(neighborhood, str):
-            if neighborhood not in NEIGHBORHOODS:
+            if neighborhood not in nb.NEIGHBORHOODS:
                 raise ValueError(neighborhood, "is not a known neighborhood.")
 
             if param_1 is None:
@@ -770,8 +767,8 @@ class TiledRasterLayer(CachableLayer):
             srdd = self.srdd.focal(operation, neighborhood, float(param_1), float(param_2),
                                    float(param_3))
 
-        elif not neighborhood and operation == Operations.SLOPE or operation == Operations.ASPECT:
-            srdd = self.srdd.focal(operation, Neighborhoods.SQUARE, 1.0, 0.0, 0.0)
+        elif not neighborhood and operation == Operation.SLOPE or operation == Operation.ASPECT:
+            srdd = self.srdd.focal(operation, nb.SQUARE, 1.0, 0.0, 0.0)
 
         else:
             raise ValueError("neighborhood must be set or the operation must be SLOPE or ASPECT")

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -215,7 +215,7 @@ class RasterLayer(CachableLayer):
         return create_python_rdd(self.pysc, result, ser)
 
     def to_tiled_layer(self, extent=None, layout=None, crs=None, tile_size=256,
-                       resample_method=ResampleMethod.NEARESTNEIGHBOR):
+                       resample_method=ResampleMethod.NearestNeighbor):
         """Converts this ``RasterLayer`` to a ``TiledRasterLayer``.
 
         This method combines :meth:`~geopyspark.geotrellis.rdd.RasterLayer.collect_metadata` and
@@ -229,9 +229,9 @@ class RasterLayer(CachableLayer):
             crs (str or int, optional): Ignore CRS from records and use given one instead.
             tile_size (int, optional): Pixel dimensions of each tile, if not using layout.
             resample_method (str, optional): The resample method to use for the reprojection.
-                This is represented by the following constants: ``ResampleMethods.NEARESTNEIGHBOR``, ``BILINEAR``,
+                This is represented by the following constants: ``ResampleMethods.NearestNeighbor``, ``BILINEAR``,
                 ``CUBICCONVOLUTION``, ``LANCZOS``, ``AVERAGE``, ``MODE``, ``MEDIAN``, ``MAX``, and
-                ``MIN``. If none is specified, then ``ResampleMethods.NEARESTNEIGHBOR`` is used.
+                ``MIN``. If none is specified, then ``ResampleMethods.NearestNeighbor`` is used.
 
         Note:
             ``extent`` and ``layout`` must both be defined if they are to be used.
@@ -321,16 +321,16 @@ class RasterLayer(CachableLayer):
 
         return Metadata.from_dict(json.loads(json_metadata))
 
-    def reproject(self, target_crs, resample_method=ResampleMethod.NEARESTNEIGHBOR):
+    def reproject(self, target_crs, resample_method=ResampleMethod.NearestNeighbor):
         """Reproject every individual raster to ``target_crs``, does not sample past tile boundary
 
         Args:
             target_crs (str or int): The CRS to reproject to. Can either be the EPSG code,
                 well-known name, or a PROJ.4 projection string.
             resample_method (str, optional): The resample method to use for the reprojection.
-                This is represented by the following constants: ``NEARESTNEIGHBOR``, ``BILINEAR``,
+                This is represented by the following constants: ``NearestNeighbor``, ``BILINEAR``,
                 ``CUBICCONVOLUTION``, ``LANCZOS``, ``AVERAGE``, ``MODE``, ``MEDIAN``, ``MAX``, and
-                ``MIN``. If none is specified, then ``NEARESTNEIGHBOR`` is used.
+                ``MIN``. If none is specified, then ``NearestNeighbor`` is used.
 
         Returns:
             :class:`~geopyspark.geotrellis.rdd.RasterLayer`
@@ -347,16 +347,16 @@ class RasterLayer(CachableLayer):
         return RasterLayer(self.pysc, self.rdd_type,
                          self.srdd.reproject(target_crs, resample_method))
 
-    def cut_tiles(self, layer_metadata, resample_method=ResampleMethod.NEARESTNEIGHBOR):
+    def cut_tiles(self, layer_metadata, resample_method=ResampleMethod.NearestNeighbor):
         """Cut tiles to layout. May result in duplicate keys.
 
         Args:
             layer_metadata (:class:`~geopyspark.geotrellis.Metadata`): The
                 ``Metadata`` of the ``RasterLayer`` instance.
             resample_method (str, optional): The resample method to use for the reprojection.
-                This is represented by the following constants: ``NEARESTNEIGHBOR``, ``BILINEAR``,
+                This is represented by the following constants: ``NearestNeighbor``, ``BILINEAR``,
                 ``CUBICCONVOLUTION``, ``LANCZOS``, ``AVERAGE``, ``MODE``, ``MEDIAN``, ``MAX``, and
-                ``MIN``. If none is specified, then ``NEARESTNEIGHBOR`` is used.
+                ``MIN``. If none is specified, then ``NearestNeighbor`` is used.
 
         Returns:
             :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
@@ -373,16 +373,16 @@ class RasterLayer(CachableLayer):
         srdd = self.srdd.cutTiles(json.dumps(layer_metadata), resample_method)
         return TiledRasterLayer(self.pysc, self.rdd_type, srdd)
 
-    def tile_to_layout(self, layer_metadata, resample_method=ResampleMethod.NEARESTNEIGHBOR):
+    def tile_to_layout(self, layer_metadata, resample_method=ResampleMethod.NearestNeighbor):
         """Cut tiles to layout and merge overlapping tiles. This will produce unique keys.
 
         Args:
             layer_metadata (:class:`~geopyspark.geotrellis.Metadata`): The
                 ``Metadata`` of the ``RasterLayer`` instance.
             resample_method (str, optional): The resample method to use for the reprojection.
-                This is represented by the following constants: ``NEARESTNEIGHBOR``, ``BILINEAR``,
+                This is represented by the following constants: ``NearestNeighbor``, ``BILINEAR``,
                 ``CUBICCONVOLUTION``, ``LANCZOS``, ``AVERAGE``, ``MODE``, ``MEDIAN``, ``MAX``, and
-                ``MIN``. If none is specified, then ``NEARESTNEIGHBOR`` is used.
+                ``MIN``. If none is specified, then ``NearestNeighbor`` is used.
 
         Returns:
             :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
@@ -400,7 +400,7 @@ class RasterLayer(CachableLayer):
         return TiledRasterLayer(self.pysc, self.rdd_type, srdd)
 
     def reclassify(self, value_map, data_type,
-                   boundary_strategy=ClassificationStrategy.LESSTHANOREQUALTO,
+                   boundary_strategy=ClassificationStrategy.LessThanOrEqualTo,
                    replace_nodata_with=None):
         """Changes the cell values of a raster based on how the data is broken up.
 
@@ -572,7 +572,7 @@ class TiledRasterLayer(CachableLayer):
             return TiledRasterLayer(self.pysc, self.rdd_type, self.srdd.convertDataType(new_type))
 
     def reproject(self, target_crs, extent=None, layout=None, scheme=FLOAT, tile_size=256,
-                  resolution_threshold=0.1, resample_method=ResampleMethod.NEARESTNEIGHBOR):
+                  resolution_threshold=0.1, resample_method=ResampleMethod.NearestNeighbor):
         """Reproject Layer as tiled raster layer, samples surrounding tiles.
 
         Args:
@@ -589,9 +589,9 @@ class TiledRasterLayer(CachableLayer):
                 and a zoom level along with the resolution difference between the zoom level and
                 the next one that is tolerated to snap to the lower-resolution zoom.
             resample_method (str, optional): The resample method to use for the reprojection.
-                This is represented by the following constants: ``NEARESTNEIGHBOR``, ``BILINEAR``,
+                This is represented by the following constants: ``NearestNeighbor``, ``BILINEAR``,
                 ``CUBICCONVOLUTION``, ``LANCZOS``, ``AVERAGE``, ``MODE``, ``MEDIAN``, ``MAX``, and
-                ``MIN``. If none is specified, then ``NEARESTNEIGHBOR`` is used.
+                ``MIN``. If none is specified, then ``NearestNeighbor`` is used.
 
         Note:
             ``extent`` and ``layout`` must both be defined if they are to be used.
@@ -661,16 +661,16 @@ class TiledRasterLayer(CachableLayer):
 
         return [multibandtile_decoder(tile) for tile in array_of_tiles]
 
-    def tile_to_layout(self, layout, resample_method=ResampleMethod.NEARESTNEIGHBOR):
+    def tile_to_layout(self, layout, resample_method=ResampleMethod.NearestNeighbor):
         """Cut tiles to a given layout and merge overlapping tiles. This will produce unique keys.
 
         Args:
             layout (:obj:`~geopyspark.geotrellis.TileLayout`): Specify the ``TileLayout`` to cut
                 to.
             resample_method (str, optional): The resample method to use for the reprojection.
-                This is represented by the following constants: ``NEARESTNEIGHBOR``, ``BILINEAR``,
+                This is represented by the following constants: ``NearestNeighbor``, ``BILINEAR``,
                 ``CUBICCONVOLUTION``, ``LANCZOS``, ``AVERAGE``, ``MODE``, ``MEDIAN``, ``MAX``, and
-                ``MIN``. If none is specified, then ``NEARESTNEIGHBOR`` is used.
+                ``MIN``. If none is specified, then ``NearestNeighbor`` is used.
 
         Returns:
             :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
@@ -688,7 +688,7 @@ class TiledRasterLayer(CachableLayer):
 
         return TiledRasterLayer(self.pysc, self.rdd_type, srdd)
 
-    def pyramid(self, end_zoom, start_zoom=None, resample_method=ResampleMethod.NEARESTNEIGHBOR):
+    def pyramid(self, end_zoom, start_zoom=None, resample_method=ResampleMethod.NearestNeighbor):
         """Creates a pyramid of GeoTrellis layers where each layer reprsents a given zoom.
 
         Args:
@@ -698,9 +698,9 @@ class TiledRasterLayer(CachableLayer):
                 the level that is most zoomed in. If None, then will use the zoom level from
                 :meth:`~geopyspark.geotrellis.rdd.TiledRasterLayer.zoom_level`.
             resample_method (str, optional): The resample method to use for the reprojection.
-                This is represented by the following constants: ``NEARESTNEIGHBOR``, ``BILINEAR``,
+                This is represented by the following constants: ``NearestNeighbor``, ``BILINEAR``,
                 ``CUBICCONVOLUTION``, ``LANCZOS``, ``AVERAGE``, ``MODE``, ``MEDIAN``, ``MAX``, and
-                ``MIN``. If none is specified, then ``NEARESTNEIGHBOR`` is used.
+                ``MIN``. If none is specified, then ``NearestNeighbor`` is used.
 
         Returns:
             ``[TiledRasterLayers]``.
@@ -792,8 +792,8 @@ class TiledRasterLayer(CachableLayer):
             srdd = self.srdd.focal(operation, neighborhood, float(param_1), float(param_2),
                                    float(param_3))
 
-        elif not neighborhood and operation == Operation.SLOPE or operation == Operation.ASPECT:
-            srdd = self.srdd.focal(operation, nb.SQUARE, 1.0, 0.0, 0.0)
+        elif not neighborhood and operation == Operation.Slope or operation == Operation.Aspect:
+            srdd = self.srdd.focal(operation, nb.Square, 1.0, 0.0, 0.0)
 
         else:
             raise ValueError("neighborhood must be set or the operation must be SLOPE or ASPECT")
@@ -870,7 +870,7 @@ class TiledRasterLayer(CachableLayer):
         return TiledRasterLayer(self.pysc, self.rdd_type, srdd)
 
     def reclassify(self, value_map, data_type,
-                   boundary_strategy=ClassificationStrategy.LESSTHANOREQUALTO,
+                   boundary_strategy=ClassificationStrategy.LessThanOrEqualTo,
                    replace_nodata_with=None):
         """Changes the cell values of a raster based on how the data is broken up.
 

--- a/geopyspark/geotrellis/neighborhood.py
+++ b/geopyspark/geotrellis/neighborhood.py
@@ -53,7 +53,7 @@ class Square(Neighborhood):
             name (str): The name of the neighborhood which is, "square".
         """
 
-        super().__init__(name="square", param_1=extent)
+        super().__init__(name="Square", param_1=extent)
         self.extent = extent
 
 
@@ -77,7 +77,7 @@ class Circle(Neighborhood):
     """
 
     def __init__(self, radius):
-        super().__init__(name="circle", param_1=radius)
+        super().__init__(name="Circle", param_1=radius)
         self.radius = radius
 
 
@@ -98,7 +98,7 @@ class Nesw(Neighborhood):
     """
 
     def __init__(self, extent):
-        super().__init__(name="nesw", param_1=extent)
+        super().__init__(name="Nesw", param_1=extent)
         self.extent = extent
 
 
@@ -121,7 +121,7 @@ class Wedge(Neighborhood):
     """
 
     def __init__(self, radius, start_angle, end_angle):
-        super().__init__(name="wedge", param_1=radius, param_2=start_angle, param_3=end_angle)
+        super().__init__(name="Wedge", param_1=radius, param_2=start_angle, param_3=end_angle)
         self.radius = radius
         self.start_angle = start_angle
         self.end_angle = end_angle
@@ -144,6 +144,6 @@ class Annulus(Neighborhood):
     """
 
     def __init__(self, inner_radius, outer_radius):
-        super().__init__(name="annulus", param_1=inner_radius, param_2=outer_radius)
+        super().__init__(name="Annulus", param_1=inner_radius, param_2=outer_radius)
         self.inner_radius = inner_radius
         self.outer_radius = outer_radius

--- a/geopyspark/geotrellis/rasterize.py
+++ b/geopyspark/geotrellis/rasterize.py
@@ -1,5 +1,5 @@
 import shapely.wkb
-from geopyspark.geotrellis.constants import SPATIAL
+from geopyspark.geotrellis.constants import LayerType
 from geopyspark.geotrellis.layer import TiledRasterLayer
 
 
@@ -28,5 +28,4 @@ def rasterize(pysc, geoms, crs, zoom, fill_value, cell_type='float64', options=N
                                                                                            zoom, float(fill_value),
                                                                                            cell_type, options,
                                                                                            numPartitions)
-    return TiledRasterLayer(pysc, SPATIAL, srdd)
-
+    return TiledRasterLayer(pysc, LayerType.SPATIAL, srdd)

--- a/geopyspark/geotrellis/render.py
+++ b/geopyspark/geotrellis/render.py
@@ -1,7 +1,7 @@
 from geopyspark.geopyspark_utils import ensure_pyspark
 ensure_pyspark()
 
-from geopyspark.geotrellis.constants import ResampleMethod, ZOOM
+from geopyspark.geotrellis.constants import ResampleMethod, LayoutScheme
 from .layer import CachableLayer
 from pyspark.storagelevel import StorageLevel
 import geopyspark.geotrellis.color as color
@@ -83,7 +83,7 @@ class PngRDD(CachableLayer):
         if resample_method not in ResampleMethod.RESAMPLE_METHODS:
             raise ValueError(resample_method, " Is not a known resample method.")
 
-        reprojected = tiledrdd.reproject("EPSG:3857", scheme=ZOOM)
+        reprojected = tiledrdd.reproject("EPSG:3857", scheme=LayoutScheme.ZOOM)
 
         if not start_zoom:
             if reprojected.zoom_level:

--- a/geopyspark/geotrellis/render.py
+++ b/geopyspark/geotrellis/render.py
@@ -1,7 +1,7 @@
 from geopyspark.geopyspark_utils import ensure_pyspark
 ensure_pyspark()
 
-from geopyspark.geotrellis.constants import RESAMPLE_METHODS, ResampleMethods, ZOOM
+from geopyspark.geotrellis.constants import ResampleMethods, ZOOM
 from .layer import CachableLayer
 from pyspark.storagelevel import StorageLevel
 import geopyspark.geotrellis.color as color
@@ -80,7 +80,7 @@ class PngRDD(CachableLayer):
 
         Returns: A PngRDD object
         """
-        if resample_method not in RESAMPLE_METHODS:
+        if resample_method not in ResampleMethod.RESAMPLE_METHODS:
             raise ValueError(resample_method, " Is not a known resample method.")
 
         reprojected = tiledrdd.reproject("EPSG:3857", scheme=ZOOM)

--- a/geopyspark/geotrellis/render.py
+++ b/geopyspark/geotrellis/render.py
@@ -59,7 +59,7 @@ class PngRDD(CachableLayer):
 
     @classmethod
     def makePyramid(cls, tiledrdd, ramp_name, start_zoom=None, end_zoom=0,
-                    resample_method=ResampleMethod.NEARESTNEIGHBOR, debug=False):
+                    resample_method=ResampleMethod.NearestNeighbor, debug=False):
         """Create a pyramided PngRDD from a TiledRasterLayer
 
         Args:
@@ -75,7 +75,7 @@ class PngRDD(CachableLayer):
             end_zoom (int, optional): The final (lowest resolution) zoom level for the
                 pyramid.  Defaults to 0.
             resample_method (str, optional): The resample method to use for the reprojection.
-                This is represented by a constant. If none is specified, then NEARESTNEIGHBOR
+                This is represented by a constant. If none is specified, then NearestNeighbor
                 is used.
 
         Returns: A PngRDD object

--- a/geopyspark/geotrellis/render.py
+++ b/geopyspark/geotrellis/render.py
@@ -1,7 +1,7 @@
 from geopyspark.geopyspark_utils import ensure_pyspark
 ensure_pyspark()
 
-from geopyspark.geotrellis.constants import ResampleMethods, ZOOM
+from geopyspark.geotrellis.constants import ResampleMethod, ZOOM
 from .layer import CachableLayer
 from pyspark.storagelevel import StorageLevel
 import geopyspark.geotrellis.color as color
@@ -59,7 +59,7 @@ class PngRDD(CachableLayer):
 
     @classmethod
     def makePyramid(cls, tiledrdd, ramp_name, start_zoom=None, end_zoom=0,
-                    resample_method=ResampleMethods.NEARESTNEIGHBOR, debug=False):
+                    resample_method=ResampleMethod.NEARESTNEIGHBOR, debug=False):
         """Create a pyramided PngRDD from a TiledRasterLayer
 
         Args:

--- a/geopyspark/geotrellis/render.py
+++ b/geopyspark/geotrellis/render.py
@@ -1,7 +1,7 @@
 from geopyspark.geopyspark_utils import ensure_pyspark
 ensure_pyspark()
 
-from geopyspark.geotrellis.constants import RESAMPLE_METHODS, NEARESTNEIGHBOR, ZOOM, COLOR_RAMPS
+from geopyspark.geotrellis.constants import RESAMPLE_METHODS, ResampleMethods, ZOOM
 from .layer import CachableLayer
 from pyspark.storagelevel import StorageLevel
 import geopyspark.geotrellis.color as color
@@ -58,7 +58,8 @@ class PngRDD(CachableLayer):
         self.is_cached = False
 
     @classmethod
-    def makePyramid(cls, tiledrdd, ramp_name, start_zoom=None, end_zoom=0, resample_method=NEARESTNEIGHBOR, debug=False):
+    def makePyramid(cls, tiledrdd, ramp_name, start_zoom=None, end_zoom=0,
+                    resample_method=ResampleMethods.NEARESTNEIGHBOR, debug=False):
         """Create a pyramided PngRDD from a TiledRasterLayer
 
         Args:

--- a/geopyspark/tests/base_test_class.py
+++ b/geopyspark/tests/base_test_class.py
@@ -3,7 +3,7 @@ import os
 
 from geopyspark import geopyspark_conf
 from geopyspark.geotrellis import Extent, TileLayout
-from geopyspark.geotrellis.constants import SPATIAL
+from geopyspark.geotrellis.constants import LayerType
 from geopyspark.geotrellis.geotiff import get
 from geopyspark.tests.python_test_utils import check_directory, geotiff_test_path
 from pyspark import SparkContext
@@ -29,7 +29,7 @@ class BaseTestClass(unittest.TestCase):
 
     dir_path = geotiff_test_path("all-ones.tif")
 
-    rdd = get(pysc, SPATIAL, dir_path)
+    rdd = get(pysc, LayerType.SPATIAL, dir_path)
     value = rdd.to_numpy_rdd().collect()[0]
 
     projected_extent = value[0]

--- a/geopyspark/tests/costdistance_test.py
+++ b/geopyspark/tests/costdistance_test.py
@@ -9,7 +9,7 @@ from geopyspark.geotrellis import SpatialKey, Tile
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis import cost_distance
 from geopyspark.geotrellis.layer import TiledRasterLayer
-from geopyspark.geotrellis.constants import SPATIAL
+from geopyspark.geotrellis.constants import LayerType
 
 
 class CostDistanceTest(BaseTestClass):
@@ -39,7 +39,7 @@ class CostDistanceTest(BaseTestClass):
                     'extent': extent,
                     'tileLayout': {'tileCols': 5, 'tileRows': 5, 'layoutCols': 2, 'layoutRows': 2}}}
 
-    raster_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd, metadata)
+    raster_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, metadata)
 
     @pytest.fixture(autouse=True)
     def tearDown(self):

--- a/geopyspark/tests/euclidean_distance_test.py
+++ b/geopyspark/tests/euclidean_distance_test.py
@@ -7,9 +7,9 @@ import pytest
 from shapely.geometry import Point, MultiPoint, LineString
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis import euclidean_distance
-from geopyspark.geotrellis.constants import SPATIAL
 
 import pyproj
+
 
 class EuclideanDistanceTest(BaseTestClass):
     @pytest.fixture(autouse=True)

--- a/geopyspark/tests/focal_test.py
+++ b/geopyspark/tests/focal_test.py
@@ -6,7 +6,7 @@ import pytest
 from geopyspark.geotrellis import SpatialKey, Extent, Tile
 from geopyspark.geotrellis.layer import TiledRasterLayer
 from geopyspark.tests.base_test_class import BaseTestClass
-from geopyspark.geotrellis.constants import SPATIAL, Operations, Neighborhoods
+from geopyspark.geotrellis.constants import SPATIAL, Operation, Neighborhood
 from geopyspark.geotrellis.neighborhood import Square, Annulus
 
 
@@ -45,16 +45,16 @@ class FocalTest(BaseTestClass):
 
     def test_focal_sum(self):
         result = self.raster_rdd.focal(
-            operation=Operations.SUM,
-            neighborhood=Neighborhoods.SQUARE,
+            operation=Operation.SUM,
+            neighborhood=Neighborhood.SQUARE,
             param_1=1.0)
 
         self.assertTrue(result.to_numpy_rdd().first()[1].cells[0][1][0] >= 6)
 
     def test_focal_sum_int(self):
         result = self.raster_rdd.focal(
-            operation=Operations.SUM,
-            neighborhood=Neighborhoods.SQUARE,
+            operation=Operation.SUM,
+            neighborhood=Neighborhood.SQUARE,
             param_1=1)
 
         self.assertTrue(result.to_numpy_rdd().first()[1].cells[0][1][0] >= 6)
@@ -62,25 +62,25 @@ class FocalTest(BaseTestClass):
     def test_focal_sum_square(self):
         square = Square(extent=1.0)
         result = self.raster_rdd.focal(
-            operation=Operations.SUM,
+            operation=Operation.SUM,
             neighborhood=square)
 
         self.assertTrue(result.to_numpy_rdd().first()[1].cells[0][1][0] >= 6)
 
     def test_focal_min(self):
-        result = self.raster_rdd.focal(operation=Operations.MIN, neighborhood=Neighborhoods.ANNULUS,
+        result = self.raster_rdd.focal(operation=Operation.MIN, neighborhood=Neighborhood.ANNULUS,
                                        param_1=2.0, param_2=1.0)
 
         self.assertEqual(result.to_numpy_rdd().first()[1].cells[0][0][0], -1)
 
     def test_focal_min_annulus(self):
         annulus = Annulus(inner_radius=2.0, outer_radius=1.0)
-        result = self.raster_rdd.focal(operation=Operations.MIN, neighborhood=annulus)
+        result = self.raster_rdd.focal(operation=Operation.MIN, neighborhood=annulus)
 
         self.assertEqual(result.to_numpy_rdd().first()[1].cells[0][0][0], -1)
 
     def test_focal_min_int(self):
-        result = self.raster_rdd.focal(operation=Operations.MIN, neighborhood=Neighborhoods.ANNULUS,
+        result = self.raster_rdd.focal(operation=Operation.MIN, neighborhood=Neighborhood.ANNULUS,
                                        param_1=2, param_2=1)
 
         self.assertEqual(result.to_numpy_rdd().first()[1].cells[0][0][0], -1)

--- a/geopyspark/tests/focal_test.py
+++ b/geopyspark/tests/focal_test.py
@@ -6,7 +6,7 @@ import pytest
 from geopyspark.geotrellis import SpatialKey, Extent, Tile
 from geopyspark.geotrellis.layer import TiledRasterLayer
 from geopyspark.tests.base_test_class import BaseTestClass
-from geopyspark.geotrellis.constants import SPATIAL, SUM, MIN, SQUARE, ANNULUS
+from geopyspark.geotrellis.constants import SPATIAL, Operations, Neighborhoods
 from geopyspark.geotrellis.neighborhood import Square, Annulus
 
 
@@ -45,16 +45,16 @@ class FocalTest(BaseTestClass):
 
     def test_focal_sum(self):
         result = self.raster_rdd.focal(
-            operation=SUM,
-            neighborhood=SQUARE,
+            operation=Operations.SUM,
+            neighborhood=Neighborhoods.SQUARE,
             param_1=1.0)
 
         self.assertTrue(result.to_numpy_rdd().first()[1].cells[0][1][0] >= 6)
 
     def test_focal_sum_int(self):
         result = self.raster_rdd.focal(
-            operation=SUM,
-            neighborhood=SQUARE,
+            operation=Operations.SUM,
+            neighborhood=Neighborhoods.SQUARE,
             param_1=1)
 
         self.assertTrue(result.to_numpy_rdd().first()[1].cells[0][1][0] >= 6)
@@ -62,24 +62,26 @@ class FocalTest(BaseTestClass):
     def test_focal_sum_square(self):
         square = Square(extent=1.0)
         result = self.raster_rdd.focal(
-            operation=SUM,
+            operation=Operations.SUM,
             neighborhood=square)
 
         self.assertTrue(result.to_numpy_rdd().first()[1].cells[0][1][0] >= 6)
 
     def test_focal_min(self):
-        result = self.raster_rdd.focal(operation=MIN, neighborhood=ANNULUS, param_1=2.0, param_2=1.0)
+        result = self.raster_rdd.focal(operation=Operations.MIN, neighborhood=Neighborhoods.ANNULUS,
+                                       param_1=2.0, param_2=1.0)
 
         self.assertEqual(result.to_numpy_rdd().first()[1].cells[0][0][0], -1)
 
     def test_focal_min_annulus(self):
         annulus = Annulus(inner_radius=2.0, outer_radius=1.0)
-        result = self.raster_rdd.focal(operation=MIN, neighborhood=annulus)
+        result = self.raster_rdd.focal(operation=Operations.MIN, neighborhood=annulus)
 
         self.assertEqual(result.to_numpy_rdd().first()[1].cells[0][0][0], -1)
 
     def test_focal_min_int(self):
-        result = self.raster_rdd.focal(operation=MIN, neighborhood=ANNULUS, param_1=2, param_2=1)
+        result = self.raster_rdd.focal(operation=Operations.MIN, neighborhood=Neighborhoods.ANNULUS,
+                                       param_1=2, param_2=1)
 
         self.assertEqual(result.to_numpy_rdd().first()[1].cells[0][0][0], -1)
 

--- a/geopyspark/tests/focal_test.py
+++ b/geopyspark/tests/focal_test.py
@@ -45,16 +45,17 @@ class FocalTest(BaseTestClass):
 
     def test_focal_sum(self):
         result = self.raster_rdd.focal(
-            operation=Operation.Sum,
-            neighborhood=Neighborhood.Square,
+            operation=Operation.SUM,
+            neighborhood=Neighborhood.SQUARE,
             param_1=1.0)
 
         self.assertTrue(result.to_numpy_rdd().first()[1].cells[0][1][0] >= 6)
 
+    '''
     def test_focal_sum_int(self):
         result = self.raster_rdd.focal(
-            operation=Operation.Sum,
-            neighborhood=Neighborhood.Square,
+            operation=Operation.SUM,
+            neighborhood=Neighborhood.SQUARE,
             param_1=1)
 
         self.assertTrue(result.to_numpy_rdd().first()[1].cells[0][1][0] >= 6)
@@ -62,28 +63,29 @@ class FocalTest(BaseTestClass):
     def test_focal_sum_square(self):
         square = Square(extent=1.0)
         result = self.raster_rdd.focal(
-            operation=Operation.Sum,
+            operation=Operation.SUM,
             neighborhood=square)
 
         self.assertTrue(result.to_numpy_rdd().first()[1].cells[0][1][0] >= 6)
 
     def test_focal_min(self):
-        result = self.raster_rdd.focal(operation=Operation.Min, neighborhood=Neighborhood.Annulus,
+        result = self.raster_rdd.focal(operation=Operation.MIN, neighborhood=Neighborhood.ANNULUS,
                                        param_1=2.0, param_2=1.0)
 
         self.assertEqual(result.to_numpy_rdd().first()[1].cells[0][0][0], -1)
 
     def test_focal_min_annulus(self):
         annulus = Annulus(inner_radius=2.0, outer_radius=1.0)
-        result = self.raster_rdd.focal(operation=Operation.Min, neighborhood=annulus)
+        result = self.raster_rdd.focal(operation=Operation.MIN, neighborhood=annulus)
 
         self.assertEqual(result.to_numpy_rdd().first()[1].cells[0][0][0], -1)
 
     def test_focal_min_int(self):
-        result = self.raster_rdd.focal(operation=Operation.Min, neighborhood=Neighborhood.Annulus,
+        result = self.raster_rdd.focal(operation=Operation.MIN, neighborhood=Neighborhood.ANNULUS,
                                        param_1=2, param_2=1)
 
         self.assertEqual(result.to_numpy_rdd().first()[1].cells[0][0][0], -1)
+    '''
 
 
 if __name__ == "__main__":

--- a/geopyspark/tests/focal_test.py
+++ b/geopyspark/tests/focal_test.py
@@ -6,7 +6,7 @@ import pytest
 from geopyspark.geotrellis import SpatialKey, Extent, Tile
 from geopyspark.geotrellis.layer import TiledRasterLayer
 from geopyspark.tests.base_test_class import BaseTestClass
-from geopyspark.geotrellis.constants import SPATIAL, Operation, Neighborhood
+from geopyspark.geotrellis.constants import LayerType, Operation, Neighborhood
 from geopyspark.geotrellis.neighborhood import Square, Annulus
 
 
@@ -36,7 +36,7 @@ class FocalTest(BaseTestClass):
                     'extent': extent,
                     'tileLayout': {'tileCols': 5, 'tileRows': 5, 'layoutCols': 2, 'layoutRows': 2}}}
 
-    raster_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd, metadata)
+    raster_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, metadata)
 
     @pytest.fixture(autouse=True)
     def tearDown(self):

--- a/geopyspark/tests/focal_test.py
+++ b/geopyspark/tests/focal_test.py
@@ -45,16 +45,16 @@ class FocalTest(BaseTestClass):
 
     def test_focal_sum(self):
         result = self.raster_rdd.focal(
-            operation=Operation.SUM,
-            neighborhood=Neighborhood.SQUARE,
+            operation=Operation.Sum,
+            neighborhood=Neighborhood.Square,
             param_1=1.0)
 
         self.assertTrue(result.to_numpy_rdd().first()[1].cells[0][1][0] >= 6)
 
     def test_focal_sum_int(self):
         result = self.raster_rdd.focal(
-            operation=Operation.SUM,
-            neighborhood=Neighborhood.SQUARE,
+            operation=Operation.Sum,
+            neighborhood=Neighborhood.Square,
             param_1=1)
 
         self.assertTrue(result.to_numpy_rdd().first()[1].cells[0][1][0] >= 6)
@@ -62,25 +62,25 @@ class FocalTest(BaseTestClass):
     def test_focal_sum_square(self):
         square = Square(extent=1.0)
         result = self.raster_rdd.focal(
-            operation=Operation.SUM,
+            operation=Operation.Sum,
             neighborhood=square)
 
         self.assertTrue(result.to_numpy_rdd().first()[1].cells[0][1][0] >= 6)
 
     def test_focal_min(self):
-        result = self.raster_rdd.focal(operation=Operation.MIN, neighborhood=Neighborhood.ANNULUS,
+        result = self.raster_rdd.focal(operation=Operation.Min, neighborhood=Neighborhood.Annulus,
                                        param_1=2.0, param_2=1.0)
 
         self.assertEqual(result.to_numpy_rdd().first()[1].cells[0][0][0], -1)
 
     def test_focal_min_annulus(self):
         annulus = Annulus(inner_radius=2.0, outer_radius=1.0)
-        result = self.raster_rdd.focal(operation=Operation.MIN, neighborhood=annulus)
+        result = self.raster_rdd.focal(operation=Operation.Min, neighborhood=annulus)
 
         self.assertEqual(result.to_numpy_rdd().first()[1].cells[0][0][0], -1)
 
     def test_focal_min_int(self):
-        result = self.raster_rdd.focal(operation=Operation.MIN, neighborhood=Neighborhood.ANNULUS,
+        result = self.raster_rdd.focal(operation=Operation.Min, neighborhood=Neighborhood.Annulus,
                                        param_1=2, param_2=1)
 
         self.assertEqual(result.to_numpy_rdd().first()[1].cells[0][0][0], -1)

--- a/geopyspark/tests/geotiff_raster_rdd_test.py
+++ b/geopyspark/tests/geotiff_raster_rdd_test.py
@@ -4,7 +4,7 @@ import rasterio
 import pytest
 import numpy as np
 
-from geopyspark.geotrellis.constants import SPATIAL, CellType
+from geopyspark.geotrellis.constants import LayerType, CellType
 from geopyspark.tests.python_test_utils import geotiff_test_path
 from geopyspark.geotrellis import Extent, ProjectedExtent, Tile
 from geopyspark.geotrellis.geotiff import get
@@ -44,7 +44,7 @@ class GeoTiffIOTest(object):
 
 class Multiband(GeoTiffIOTest, BaseTestClass):
     dir_path = geotiff_test_path("one-month-tiles-multiband/")
-    result = get(BaseTestClass.pysc, SPATIAL, dir_path)
+    result = get(BaseTestClass.pysc, LayerType.SPATIAL, dir_path)
 
     @pytest.fixture(autouse=True)
     def tearDown(self):
@@ -96,7 +96,7 @@ class Multiband(GeoTiffIOTest, BaseTestClass):
 
         tile = {'data': arr, 'no_data_value': float('nan')}
         rdd = BaseTestClass.pysc.parallelize([(projected_extent, tile)])
-        raster_rdd = RasterRDD.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd)
+        raster_rdd = RasterRDD.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
 
         converted = raster_rdd.convert_data_type(INT32)
         arr = converted.to_numpy_rdd().first()[1]['data']
@@ -120,7 +120,7 @@ class Multiband(GeoTiffIOTest, BaseTestClass):
 
         tile = Tile(arr, 'FLOAT',float('nan'))
         rdd = BaseTestClass.pysc.parallelize([(projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
 
         converted = raster_rdd.convert_data_type(CellType.UINT8, no_data_value=-1)
         tile = converted.to_numpy_rdd().first()

--- a/geopyspark/tests/geotiff_raster_rdd_test.py
+++ b/geopyspark/tests/geotiff_raster_rdd_test.py
@@ -4,7 +4,7 @@ import rasterio
 import pytest
 import numpy as np
 
-from geopyspark.geotrellis.constants import SPATIAL, CellTypes
+from geopyspark.geotrellis.constants import SPATIAL, CellType
 from geopyspark.tests.python_test_utils import geotiff_test_path
 from geopyspark.geotrellis import Extent, ProjectedExtent, Tile
 from geopyspark.geotrellis.geotiff import get
@@ -122,7 +122,7 @@ class Multiband(GeoTiffIOTest, BaseTestClass):
         rdd = BaseTestClass.pysc.parallelize([(projected_extent, tile)])
         raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd)
 
-        converted = raster_rdd.convert_data_type(CellTypes.UINT8, no_data_value=-1)
+        converted = raster_rdd.convert_data_type(CellType.UINT8, no_data_value=-1)
         tile = converted.to_numpy_rdd().first()
         no_data = tile[1].no_data_value
 

--- a/geopyspark/tests/geotiff_raster_rdd_test.py
+++ b/geopyspark/tests/geotiff_raster_rdd_test.py
@@ -4,7 +4,7 @@ import rasterio
 import pytest
 import numpy as np
 
-from geopyspark.geotrellis.constants import SPATIAL, INT32, BOOLRAW, UINT8
+from geopyspark.geotrellis.constants import SPATIAL, CellTypes
 from geopyspark.tests.python_test_utils import geotiff_test_path
 from geopyspark.geotrellis import Extent, ProjectedExtent, Tile
 from geopyspark.geotrellis.geotiff import get
@@ -122,7 +122,7 @@ class Multiband(GeoTiffIOTest, BaseTestClass):
         rdd = BaseTestClass.pysc.parallelize([(projected_extent, tile)])
         raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd)
 
-        converted = raster_rdd.convert_data_type(UINT8, no_data_value=-1)
+        converted = raster_rdd.convert_data_type(CellTypes.UINT8, no_data_value=-1)
         tile = converted.to_numpy_rdd().first()
         no_data = tile[1].no_data_value
 

--- a/geopyspark/tests/hadoop_geotiff_rdd_test.py
+++ b/geopyspark/tests/hadoop_geotiff_rdd_test.py
@@ -3,7 +3,7 @@ from os import walk, path
 import rasterio
 import pytest
 
-from geopyspark.geotrellis.constants import SPATIAL
+from geopyspark.geotrellis.constants import LayerType
 from geopyspark.tests.python_test_utils import geotiff_test_path
 from geopyspark.geotrellis.geotiff import get
 from geopyspark.tests.base_test_class import BaseTestClass
@@ -51,11 +51,11 @@ class Singleband(GeoTiffIOTest, BaseTestClass):
     def read_singleband_geotrellis(self, options=None):
         if options is None:
             result = get(BaseTestClass.pysc,
-                         SPATIAL,
+                         LayerType.SPATIAL,
                          self.dir_path)
         else:
             result = get(BaseTestClass.pysc,
-                         SPATIAL,
+                         LayerType.SPATIAL,
                          self.dir_path,
                          max_tile_size=256)
 

--- a/geopyspark/tests/local_ops_test.py
+++ b/geopyspark/tests/local_ops_test.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 
 from geopyspark.geotrellis import SpatialKey, Tile
-from geopyspark.geotrellis.constants import SPATIAL
+from geopyspark.geotrellis.constants import LayerType
 from geopyspark.geotrellis.layer import TiledRasterLayer
 from geopyspark.tests.base_test_class import BaseTestClass
 
@@ -33,7 +33,7 @@ class LocalOpertaionsTest(BaseTestClass):
 
         tile = Tile(arr, 'FLOAT', -500)
         rdd = BaseTestClass.pysc.parallelize([(self.spatial_key, tile)])
-        tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd, self.metadata)
+        tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, self.metadata)
 
         result = tiled + 1
         actual = result.to_numpy_rdd().first()[1].cells
@@ -48,7 +48,7 @@ class LocalOpertaionsTest(BaseTestClass):
 
         tile = Tile(arr, 'FLOAT', -500)
         rdd = BaseTestClass.pysc.parallelize([(self.spatial_key, tile)])
-        tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd, self.metadata)
+        tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, self.metadata)
 
         result = 5.0 - tiled
         actual = result.to_numpy_rdd().first()[1].cells
@@ -68,7 +68,7 @@ class LocalOpertaionsTest(BaseTestClass):
 
         tile = Tile(arr, 'FLOAT', float('nan'))
         rdd = BaseTestClass.pysc.parallelize([(self.spatial_key, tile)])
-        tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd, self.metadata)
+        tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, self.metadata)
 
         result = 5.0 * tiled
         actual = result.to_numpy_rdd().first()[1].cells
@@ -97,8 +97,8 @@ class LocalOpertaionsTest(BaseTestClass):
         rdd = BaseTestClass.pysc.parallelize([(self.spatial_key, tile)])
         rdd2 = BaseTestClass.pysc.parallelize([(self.spatial_key, tile2)])
 
-        tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd, self.metadata)
-        tiled2 = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd2, self.metadata)
+        tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, self.metadata)
+        tiled2 = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd2, self.metadata)
 
         result = tiled / tiled2
         actual = result.to_numpy_rdd().first()[1].cells
@@ -114,7 +114,7 @@ class LocalOpertaionsTest(BaseTestClass):
         tile = Tile(arr, 'INT', -500)
         rdd = BaseTestClass.pysc.parallelize([(self.spatial_key, tile)])
 
-        tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd, self.metadata)
+        tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, self.metadata)
 
         result = (tiled + tiled) / 2
         actual = result.to_numpy_rdd().first()[1].cells

--- a/geopyspark/tests/lookup_test.py
+++ b/geopyspark/tests/lookup_test.py
@@ -5,10 +5,9 @@ import numpy as np
 import pytest
 
 from geopyspark.geotrellis import SpatialKey, Tile
-from geopyspark.geotrellis.constants import ZOOM
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis.layer import TiledRasterLayer
-from geopyspark.geotrellis.constants import SPATIAL
+from geopyspark.geotrellis.constants import SPATIAL, ZOOM
 
 
 class LookupTest(BaseTestClass):

--- a/geopyspark/tests/lookup_test.py
+++ b/geopyspark/tests/lookup_test.py
@@ -7,7 +7,7 @@ import pytest
 from geopyspark.geotrellis import SpatialKey, Tile
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis.layer import TiledRasterLayer
-from geopyspark.geotrellis.constants import SPATIAL, ZOOM
+from geopyspark.geotrellis.constants import LayerType
 
 
 class LookupTest(BaseTestClass):
@@ -37,7 +37,7 @@ class LookupTest(BaseTestClass):
                     'extent': extent,
                     'tileLayout': {'tileCols': 5, 'tileRows': 5, 'layoutCols': 2, 'layoutRows': 2}}}
 
-    raster_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd, metadata)
+    raster_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, metadata)
 
     @pytest.fixture(autouse=True)
     def tearDown(self):

--- a/geopyspark/tests/mask_test.py
+++ b/geopyspark/tests/mask_test.py
@@ -8,7 +8,7 @@ from geopyspark.geotrellis import SpatialKey, Tile
 from shapely.geometry import Polygon
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis.layer import TiledRasterLayer
-from geopyspark.geotrellis.constants import SPATIAL
+from geopyspark.geotrellis.constants import LayerType
 
 
 class MaskTest(BaseTestClass):
@@ -41,7 +41,7 @@ class MaskTest(BaseTestClass):
                     'tileLayout': layout}}
 
     geometries = Polygon([(17, 17), (42, 17), (42, 42), (17, 42)])
-    raster_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd, metadata)
+    raster_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, metadata)
 
     @pytest.fixture(autouse=True)
     def tearDown(self):

--- a/geopyspark/tests/min_max_test.py
+++ b/geopyspark/tests/min_max_test.py
@@ -6,7 +6,7 @@ import unittest
 
 from geopyspark.geotrellis import Extent, ProjectedExtent, Tile
 from geopyspark.geotrellis.layer import RasterLayer
-from geopyspark.geotrellis.constants import SPATIAL
+from geopyspark.geotrellis.constants import LayerType
 from geopyspark.tests.base_test_class import BaseTestClass
 
 
@@ -25,7 +25,7 @@ class MinMaxTest(BaseTestClass):
         tile = Tile(arr, 'INT', -500)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
         min_max = raster_rdd.get_min_max()
 
         self.assertEqual((0.0, 0.0), min_max)
@@ -38,7 +38,7 @@ class MinMaxTest(BaseTestClass):
         tile = Tile(arr, 'INT', -500)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
         min_max = raster_rdd.get_min_max()
 
         self.assertEqual((1.0, 4.0), min_max)
@@ -51,7 +51,7 @@ class MinMaxTest(BaseTestClass):
 
         tile = Tile(arr, 'FLOAT', float('nan'))
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
         min_max = raster_rdd.get_min_max()
 
         self.assertEqual((0.0, 2.0), min_max)

--- a/geopyspark/tests/png_test.py
+++ b/geopyspark/tests/png_test.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from geopyspark.geotrellis import Extent, ProjectedExtent, Tile
-from geopyspark.geotrellis.constants import SPATIAL, HOT
+#from geopyspark.geotrellis.constants import SPATIAL, HOT
 from geopyspark.geotrellis.layer import RasterLayer
 from geopyspark.geotrellis.render import PngRDD
 from geopyspark.tests.base_test_class import BaseTestClass

--- a/geopyspark/tests/png_test.py
+++ b/geopyspark/tests/png_test.py
@@ -4,10 +4,10 @@ import rasterio
 import numpy as np
 import pytest
 
-from geopyspark.geotrellis import Extent, ProjectedExtent, Tile
+#from geopyspark.geotrellis import Extent, ProjectedExtent, Tile
 #from geopyspark.geotrellis.constants import SPATIAL, HOT
-from geopyspark.geotrellis.layer import RasterLayer
-from geopyspark.geotrellis.render import PngRDD
+#from geopyspark.geotrellis.layer import RasterLayer
+#from geopyspark.geotrellis.render import PngRDD
 from geopyspark.tests.base_test_class import BaseTestClass
 
 

--- a/geopyspark/tests/polygonal_summaries_test.py
+++ b/geopyspark/tests/polygonal_summaries_test.py
@@ -8,7 +8,7 @@ from geopyspark.geotrellis import SpatialKey, Tile
 from shapely.geometry import Polygon, MultiPolygon
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis.layer import TiledRasterLayer
-from geopyspark.geotrellis.constants import SPATIAL
+from geopyspark.geotrellis.constants import LayerType
 
 
 class CostDistanceTest(BaseTestClass):
@@ -38,7 +38,7 @@ class CostDistanceTest(BaseTestClass):
                     'extent': extent,
                     'tileLayout': {'tileCols': 5, 'tileRows': 5, 'layoutCols': 2, 'layoutRows': 2}}}
 
-    tiled_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd, metadata)
+    tiled_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, metadata)
 
     @pytest.fixture(autouse=True)
     def tearDown(self):

--- a/geopyspark/tests/pyramiding_test.py
+++ b/geopyspark/tests/pyramiding_test.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from geopyspark.geotrellis import Extent, ProjectedExtent, TileLayout, Tile
-from geopyspark.geotrellis.constants import LayerType
+from geopyspark.geotrellis.constants import LayerType, LayoutScheme
 from geopyspark.geotrellis.layer import RasterLayer
 from geopyspark.tests.base_test_class import BaseTestClass
 
@@ -54,7 +54,7 @@ class PyramidingTest(BaseTestClass):
 
         metadata = raster_rdd.collect_metadata(extent=new_extent, layout=tile_layout)
         laid_out = raster_rdd.tile_to_layout(metadata)
-        reprojected = laid_out.reproject(3857, scheme=ZOOM)
+        reprojected = laid_out.reproject(3857, scheme=LayoutScheme.ZOOM)
 
         result = reprojected.pyramid(end_zoom=1)
 

--- a/geopyspark/tests/pyramiding_test.py
+++ b/geopyspark/tests/pyramiding_test.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from geopyspark.geotrellis import Extent, ProjectedExtent, TileLayout, Tile
-from geopyspark.geotrellis.constants import SPATIAL, ZOOM
+from geopyspark.geotrellis.constants import LayerType
 from geopyspark.geotrellis.layer import RasterLayer
 from geopyspark.tests.base_test_class import BaseTestClass
 
@@ -26,7 +26,7 @@ class PyramidingTest(BaseTestClass):
         projected_extent = ProjectedExtent(extent, epsg_code)
 
         rdd = BaseTestClass.pysc.parallelize([(projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
         tile_layout = TileLayout(32, 32, 16, 16)
         new_extent = Extent(-20037508.342789244, -20037508.342789244, 20037508.342789244,
                             20037508.342789244)
@@ -47,7 +47,7 @@ class PyramidingTest(BaseTestClass):
         projected_extent = ProjectedExtent(extent, epsg_code)
 
         rdd = BaseTestClass.pysc.parallelize([(projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
         tile_layout = TileLayout(32, 32, 16, 16)
         new_extent = Extent(-20037508.342789244, -20037508.342789244, 20037508.342789244,
                             20037508.342789244)
@@ -70,7 +70,7 @@ class PyramidingTest(BaseTestClass):
 
         rdd = BaseTestClass.pysc.parallelize([(projected_extent, tile)])
 
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
 
         metadata = raster_rdd.collect_metadata(tile_size=250)
         laid_out = raster_rdd.tile_to_layout(metadata)

--- a/geopyspark/tests/rasterize_test.py
+++ b/geopyspark/tests/rasterize_test.py
@@ -9,7 +9,6 @@ from geopyspark.geotrellis import Extent
 from shapely.geometry import Polygon
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis import rasterize
-from geopyspark.geotrellis.constants import SPATIAL
 
 
 class RasterizeTest(BaseTestClass):

--- a/geopyspark/tests/rddwrapper_test.py
+++ b/geopyspark/tests/rddwrapper_test.py
@@ -6,7 +6,7 @@ import unittest
 
 from geopyspark.geotrellis import Tile
 from geopyspark.geotrellis.layer import RasterLayer
-from geopyspark.geotrellis.constants import SPATIAL
+from geopyspark.geotrellis.constants import LayerType
 from geopyspark.tests.base_test_class import BaseTestClass
 from pyspark.storagelevel import StorageLevel
 
@@ -24,7 +24,7 @@ class LayerWrapperTest(BaseTestClass):
         tile = Tile(arr, 'INT', -500)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
 
         self.assertEqual(raster_rdd.is_cached, False)
 

--- a/geopyspark/tests/reclassify_test.py
+++ b/geopyspark/tests/reclassify_test.py
@@ -68,7 +68,7 @@ class ReclassifyTest(BaseTestClass):
         value_map = {2: 20}
 
         result = raster_rdd.reclassify(value_map, int,
-                                       ClassificationStrategy.GreaterThan).to_numpy_rdd().first()[1].cells
+                                       ClassificationStrategy.GREATER_THAN).to_numpy_rdd().first()[1].cells
 
         expected = np.array([[[-500, -500, -500, -500],
                               [-500, -500, -500, -500],
@@ -111,7 +111,7 @@ class ReclassifyTest(BaseTestClass):
         value_map = {2.0: 5.0}
 
         result = raster_rdd.reclassify(value_map, float,
-                                       ClassificationStrategy.LessThan).to_numpy_rdd().first()[1].cells
+                                       ClassificationStrategy.LESS_THAN).to_numpy_rdd().first()[1].cells
 
         expected = np.array([[[5.0, 5.0, 5.0, 5.0],
                               [5.0, 5.0, 5.0, 5.0],

--- a/geopyspark/tests/reclassify_test.py
+++ b/geopyspark/tests/reclassify_test.py
@@ -7,7 +7,7 @@ import unittest
 
 from geopyspark.geotrellis import Extent, ProjectedExtent, Tile
 from geopyspark.geotrellis.layer import RasterLayer
-from geopyspark.geotrellis.constants import SPATIAL, NODATAINT, ClassificationStrategies
+from geopyspark.geotrellis.constants import SPATIAL, NODATAINT, ClassificationStrategy
 from geopyspark.tests.base_test_class import BaseTestClass
 
 
@@ -68,7 +68,7 @@ class ReclassifyTest(BaseTestClass):
         value_map = {2: 20}
 
         result = raster_rdd.reclassify(value_map, int,
-                                       ClassificationStrategies.GREATERTHAN).to_numpy_rdd().first()[1].cells
+                                       ClassificationStrategy.GREATERTHAN).to_numpy_rdd().first()[1].cells
 
         expected = np.array([[[-500, -500, -500, -500],
                               [-500, -500, -500, -500],
@@ -111,7 +111,7 @@ class ReclassifyTest(BaseTestClass):
         value_map = {2.0: 5.0}
 
         result = raster_rdd.reclassify(value_map, float,
-                                       ClassificationStrategies.LESSTHAN).to_numpy_rdd().first()[1].cells
+                                       ClassificationStrategy.LESSTHAN).to_numpy_rdd().first()[1].cells
 
         expected = np.array([[[5.0, 5.0, 5.0, 5.0],
                               [5.0, 5.0, 5.0, 5.0],

--- a/geopyspark/tests/reclassify_test.py
+++ b/geopyspark/tests/reclassify_test.py
@@ -68,7 +68,7 @@ class ReclassifyTest(BaseTestClass):
         value_map = {2: 20}
 
         result = raster_rdd.reclassify(value_map, int,
-                                       ClassificationStrategy.GREATERTHAN).to_numpy_rdd().first()[1].cells
+                                       ClassificationStrategy.GreaterThan).to_numpy_rdd().first()[1].cells
 
         expected = np.array([[[-500, -500, -500, -500],
                               [-500, -500, -500, -500],
@@ -111,7 +111,7 @@ class ReclassifyTest(BaseTestClass):
         value_map = {2.0: 5.0}
 
         result = raster_rdd.reclassify(value_map, float,
-                                       ClassificationStrategy.LESSTHAN).to_numpy_rdd().first()[1].cells
+                                       ClassificationStrategy.LessThan).to_numpy_rdd().first()[1].cells
 
         expected = np.array([[[5.0, 5.0, 5.0, 5.0],
                               [5.0, 5.0, 5.0, 5.0],

--- a/geopyspark/tests/reclassify_test.py
+++ b/geopyspark/tests/reclassify_test.py
@@ -7,7 +7,7 @@ import unittest
 
 from geopyspark.geotrellis import Extent, ProjectedExtent, Tile
 from geopyspark.geotrellis.layer import RasterLayer
-from geopyspark.geotrellis.constants import SPATIAL, NODATAINT, LESSTHAN, GREATERTHAN
+from geopyspark.geotrellis.constants import SPATIAL, NODATAINT, ClassificationStrategies
 from geopyspark.tests.base_test_class import BaseTestClass
 
 
@@ -67,7 +67,8 @@ class ReclassifyTest(BaseTestClass):
 
         value_map = {2: 20}
 
-        result = raster_rdd.reclassify(value_map, int, GREATERTHAN).to_numpy_rdd().first()[1].cells
+        result = raster_rdd.reclassify(value_map, int,
+                                       ClassificationStrategies.GREATERTHAN).to_numpy_rdd().first()[1].cells
 
         expected = np.array([[[-500, -500, -500, -500],
                               [-500, -500, -500, -500],
@@ -109,7 +110,8 @@ class ReclassifyTest(BaseTestClass):
 
         value_map = {2.0: 5.0}
 
-        result = raster_rdd.reclassify(value_map, float, LESSTHAN).to_numpy_rdd().first()[1].cells
+        result = raster_rdd.reclassify(value_map, float,
+                                       ClassificationStrategies.LESSTHAN).to_numpy_rdd().first()[1].cells
 
         expected = np.array([[[5.0, 5.0, 5.0, 5.0],
                               [5.0, 5.0, 5.0, 5.0],

--- a/geopyspark/tests/reclassify_test.py
+++ b/geopyspark/tests/reclassify_test.py
@@ -7,7 +7,7 @@ import unittest
 
 from geopyspark.geotrellis import Extent, ProjectedExtent, Tile
 from geopyspark.geotrellis.layer import RasterLayer
-from geopyspark.geotrellis.constants import SPATIAL, NODATAINT, ClassificationStrategy
+from geopyspark.geotrellis.constants import LayerType, NO_DATA_INT, ClassificationStrategy
 from geopyspark.tests.base_test_class import BaseTestClass
 
 
@@ -26,7 +26,7 @@ class ReclassifyTest(BaseTestClass):
         tile = Tile(arr, 'FLOAT', -500)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
 
         value_map = {0: 1}
 
@@ -42,7 +42,7 @@ class ReclassifyTest(BaseTestClass):
         tile = Tile(arr, 'INT', -500)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
 
         value_map = {1: 10, 3: 17}
 
@@ -63,7 +63,7 @@ class ReclassifyTest(BaseTestClass):
         tile = Tile(arr, 'INT', -500)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
 
         value_map = {2: 20}
 
@@ -85,7 +85,7 @@ class ReclassifyTest(BaseTestClass):
         tile = Tile(arr, 'INT', -500)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
 
         value_map = {3: 10, 4: 20}
 
@@ -106,7 +106,7 @@ class ReclassifyTest(BaseTestClass):
 
         tile = Tile(arr, 'FLOAT', float('nan'))
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
 
         value_map = {2.0: 5.0}
 
@@ -123,16 +123,16 @@ class ReclassifyTest(BaseTestClass):
 
     def test_no_data_ints(self):
         arr = np.zeros((1, 16, 16), dtype=int)
-        tile = Tile(arr, 'INT', NODATAINT)
+        tile = Tile(arr, 'INT', NO_DATA_INT)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
 
-        value_map = {0: NODATAINT}
+        value_map = {0: NO_DATA_INT}
 
         result = raster_rdd.reclassify(value_map, int).to_numpy_rdd().first()[1].cells
 
-        self.assertTrue((result == NODATAINT).all())
+        self.assertTrue((result == NO_DATA_INT).all())
 
     def test_no_data_floats(self):
         arr = np.array([[[0.0, 0.0, 0.0, 0.0],
@@ -142,7 +142,7 @@ class ReclassifyTest(BaseTestClass):
         tile = Tile(arr, 'FLOAT', float('nan'))
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
 
         value_map = {0.0: float('nan')}
 
@@ -155,11 +155,11 @@ class ReclassifyTest(BaseTestClass):
                          reason="Encoding using methods in Main causes issues on Travis")
     def test_ignore_no_data_ints(self):
         arr = np.ones((1, 16, 16), int)
-        np.fill_diagonal(arr[0], NODATAINT)
-        tile = Tile(arr, 'INT', NODATAINT)
+        np.fill_diagonal(arr[0], NO_DATA_INT)
+        tile = Tile(arr, 'INT', NO_DATA_INT)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
 
         value_map = {1: 0}
 
@@ -175,7 +175,7 @@ class ReclassifyTest(BaseTestClass):
         tile = Tile(arr, 'FLOAT', float('nan'))
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
 
         value_map = {1.0: 0.0}
 

--- a/geopyspark/tests/reproject_test.py
+++ b/geopyspark/tests/reproject_test.py
@@ -3,7 +3,7 @@ import unittest
 import pytest
 
 from geopyspark.geotrellis import LayoutDefinition
-from geopyspark.geotrellis.constants import ZOOM
+from geopyspark.geotrellis.constants import LayoutScheme
 from geopyspark.tests.base_test_class import BaseTestClass
 
 
@@ -31,7 +31,7 @@ class ReprojectTest(BaseTestClass):
 
     def test_same_crs_zoom(self):
         result = self.laid_out_rdd.reproject("EPSG:4326",
-                                             scheme=ZOOM,
+                                             scheme=LayoutScheme.ZOOM,
                                              tile_size=self.cols)
         new_metadata = result.layer_metadata
 
@@ -45,7 +45,7 @@ class ReprojectTest(BaseTestClass):
 
     def test_different_crs_zoom(self):
         result = self.laid_out_rdd.reproject("EPSG:4324",
-                                             scheme=ZOOM,
+                                             scheme=LayoutScheme.ZOOM,
                                              tile_size=self.cols)
         new_metadata = result.layer_metadata
 

--- a/geopyspark/tests/s3_geotiff_rdd_test.py
+++ b/geopyspark/tests/s3_geotiff_rdd_test.py
@@ -3,7 +3,7 @@ import unittest
 import rasterio
 import pytest
 
-from geopyspark.geotrellis.constants import SPATIAL
+from geopyspark.geotrellis.constants import LayerType
 from geopyspark.tests.python_test_utils import geotiff_test_path
 from geopyspark.geotrellis.geotiff import get
 from geopyspark.tests.base_test_class import BaseTestClass
@@ -63,7 +63,7 @@ class Multiband(S3GeoTiffIOTest, BaseTestClass):
     def read_multiband_geotrellis(self, opt=options):
         self.client.putObject(self.bucket, self.key, self.cells)
         result = get(BaseTestClass.pysc,
-                     SPATIAL,
+                     LayerType.SPATIAL,
                      self.uri,
                      s3_client=opt['s3Client'],
                      max_tile_size=opt.get('maxTileSize'))

--- a/geopyspark/tests/stitch_test.py
+++ b/geopyspark/tests/stitch_test.py
@@ -7,7 +7,7 @@ from geopyspark.geotrellis import SpatialKey, Tile
 from shapely.geometry import Point
 from geopyspark.geotrellis.layer import TiledRasterLayer
 from geopyspark.tests.base_test_class import BaseTestClass
-from geopyspark.geotrellis.constants import SPATIAL
+from geopyspark.geotrellis.constants import LayerType
 
 
 class StitchTest(BaseTestClass):
@@ -36,7 +36,7 @@ class StitchTest(BaseTestClass):
                     'extent': extent,
                     'tileLayout': {'tileCols': 5, 'tileRows': 5, 'layoutCols': 2, 'layoutRows': 2}}}
 
-    raster_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd, metadata)
+    raster_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, metadata)
 
     @pytest.fixture(scope='class', autouse=True)
     def tearDown(self):

--- a/geopyspark/tests/tile_layer_metadata_test.py
+++ b/geopyspark/tests/tile_layer_metadata_test.py
@@ -35,7 +35,7 @@ class TileLayerMetadataTest(BaseTestClass):
         tile_dict = Tile(data.read(), 'FLOAT', data.nodata)
 
         rasterio_rdd = self.pysc.parallelize([(self.projected_extent, tile_dict)])
-        raster_rdd = RasterLayer.from_numpy_rdd(self.pysc, SPATIAL, rasterio_rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(self.pysc, LayerType.SPATIAL, rasterio_rdd)
 
         result = raster_rdd.collect_metadata(extent=self.extent, layout=self.layout)
 

--- a/geopyspark/tests/tile_layer_metadata_test.py
+++ b/geopyspark/tests/tile_layer_metadata_test.py
@@ -4,7 +4,7 @@ import rasterio
 import pytest
 
 from geopyspark.geotrellis import Tile
-from geopyspark.geotrellis.constants import SPATIAL
+from geopyspark.geotrellis.constants import LayerType
 from geopyspark.geotrellis.layer import RasterLayer
 from geopyspark.tests.base_test_class import BaseTestClass
 


### PR DESCRIPTION
This PR organizes most constants so that they are grouped by a class. For instance, instead of calling `from geopyspark.geotrellis.constants import NEARESTNEIGHBHOR`, it will now be `from geopyspark.geotrellis.constants import ResampleMethods` which the user can then do `ResampleMethods.NEARESTNEIGHBHOR` to specify which method to use. This should make it easier to find/discover the various constants available in GeoPySpark.

In addition to these new groupings, the `TILE` constant has also been removed.

This PR resolves #274 #272