### PR TITLE
Histogram Wrapper

### DIFF
--- a/docs/docs/geopyspark.geotrellis.rst
+++ b/docs/docs/geopyspark.geotrellis.rst
@@ -81,3 +81,11 @@ geopyspark.geotrellis.rasterize module
 .. automodule:: geopyspark.geotrellis.rasterize
    :members:
    :inherited-members:
+
+geopyspark.geotrellis.histogram module
+-------------------------------------------
+
+.. automodule:: geopyspark.geotrellis.histogram
+   :members:
+   :inherited-members:
+

--- a/geopyspark/geotrellis/color.py
+++ b/geopyspark/geotrellis/color.py
@@ -202,7 +202,7 @@ class ColorMap(object):
     def from_histogram(cls, pysc, histogram, color_list, no_data_color=0x00000000,
                        fallback=0x00000000, class_boundary_type=ClassificationStrategy.LESS_THAN_OR_EQUAL_TO):
 
-        return cls(pysc._gateway.jvm.geopyspark.geotrellis.ColorMapUtils.fromHistogram(histogram,
+        return cls(pysc._gateway.jvm.geopyspark.geotrellis.ColorMapUtils.fromHistogram(histogram.scala_histogram,
                                                                                        color_list,
                                                                                        no_data_color,
                                                                                        fallback,

--- a/geopyspark/geotrellis/histogram.py
+++ b/geopyspark/geotrellis/histogram.py
@@ -21,20 +21,6 @@ class Histogram(object):
     def __init__(self, scala_histogram):
         self.scala_histogram = scala_histogram
 
-    @classmethod
-    def from_tiled_layer(cls, tiled_layer):
-        """Creates an instance of ``Histogram`` from a ``TiledRasterLayer``.
-
-        Args:
-            tiled_layer (:class:`~geopyspark.geotrellis.layer.TiledRasterLayer`): The tiled layer
-                from which the histogram should be derived from.
-
-        Returns:
-            :class:`~geopyspark.geotrellis.histogram.Histogram`
-        """
-
-        return cls(tiled_layer.get_histogram())
-
     def min(self):
         """The smallest value of the histogram.
 

--- a/geopyspark/geotrellis/histogram.py
+++ b/geopyspark/geotrellis/histogram.py
@@ -1,0 +1,46 @@
+
+
+class Histogram(object):
+    def __init__(self, scala_histogram):
+        self.scala_histogram = scala_histogram
+
+    @classmethod
+    def from_tiled_layer(cls, tiled_layer):
+        return cls(tiled_layer.get_histogram())
+
+    def min(self):
+        return self.scala_histogram.minValue().get()
+
+    def max(self):
+        return self.scala_histogram.maxValue().get()
+
+    def min_max(self):
+        tup = self.scala_histogram.minMaxValues().get()
+
+        return (tup._1(), tup._2())
+
+    def mean(self):
+        return self.scala_histogram.mean().get()
+
+    def mode(self):
+        return self.scala_histogram.mode().get()
+
+    def median(self):
+        return self.scala_histogram.mean().get()
+
+    def values(self):
+        return list(self.scala_histogram.values())
+
+    def cdf(self):
+        cdfs = list(self.scala_histogram.cdf())
+
+        return [(cdf._1(), cdf._2()) for cdf in cdfs]
+
+    def bucket_count(self):
+        return self.scala_histogram.bucketCount()
+
+    def quantile_breaks(self):
+        return list(self.scala_histogram.quantileBreaks())
+
+    def merge(self, other_histogram):
+        return Histogram(self.scala_histogram.merge(other_histogram.scala_histogram))

--- a/geopyspark/geotrellis/histogram.py
+++ b/geopyspark/geotrellis/histogram.py
@@ -1,46 +1,159 @@
+"""This module contains the ``Histogram`` class which is a wrapper of the GeoTrellis Histogram
+class.
+"""
 
 
 class Histogram(object):
+    """A wrapper class for a GeoTrellis Histogram.
+
+    The underlying histogram is produced from the values within a
+    :class:`~geopyspark.geotrellis.layer.TiledRasterLayer`. These values represented by the
+    histogram can either be ``Int`` or ``Float`` depending on the data type of the cells in the
+    layer.
+
+    Args:
+        scala_histogram (py4j.JavaObject): An instance of the GeoTrellis histogram.
+
+    Attributes:
+        scala_histogram (py4j.JavaObject): An instance of the GeoTrellis histogram.
+    """
+
     def __init__(self, scala_histogram):
         self.scala_histogram = scala_histogram
 
     @classmethod
     def from_tiled_layer(cls, tiled_layer):
+        """Creates an instance of ``Histogram`` from a ``TiledRasterLayer``.
+
+        Args:
+            tiled_layer (:class:`~geopyspark.geotrellis.layer.TiledRasterLayer`): The tiled layer
+                from which the histogram should be derived from.
+
+        Returns:
+            :class:`~geopyspark.geotrellis.histogram.Histogram`
+        """
+
         return cls(tiled_layer.get_histogram())
 
     def min(self):
+        """The smallest value of the histogram.
+
+        This will return either an ``int`` or ``float`` depedning on the type of values
+        within the histogram.
+
+        Returns:
+            int or float
+        """
+
         return self.scala_histogram.minValue().get()
 
     def max(self):
+        """The largest value of the histogram.
+
+        This will return either an ``int`` or ``float`` depedning on the type of values
+        within the histogram.
+
+        Returns:
+            int or float
+        """
+
         return self.scala_histogram.maxValue().get()
 
     def min_max(self):
+        """The largest and smallest values of the histogram.
+
+        This will return either an ``int`` or ``float`` depedning on the type of values
+        within the histogram.
+
+        Returns:
+            (int, int) or (float, float)
+        """
+
         tup = self.scala_histogram.minMaxValues().get()
 
         return (tup._1(), tup._2())
 
     def mean(self):
+        """Determines the mean of the histogram.
+
+        Returns:
+            float
+        """
+
         return self.scala_histogram.mean().get()
 
     def mode(self):
+        """Determines the mode of the histogram.
+
+        This will return either an ``int`` or ``float`` depedning on the type of values
+        within the histogram.
+
+        Returns:
+            int or float
+        """
+
         return self.scala_histogram.mode().get()
 
     def median(self):
+        """Determines the median of the histogram.
+
+        Returns:
+            float
+        """
+
         return self.scala_histogram.mean().get()
 
     def values(self):
+        """Lists each indiviual value within the histogram.
+
+        This will return a list of either ``int``s or ``float``s depedning on the type of values
+        within the histogram.
+
+        Returns:
+            [int] or [float]
+        """
+
         return list(self.scala_histogram.values())
 
     def cdf(self):
+        """Returns the cdf of the distribution of the histogram.
+
+        Returns:
+            [(float, float)]
+        """
+
         cdfs = list(self.scala_histogram.cdf())
 
         return [(cdf._1(), cdf._2()) for cdf in cdfs]
 
     def bucket_count(self):
+        """Returns the number of buckets within the histogram.
+
+        Returns:
+            int
+        """
+
         return self.scala_histogram.bucketCount()
 
     def quantile_breaks(self):
+        """Returns quantile breaks for this Layer.
+
+        Args:
+            num_breaks (int): The number of breaks to return.
+        """
+
         return list(self.scala_histogram.quantileBreaks())
 
     def merge(self, other_histogram):
+        """Merges this instance of ``Histogram`` with another. The resulting ``Histogram``
+        will contain values from both ``Histogram``s
+
+        Args:
+            other_histogram (:class:`~geopyspark.geotrellis.histogram.Histogram`): The
+                ``Histogram`` that should be merged with this instance.
+
+        Returns:
+            :class:`~geopyspark.geotrellis.histogram.Histogram`
+        """
+
         return Histogram(self.scala_histogram.merge(other_histogram.scala_histogram))

--- a/geopyspark/geotrellis/histogram.py
+++ b/geopyspark/geotrellis/histogram.py
@@ -135,14 +135,17 @@ class Histogram(object):
 
         return self.scala_histogram.bucketCount()
 
-    def quantile_breaks(self):
+    def quantile_breaks(self, num_breaks):
         """Returns quantile breaks for this Layer.
 
         Args:
             num_breaks (int): The number of breaks to return.
+
+        Returns:
+            ``[int]``
         """
 
-        return list(self.scala_histogram.quantileBreaks())
+        return list(self.scala_histogram.quantileBreaks(num_breaks))
 
     def merge(self, other_histogram):
         """Merges this instance of ``Histogram`` with another. The resulting ``Histogram``

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -14,6 +14,7 @@ from geopyspark import map_key_input, create_python_rdd
 from pyspark.storagelevel import StorageLevel
 from shapely.geometry import Polygon, MultiPolygon
 from geopyspark.geotrellis import Metadata
+from geopyspark.geotrellis.histogram import Histogram
 from geopyspark.geotrellis.constants import (Operation,
                                              Neighborhood as nb,
                                              ResampleMethod,
@@ -21,7 +22,7 @@ from geopyspark.geotrellis.constants import (Operation,
                                              CellType,
                                              LayoutScheme,
                                              LayerType,
-                                             NO_DATA_INT,
+                                             NO_DATA_INT
                                             )
 from geopyspark.geotrellis.neighborhood import Neighborhood
 
@@ -1028,7 +1029,7 @@ class TiledRasterLayer(CachableLayer):
             histogram = self.srdd.getDoubleHistograms()
         else:
             histogram = self.srdd.getIntHistograms()
-        return histogram
+        return Histogram(histogram)
 
     def _process_operation(self, value, operation):
         if isinstance(value, int) or isinstance(value, float):

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -1017,18 +1017,17 @@ class TiledRasterLayer(CachableLayer):
         return self.srdd.isFloatingPointLayer()
 
     def get_histogram(self):
-        """Returns an array of Java histogram objects, one for each band of the raster.
-
-        Args:
-            None
+        """Creates a ``Histogram`` from the values within this layer.
 
         Returns:
             :class:`~geopyspark.geotrellis.histogram.Histogram`
         """
+
         if self.is_floating_point_layer:
             histogram = self.srdd.getDoubleHistograms()
         else:
             histogram = self.srdd.getIntHistograms()
+
         return Histogram(histogram)
 
     def _process_operation(self, value, operation):

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -1023,7 +1023,7 @@ class TiledRasterLayer(CachableLayer):
             None
 
         Returns:
-            An array of Java objects containing the histograms of each band
+            :class:`~geopyspark.geotrellis.histogram.Histogram`
         """
         if self.is_floating_point_layer:
             histogram = self.srdd.getDoubleHistograms()

--- a/geopyspark/tests/histogram_test.py
+++ b/geopyspark/tests/histogram_test.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 
 from geopyspark.geotrellis import SpatialKey, Tile
-from geopyspark.geotrellis.constants import SPATIAL
+from geopyspark.geotrellis.constants import LayerType
 from geopyspark.geotrellis.layer import TiledRasterLayer
 from geopyspark.tests.base_test_class import BaseTestClass
 
@@ -30,7 +30,7 @@ class HistogramTest(BaseTestClass):
 
     tile = Tile(arr, 'FLOAT', -500)
     rdd = BaseTestClass.pysc.parallelize([(spatial_key, tile)])
-    tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd, metadata)
+    tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, metadata)
 
     hist = tiled.get_histogram()
 
@@ -69,7 +69,8 @@ class HistogramTest(BaseTestClass):
 
         tile2 = Tile(arr2, 'FLOAT', -500)
         rdd2 = BaseTestClass.pysc.parallelize([(self.spatial_key, tile2)])
-        tiled2 = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd2, self.metadata)
+        tiled2 = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd2,
+                                                 self.metadata)
 
         hist2 = tiled2.get_histogram()
 

--- a/geopyspark/tests/histogram_test.py
+++ b/geopyspark/tests/histogram_test.py
@@ -1,0 +1,84 @@
+import unittest
+import pytest
+import numpy as np
+
+from geopyspark.geotrellis import SpatialKey, Tile
+from geopyspark.geotrellis.constants import SPATIAL
+from geopyspark.geotrellis.layer import TiledRasterLayer
+from geopyspark.tests.base_test_class import BaseTestClass
+
+
+class HistogramTest(BaseTestClass):
+    extent = {'xmin': 0.0, 'ymin': 0.0, 'xmax': 33.0, 'ymax': 33.0}
+    layout = {'layoutCols': 1, 'layoutRows': 1, 'tileCols': 4, 'tileRows': 4}
+    metadata = {'cellType': 'float32ud-1.0',
+                'extent': extent,
+                'crs': '+proj=longlat +datum=WGS84 +no_defs ',
+                'bounds': {
+                    'minKey': {'col': 0, 'row': 0},
+                    'maxKey': {'col': 0, 'row': 0}},
+                'layoutDefinition': {
+                    'extent': extent,
+                    'tileLayout': {'tileCols': 4, 'tileRows': 4, 'layoutCols': 1, 'layoutRows': 1}}}
+
+    spatial_key = SpatialKey(0, 0)
+
+    arr = np.array([[[1.0, 1.0, 1.0, 1.0],
+                     [2.0, 2.0, 2.0, 2.0],
+                     [3.0, 3.0, 3.0, 3.0],
+                     [4.0, 4.0, 4.0, 4.0]]], dtype=float)
+
+    tile = Tile(arr, 'FLOAT', -500)
+    rdd = BaseTestClass.pysc.parallelize([(spatial_key, tile)])
+    tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd, metadata)
+
+    hist = tiled.get_histogram()
+
+    def test_min(self):
+        self.assertEqual(self.hist.min(), 1.0)
+
+    def test_max(self):
+        self.assertEqual(self.hist.max(), 4.0)
+
+    def test_min_max(self):
+        self.assertEqual(self.hist.min_max(), (1.0, 4.0))
+
+    def test_mean(self):
+        self.assertEqual(self.hist.mean(), 2.5)
+
+    def test_median(self):
+        self.assertEqual(self.hist.median(), 2.5)
+
+    def test_cdf(self):
+        expected_cdf = [(1.0, 0.25), (2.0, 0.5), (3.0, 0.75), (4.0, 1.0)]
+
+        self.assertEqual(self.hist.cdf(), expected_cdf)
+
+    def test_bucket_count(self):
+        self.assertEqual(self.hist.bucket_count(), 4)
+
+    def test_values(self):
+        self.assertEqual(self.hist.values(), [1.0, 2.0, 3.0, 4.0])
+
+    def test_merge(self):
+
+        arr2 = np.array([[[1.0, 1.0, 1.0, 1.0],
+                         [1.0, 1.0, 1.0, 1.0],
+                         [1.0, 1.0, 1.0, 1.0],
+                         [1.0, 1.0, 1.0, 1.0]]], dtype=float)
+
+        tile2 = Tile(arr2, 'FLOAT', -500)
+        rdd2 = BaseTestClass.pysc.parallelize([(self.spatial_key, tile2)])
+        tiled2 = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, SPATIAL, rdd2, self.metadata)
+
+        hist2 = tiled2.get_histogram()
+
+        merged = self.hist.merge(hist2)
+
+
+        self.assertEqual(merged.values(), [1.0, 2.0, 3.0, 4.0])
+        self.assertEqual(merged.mean(), 1.75)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/geopyspark/tests/histogram_test.py
+++ b/geopyspark/tests/histogram_test.py
@@ -63,9 +63,9 @@ class HistogramTest(BaseTestClass):
     def test_merge(self):
 
         arr2 = np.array([[[1.0, 1.0, 1.0, 1.0],
-                         [1.0, 1.0, 1.0, 1.0],
-                         [1.0, 1.0, 1.0, 1.0],
-                         [1.0, 1.0, 1.0, 1.0]]], dtype=float)
+                          [1.0, 1.0, 1.0, 1.0],
+                          [1.0, 1.0, 1.0, 1.0],
+                          [1.0, 1.0, 1.0, 1.0]]], dtype=float)
 
         tile2 = Tile(arr2, 'FLOAT', -500)
         rdd2 = BaseTestClass.pysc.parallelize([(self.spatial_key, tile2)])


### PR DESCRIPTION
This PR adds the `Histogram` class to GeoPySpark. This acts as a wrapper for GeoTrellis' `Histogram[T]` type. This class can do many of the same tasks its Scala counterpart can do, and is what's expected and returned when dealing with histograms in GeoPySpark.

This PR resolves #286 