### PR TITLE
Broke Out Options For geotiff.get

### DIFF
--- a/geopyspark/geotrellis/geotiff.py
+++ b/geopyspark/geotrellis/geotiff.py
@@ -8,8 +8,13 @@ from functools import reduce
 def get(pysc,
         rdd_type,
         uri,
-        options=None,
-        **kwargs):
+        crs=None,
+        max_tile_size=None,
+        num_partitions=None,
+        chunk_size=None,
+        time_tag=None,
+        time_format=None,
+        s3_client=None):
 
     """Creates a ``RasterLayer`` from GeoTiffs that are located on the local file system, ``HDFS``,
     or ``S3``.
@@ -22,49 +27,31 @@ def get(pysc,
             Note:
                 All of the GeoTiffs must have the same saptial type.
         uri (str): The path to a given file/directory.
-        options (dict, optional): A dictionary of different options that are used
-            when creating the Layer. This defaults to ``None``. If ``None``, then the
-            Layer will be created using the default options for the given backend
-            in GeoTrellis.
+        crs (str, optional): The CRS that the output tiles should be
+            in. The CRS must be in the well-known name format. If ``None``,
+            then the CRS that the tiles were originally in will be used.
+        max_tile_size (int, optional): The max size of each tile in the
+            resulting Layer. If the size is smaller than a read in tile,
+            then that tile will be broken into tiles of the specified
+            size. If ``None``, then the whole tile will be read in.
+        num_partitions (int, optional): The number of repartitions Spark
+            will make when the data is repartitioned. If ``None``, then the
+            data will not be repartitioned.
+        chunk_size (int, optional): How many bytes of the file should be
+            read in at a time. If ``None``, then files will be read in 65536
+            byte chunks.
+        time_tag (str, optional): The name of the tiff tag that contains
+            the time stamp for the tile. If ``None``, then the default value
+            is: ``TIFFTAG_DATETIME``.
+        time_format (str, optional): The pattern of the time stamp for
+            java.time.format.DateTimeFormatter to parse. If ``None``,
+            then the default value is: ``yyyy:MM:dd HH:mm:ss``.
+        s3_client (str, optional): Which ``S3Cleint`` to use when reading
+            GeoTiffs from S3. There are currently two options: ``default`` and
+            ``mock``. If ``None``, ``defualt`` is used.
 
             Note:
-                Key values in the ``dict`` should be in camel case, as this is the style that is
-                used in Scala.
-
-            These are the options when using the local file system or ``HDFS``:
-                * **crs** (str, optional): The CRS that the output tiles should be
-                    in. The CRS must be in the well-known name format. If ``None``,
-                    then the CRS that the tiles were originally in will be used.
-                * **timeTag** (str, optional): The name of the tiff tag that contains
-                    the time stamp for the tile. If ``None``, then the default value
-                    is: ``TIFFTAG_DATETIME``.
-                * **timeFormat** (str, optional): The pattern of the time stamp for
-                    java.time.format.DateTimeFormatter to parse. If ``None``,
-                    then the default value is: ``yyyy:MM:dd HH:mm:ss``.
-                * **maxTileSize** (int, optional): The max size of each tile in the
-                    resulting Layer. If the size is smaller than a read in tile,
-                    then that tile will be broken into tiles of the specified
-                    size. If ``None``, then the whole tile will be read in.
-                * **numPartitions** (int, optional): The number of repartitions Spark
-                    will make when the data is repartitioned. If ``None``, then the
-                    data will not be repartitioned.
-                * **chunkSize** (int, optional): How many bytes of the file should be
-                    read in at a time. If None, then files will be read in 65536
-                    byte chunks.
-
-            ``S3`` has the above options in addition to this:
-                * **s3Client** (str, optional): Which ``S3Cleint`` to use when reading
-                    GeoTiffs. There are currently two options: ``default`` and
-                    ``mock``. If ``None``, ``defualt`` is used.
-
-                    Note:
-                        ``mock`` should only be used in unit tests and debugging.
-
-        **kwargs: Option parameters can also be entered as keyword arguements.
-
-    Note:
-        Defining both ``options`` and ``kwargs`` will cause the ``kwargs`` to be ignored in favor
-        of ``options``.
+                ``mock`` should only be used in unit tests and debugging.
 
     Returns:
         :class:`~geopyspark.geotrellis.rdd.RasterLayer`
@@ -74,30 +61,38 @@ def get(pysc,
 
     key = map_key_input(rdd_type, False)
 
-    if kwargs and not options:
-        options = kwargs
+    options = {}
 
-    if options:
-        if isinstance(uri, list):
-            srdd = geotiff_rdd.get(pysc._jsc.sc(),
-                                   key,
-                                   uri,
-                                   options)
-        else:
-            srdd = geotiff_rdd.get(pysc._jsc.sc(),
-                                   key,
-                                   [uri],
-                                   options)
+    if time_tag:
+        options['timeTag'] = time_tag
+
+    if time_format:
+        options['timeFormat'] = time_format
+
+    if crs:
+        options['crs'] = crs
+
+    if max_tile_size:
+        options['maxTileSize'] = max_tile_size
+
+    if chunk_size:
+        options['chunkSize'] = chunk_size
+
+    if s3_client:
+        options['s3Client'] = s3_client
+
+    if num_partitions:
+        options['numPartitions'] = num_partitions
+
+    if isinstance(uri, list):
+        srdd = geotiff_rdd.get(pysc._jsc.sc(),
+                               key,
+                               uri,
+                               options)
     else:
-        if isinstance(uri, list):
-            srdd = geotiff_rdd.get(pysc._jsc.sc(),
-                                   key,
-                                   uri,
-                                   {})
-        else:
-            srdd = geotiff_rdd.get(pysc._jsc.sc(),
-                                   key,
-                                   [uri],
-                                   {})
+        srdd = geotiff_rdd.get(pysc._jsc.sc(),
+                               key,
+                               [uri],
+                               options)
 
     return RasterLayer(pysc, rdd_type, srdd)

--- a/geopyspark/tests/hadoop_geotiff_rdd_test.py
+++ b/geopyspark/tests/hadoop_geotiff_rdd_test.py
@@ -57,7 +57,7 @@ class Singleband(GeoTiffIOTest, BaseTestClass):
             result = get(BaseTestClass.pysc,
                          SPATIAL,
                          self.dir_path,
-                         maxTileSize=256)
+                         max_tile_size=256)
 
         return [tile[1] for tile in result.to_numpy_rdd().collect()]
 

--- a/geopyspark/tests/s3_geotiff_rdd_test.py
+++ b/geopyspark/tests/s3_geotiff_rdd_test.py
@@ -65,7 +65,8 @@ class Multiband(S3GeoTiffIOTest, BaseTestClass):
         result = get(BaseTestClass.pysc,
                      SPATIAL,
                      self.uri,
-                     opt)
+                     s3_client=opt['s3Client'],
+                     max_tile_size=opt.get('maxTileSize'))
 
         return [tile[1] for tile in result.to_numpy_rdd().collect()]
 


### PR DESCRIPTION
This PR breaks out the options for `geotiff.get` so that they can be entered as optional keyword arguments instead of as a `dict` or `**kwargs`.

This PR resolves #273 