### PR TITLE
Fix Loading Of Native Dependencies In Local Kernels

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -7,7 +7,7 @@ NETCDF-JAR := netcdfAll-5.0.0-SNAPSHOT.jar
 GDAL-BLOB := archives/gdal-and-friends.tar.gz
 PYTHON-BLOB := archives/geopyspark-and-friends.tar.gz
 GEONOTEBOOK := 178bde1679ae3bc084c044ca3eeb915a137f689f
-VERSION := 8
+VERSION := 9
 STAGE0 := jamesmcclain/jupyter-geopyspark:stage0
 STAGE1 := quay.io/geodocker/jupyter-geopyspark:$(VERSION)
 

--- a/docker/kernels/geonotebook-local/kernel.json
+++ b/docker/kernels/geonotebook-local/kernel.json
@@ -9,9 +9,10 @@
   "{connection_file}"
  ],
   "env": {
+      "LD_LIBRARY_PATH": "/home/hadoop/local/gdal/lib",
       "PYSPARK_PYTHON": "/usr/bin/python3.4",
       "SPARK_HOME": "/usr/local/spark-2.1.0-bin-hadoop2.7",
       "PYTHONPATH": "/usr/local/spark-2.1.0-bin-hadoop2.7/python/lib/pyspark.zip:/usr/local/spark-2.1.0-bin-hadoop2.7/python/lib/py4j-0.10.4-src.zip",
-      "PYSPARK_SUBMIT_ARGS": "--master local[*] --driver-memory 8G --archives /blobs/gdal-and-friends.tar.gz,/blobs/geopyspark-and-friends.tar.gz --jars /blobs/geotrellis-backend-assembly-0.1.0.jar,/blobs/netcdfAll-5.0.0-SNAPSHOT.jar --conf spark.serializer=org.apache.spark.serializer.KryoSerializer --conf spark.kyro.registrator=geotrellis.spark.io.kyro.KryoRegistrator --conf spark.executorEnv.LD_LIBRARY_PATH=gdal-and-friends.tar.gz/lib/ --conf spark.executorEnv.PYTHONPATH=geopyspark-and-friends.tar.gz/ pyspark-shell"
+      "PYSPARK_SUBMIT_ARGS": "--master local[*] --driver-memory 8G --archives /blobs/gdal-and-friends.tar.gz,/blobs/geopyspark-and-friends.tar.gz --jars /blobs/geotrellis-backend-assembly-0.1.0.jar,/blobs/netcdfAll-5.0.0-SNAPSHOT.jar --conf spark.serializer=org.apache.spark.serializer.KryoSerializer --conf spark.kyro.registrator=geotrellis.spark.io.kyro.KryoRegistrator --conf spark.executorEnv.LD_LIBRARY_PATH=/home/hadoop/local/gdal/lib pyspark-shell"
   }
 }

--- a/docker/kernels/local/kernel.json
+++ b/docker/kernels/local/kernel.json
@@ -7,10 +7,11 @@
     "{connection_file}"
   ],
   "env": {
+      "LD_LIBRARY_PATH": "/home/hadoop/local/gdal/lib",
       "PYSPARK_PYTHON": "/usr/bin/python3.4",
       "SPARK_HOME": "/usr/local/spark-2.1.0-bin-hadoop2.7",
       "PYTHONPATH": "/usr/local/spark-2.1.0-bin-hadoop2.7/python/lib/pyspark.zip:/usr/local/spark-2.1.0-bin-hadoop2.7/python/lib/py4j-0.10.4-src.zip",
-      "PYSPARK_SUBMIT_ARGS": "--master local --archives /blobs/gdal-and-friends.tar.gz,/blobs/geopyspark-and-friends.tar.gz --jars /blobs/geotrellis-backend-assembly-0.1.0.jar --conf spark.serializer=org.apache.spark.serializer.KryoSerializer --conf spark.kyro.registrator=geotrellis.spark.io.kyro.KryoRegistrator --conf spark.executorEnv.LD_LIBRARY_PATH=gdal-and-friends.tar.gz/lib/ --conf spark.executorEnv.PYTHONPATH=geopyspark-and-friends.tar.gz/ pyspark-shell"
+      "PYSPARK_SUBMIT_ARGS": "--master local[*] --archives /blobs/gdal-and-friends.tar.gz,/blobs/geopyspark-and-friends.tar.gz --jars /blobs/geotrellis-backend-assembly-0.1.0.jar --conf spark.serializer=org.apache.spark.serializer.KryoSerializer --conf spark.kyro.registrator=geotrellis.spark.io.kyro.KryoRegistrator --conf spark.executorEnv.LD_LIBRARY_PATH=/home/hadoop/local/gdal/lib/ pyspark-shell"
   },
   "language": "python",
   "display_name": "PySpark (local)"


### PR DESCRIPTION
It should be possible to load native dependencies now, whereas it was not before.  How/when this problem started is a mystery to me, it looks like it might always have been broken.  (My heart and my best intentions tell me that this used to work, but the facts and evidence tell me that it did not.)

To test:
All notebooks that used to work locally should still work.  In addition, you should be able to run the line `import gdal` either on the master or an executor, whereas that could not be done before.