### PR TITLE
Pyramiding Test Now Works for Python3.6

### DIFF
--- a/geopyspark/tests/pyramiding_test.py
+++ b/geopyspark/tests/pyramiding_test.py
@@ -82,14 +82,16 @@ class PyramidingTest(BaseTestClass):
         previous_layout_cols = None
         previous_layout_rows = None
 
-        for x in result.levels.values():
-            metadata = x.layer_metadata
+        values = sorted(list(result.levels.items()), reverse=True, key=lambda tup: tup[0])
+
+        for x in values:
+            metadata = x[1].layer_metadata
             layout_cols = metadata.tile_layout.layoutCols
             layout_rows = metadata.tile_layout.layoutRows
 
             if previous_layout_cols and previous_layout_rows:
-                self.assertEqual(layout_cols, previous_layout_cols*2)
-                self.assertEqual(layout_rows, previous_layout_rows*2)
+                self.assertEqual(layout_cols*2, previous_layout_cols)
+                self.assertEqual(layout_rows*2, previous_layout_rows)
             else:
                 self.assertTrue(layout_cols % 2 == 0)
                 self.assertTrue(layout_rows % 2 == 0)


### PR DESCRIPTION
As of right now, the `pyramiding_test` fails for Python3.6 ([link](https://travis-ci.org/locationtech-labs/geopyspark/jobs/248427028#L3589) to Travis log). The cause of this appears to be the order in which values are returned from a `dict` between Python3.6 and the earlier versions of Python. This PR sorts the values of the list to ensure the tests are using the expected values.