### PR TITLE
Linter for GeoPySpark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ before_install:
 install:
   - pip3 install -r requirements.txt
   - pip3 install pyproj
+  - pip3 install pylint
   - pip3 install .
 
 cache:
@@ -49,3 +50,4 @@ script:
   - "export JAVA_HOME=/usr/lib/jvm/java-8-oracle"
   - pytest -k "schema" geopyspark/tests/schema_tests/
   - pytest -k "not schema" geopyspark/tests/*test.py
+  - pylint geopyspark

--- a/geopyspark/__init__.py
+++ b/geopyspark/__init__.py
@@ -1,9 +1,9 @@
-from geopyspark.geopyspark_utils import ensure_pyspark
-ensure_pyspark()
-
 import os
 import glob
 from pkg_resources import resource_filename
+
+from geopyspark.geopyspark_utils import ensure_pyspark
+ensure_pyspark()
 
 from geopyspark.geopyspark_constants import JAR
 
@@ -55,21 +55,21 @@ def geopyspark_conf(master=None, appName=None, additional_jar_dirs=[]):
     object may be used as is , or may be adjusted according to the user's needs.
 
     Args:
-        master (string): The master URL to connect to, such as "local" to run 
-            locally with one thread, "local[4]" to run locally with 4 cores, or 
+        master (string): The master URL to connect to, such as "local" to run
+            locally with one thread, "local[4]" to run locally with 4 cores, or
             "spark://master:7077" to run on a Spark standalone cluster.
-        appName (string): The name of the application, as seen in the Spark 
+        appName (string): The name of the application, as seen in the Spark
             console
         additional_jar_dirs (optional, list): A list of directory locations that
-            might contain JAR files needed by the current script.  Already 
+            might contain JAR files needed by the current script.  Already
             includes $(cwd)/jars.
 
     Returns:
         [SparkConf]
 
     Note:
-        The GEOPYSPARK_JARS_DIR environment variable may contain a colon-separated 
-        list of directories to search for JAR files to make available via the 
+        The GEOPYSPARK_JARS_DIR environment variable may contain a colon-separated
+        list of directories to search for JAR files to make available via the
         SparkConf.
     """
     conf = SparkConf()
@@ -90,10 +90,10 @@ def geopyspark_conf(master=None, appName=None, additional_jar_dirs=[]):
     cwd = os.getcwd()
 
     if 'GEOPYSPARK_JARS_PATH' in os.environ:
-        additional_jar_dirs=os.environ['GEOPYSPARK_JARS_PATH'].split(':')
+        additional_jar_dirs = os.environ['GEOPYSPARK_JARS_PATH'].split(':')
     else:
-        additional_jar_dirs=[]
-    
+        additional_jar_dirs = []
+
     local_prefixes = [
         os.path.abspath(os.path.join(current_location, 'jars')),
         os.path.abspath(os.path.join(cwd, 'jars')),
@@ -114,7 +114,7 @@ def geopyspark_conf(master=None, appName=None, additional_jar_dirs=[]):
     returned = [glob.glob(jar_files) for jar_files in possible_jars]
     jars = [jar for sublist in returned for jar in sublist]
 
-    if len(jars) == 0:
+    if not jars:
         raise IOError("Failed to find any jars. Looked at these paths {}".format(possible_jars))
 
     jar_string = ",".join(jars)

--- a/geopyspark/geopyspark_utils.py
+++ b/geopyspark/geopyspark_utils.py
@@ -4,9 +4,6 @@ import sys
 
 import os
 from os import path
-from pkg_resources import resource_filename
-
-from geopyspark.geopyspark_constants import JAR
 
 
 def ensure_pyspark():

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -1,10 +1,11 @@
 """This subpackage contains the code that reads, writes, and processes data using GeoTrellis."""
 from collections import namedtuple
-from shapely.geometry import box
 import warnings
 import functools
+from shapely.geometry import box
 
 from geopyspark.geotrellis.constants import CellType, NO_DATA_INT
+from . import converters
 
 
 def deprecated(func):
@@ -398,5 +399,3 @@ class Metadata(object):
 
 __all__ = ["catalog", "geotiff", "layer", "cost_distance", "hillshade", "euclidean_distance",
            "rasterize", "tms"]
-
-from . import converters

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -5,7 +5,6 @@ import functools
 from shapely.geometry import box
 
 from geopyspark.geotrellis.constants import CellType, NO_DATA_INT
-from . import converters
 
 
 def deprecated(func):
@@ -399,3 +398,5 @@ class Metadata(object):
 
 __all__ = ["catalog", "geotiff", "layer", "cost_distance", "hillshade", "euclidean_distance",
            "rasterize", "tms"]
+
+from . import converters

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -5,15 +5,15 @@ import json
 from collections import namedtuple
 from urllib.parse import urlparse
 
+from shapely.geometry import Polygon, MultiPolygon, Point
+from shapely.wkt import dumps
+import shapely.wkb
+
 from geopyspark import map_key_input
 from geopyspark.geotrellis.constants import LayerType, IndexingMethod
 from geopyspark.geotrellis.protobufcodecs import multibandtile_decoder
 from geopyspark.geotrellis import Metadata, Extent, deprecated
 from geopyspark.geotrellis.layer import TiledRasterLayer
-
-from shapely.geometry import Polygon, MultiPolygon, Point
-from shapely.wkt import dumps
-import shapely.wkb
 
 
 _mapped_cached = {}

--- a/geopyspark/geotrellis/color.py
+++ b/geopyspark/geotrellis/color.py
@@ -1,9 +1,9 @@
+import struct
 from geopyspark.geopyspark_utils import ensure_pyspark
 ensure_pyspark()
 
 from geopyspark.geotrellis.constants import ClassificationStrategy
 
-import struct
 
 def get_breaks_from_colors(colors):
     """Returns a list of integer colors from a list of Color objects from the
@@ -43,7 +43,7 @@ def get_breaks_from_matplot(ramp_name, num_colors):
     import colortools
     import matplotlib.cm as mpc
     ramp = mpc.get_cmap(ramp_name)
-    return  [ struct.unpack('>L', bytes(map(lambda x: int(x*255), ramp(x / (num_colors - 1)))))[0] for x in range(0, num_colors)]
+    return  [struct.unpack('>L', bytes(map(lambda x: int(x*255), ramp(x / (num_colors - 1)))))[0] for x in range(0, num_colors)]
 
 def get_breaks(pysc, ramp_name, num_colors=None):
     """Returns a list of values that represent the breaks in color for the given color ramp.
@@ -94,28 +94,29 @@ def get_hex(pysc, ramp_name, num_colors=None):
 
 """A dict giving the color mapping from NLCD values to colors
 """
-nlcd_color_map =  { 0  : 0x00000000,
-                    11 : 0x526095FF,     # Open Water
-                    12 : 0xFFFFFFFF,     # Perennial Ice/Snow
-                    21 : 0xD28170FF,     # Low Intensity Residential
-                    22 : 0xEE0006FF,     # High Intensity Residential
-                    23 : 0x990009FF,     # Commercial/Industrial/Transportation
-                    31 : 0xBFB8B1FF,     # Bare Rock/Sand/Clay
-                    32 : 0x969798FF,     # Quarries/Strip Mines/Gravel Pits
-                    33 : 0x382959FF,     # Transitional
-                    41 : 0x579D57FF,     # Deciduous Forest
-                    42 : 0x2A6B3DFF,     # Evergreen Forest
-                    43 : 0xA6BF7BFF,     # Mixed Forest
-                    51 : 0xBAA65CFF,     # Shrubland
-                    61 : 0x45511FFF,     # Orchards/Vineyards/Other
-                    71 : 0xD0CFAAFF,     # Grasslands/Herbaceous
-                    81 : 0xCCC82FFF,     # Pasture/Hay
-                    82 : 0x9D5D1DFF,     # Row Crops
-                    83 : 0xCD9747FF,     # Small Grains
-                    84 : 0xA7AB9FFF,     # Fallow
-                    85 : 0xE68A2AFF,     # Urban/Recreational Grasses
-                    91 : 0xB6D8F5FF,     # Woody Wetlands
-                    92 : 0xB6D8F5FF }    # Emergent Herbaceous Wetlands
+nlcd_color_map = {
+    0  : 0x00000000,
+    11 : 0x526095FF,     # Open Water
+    12 : 0xFFFFFFFF,     # Perennial Ice/Snow
+    21 : 0xD28170FF,     # Low Intensity Residential
+    22 : 0xEE0006FF,     # High Intensity Residential
+    23 : 0x990009FF,     # Commercial/Industrial/Transportation
+    31 : 0xBFB8B1FF,     # Bare Rock/Sand/Clay
+    32 : 0x969798FF,     # Quarries/Strip Mines/Gravel Pits
+    33 : 0x382959FF,     # Transitional
+    41 : 0x579D57FF,     # Deciduous Forest
+    42 : 0x2A6B3DFF,     # Evergreen Forest
+    43 : 0xA6BF7BFF,     # Mixed Forest
+    51 : 0xBAA65CFF,     # Shrubland
+    61 : 0x45511FFF,     # Orchards/Vineyards/Other
+    71 : 0xD0CFAAFF,     # Grasslands/Herbaceous
+    81 : 0xCCC82FFF,     # Pasture/Hay
+    82 : 0x9D5D1DFF,     # Row Crops
+    83 : 0xCD9747FF,     # Small Grains
+    84 : 0xA7AB9FFF,     # Fallow
+    85 : 0xE68A2AFF,     # Urban/Recreational Grasses
+    91 : 0xB6D8F5FF,     # Woody Wetlands
+    92 : 0xB6D8F5FF}    # Emergent Herbaceous Wetlands
 
 class ColorMap(object):
     """A class to represent a color map

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -143,7 +143,8 @@ class CellType(Enum):
     FLOAT32 = "float32"
     FLOAT64 = "float64"
 
-    def create_user_defined_celltype(self, cell_type, no_data_value):
+    @staticmethod
+    def create_user_defined_celltype(cell_type, no_data_value):
         cell_type = CellType(cell_type).value
 
         if 'bool' in cell_type:

--- a/geopyspark/geotrellis/converters.py
+++ b/geopyspark/geotrellis/converters.py
@@ -1,7 +1,6 @@
-from py4j.java_gateway import JavaObject, JavaMember, get_method, JavaClass
-from py4j.protocol import (
-    Py4JError, get_command_part, get_return_value, register_input_converter,
-    register_output_converter)
+# pylint: skip-file
+from py4j.java_gateway import JavaClass
+from py4j.protocol import register_input_converter
 
 from geopyspark.geotrellis import RasterizerOptions
 

--- a/geopyspark/geotrellis/euclidean_distance.py
+++ b/geopyspark/geotrellis/euclidean_distance.py
@@ -25,8 +25,8 @@ def euclidean_distance(pysc, geometry, source_crs, zoom, cellType='float64'):
         source_crs = str(source_crs)
 
     srdd = pysc._gateway.jvm.geopyspark.geotrellis.SpatialTiledRasterRDD.euclideanDistance(pysc._jsc.sc(),
-                                                                                      shapely.wkb.dumps(geometry),
-                                                                                      source_crs,
-                                                                                      cellType,
-                                                                                      zoom)
+                                                                                           shapely.wkb.dumps(geometry),
+                                                                                           source_crs,
+                                                                                           cellType,
+                                                                                           zoom)
     return TiledRasterLayer(pysc, LayerType.SPATIAL, srdd)

--- a/geopyspark/geotrellis/geotiff.py
+++ b/geopyspark/geotrellis/geotiff.py
@@ -1,9 +1,9 @@
 """This module contains functions that create ``RasterLayer`` from files."""
 
+from functools import reduce
 from geopyspark import map_key_input
 from geopyspark.geotrellis.constants import LayerType
 from geopyspark.geotrellis.layer import RasterLayer
-from functools import reduce
 
 
 def get(pysc,

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -5,14 +5,15 @@ when performing operations.
 '''
 import json
 import shapely.wkb
+from shapely.geometry import Polygon, MultiPolygon
 from geopyspark.geotrellis.protobufcodecs import multibandtile_decoder
 from geopyspark.geotrellis.protobufserializer import ProtoBufSerializer
 from geopyspark.geopyspark_utils import ensure_pyspark
 ensure_pyspark()
 
-from geopyspark import map_key_input, create_python_rdd
 from pyspark.storagelevel import StorageLevel
-from shapely.geometry import Polygon, MultiPolygon
+
+from geopyspark import map_key_input, create_python_rdd
 from geopyspark.geotrellis import Metadata
 from geopyspark.geotrellis.histogram import Histogram
 from geopyspark.geotrellis.constants import (Operation,
@@ -338,7 +339,7 @@ class RasterLayer(CachableLayer):
             target_crs = str(target_crs)
 
         return RasterLayer(self.pysc, self.rdd_type,
-                         self.srdd.reproject(target_crs, ResampleMethod(resample_method).value))
+                           self.srdd.reproject(target_crs, ResampleMethod(resample_method).value))
 
     def cut_tiles(self, layer_metadata, resample_method=ResampleMethod.NEAREST_NEIGHBOR):
         """Cut tiles to layout. May result in duplicate keys.
@@ -547,7 +548,7 @@ class TiledRasterLayer(CachableLayer):
             no_data_constant = CellType(new_type).value + "ud" + str(no_data_value)
 
             return TiledRasterLayer(self.pysc, self.rdd_type,
-                                  self.srdd.convertDataType(no_data_constant))
+                                    self.srdd.convertDataType(no_data_constant))
         else:
             return TiledRasterLayer(self.pysc, self.rdd_type,
                                     self.srdd.convertDataType(CellType(new_type).value))

--- a/geopyspark/geotrellis/neighborhood.py
+++ b/geopyspark/geotrellis/neighborhood.py
@@ -53,7 +53,7 @@ class Square(Neighborhood):
             name (str): The name of the neighborhood which is, "square".
         """
 
-        super().__init__(name="Square", param_1=extent)
+        Neighborhood.__init__(name="Square", param_1=extent)
         self.extent = extent
 
 
@@ -77,7 +77,7 @@ class Circle(Neighborhood):
     """
 
     def __init__(self, radius):
-        super().__init__(name="Circle", param_1=radius)
+        Neighborhood.__init__(name="Circle", param_1=radius)
         self.radius = radius
 
 
@@ -98,7 +98,7 @@ class Nesw(Neighborhood):
     """
 
     def __init__(self, extent):
-        super().__init__(name="Nesw", param_1=extent)
+        Neighborhood.__init__(name="Nesw", param_1=extent)
         self.extent = extent
 
 
@@ -121,7 +121,7 @@ class Wedge(Neighborhood):
     """
 
     def __init__(self, radius, start_angle, end_angle):
-        super().__init__(name="Wedge", param_1=radius, param_2=start_angle, param_3=end_angle)
+        Neighborhood.__init__(name="Wedge", param_1=radius, param_2=start_angle, param_3=end_angle)
         self.radius = radius
         self.start_angle = start_angle
         self.end_angle = end_angle
@@ -144,6 +144,6 @@ class Annulus(Neighborhood):
     """
 
     def __init__(self, inner_radius, outer_radius):
-        super().__init__(name="Annulus", param_1=inner_radius, param_2=outer_radius)
+        Neighborhood.__init__(name="Annulus", param_1=inner_radius, param_2=outer_radius)
         self.inner_radius = inner_radius
         self.outer_radius = outer_radius

--- a/geopyspark/geotrellis/protobufcodecs.py
+++ b/geopyspark/geotrellis/protobufcodecs.py
@@ -218,7 +218,7 @@ def from_pb_space_time_key(pb_space_time_key):
     """
 
     return SpaceTimeKey(col=pb_space_time_key.col, row=pb_space_time_key.row,
-                       instant=pb_space_time_key.instant)
+                        instant=pb_space_time_key.instant)
 
 def space_time_key_decoder(proto_bytes):
     """Decodes a ``SpaceTimeKey`` into Python.

--- a/geopyspark/geotrellis/protobufserializer.py
+++ b/geopyspark/geotrellis/protobufserializer.py
@@ -25,7 +25,7 @@ class ProtoBufSerializer(FramedSerializer):
     __slots__ = ['decoding_method', 'encoding_method']
 
     def __init__(self, decoding_method, encoding_method):
-        super().__init__()
+        FramedSerializer.__init__()
 
         self.decoding_method = decoding_method
         self.encoding_method = encoding_method

--- a/geopyspark/geotrellis/protobufserializer.py
+++ b/geopyspark/geotrellis/protobufserializer.py
@@ -25,7 +25,7 @@ class ProtoBufSerializer(FramedSerializer):
     __slots__ = ['decoding_method', 'encoding_method']
 
     def __init__(self, decoding_method, encoding_method):
-        FramedSerializer.__init__()
+        FramedSerializer.__init__(self)
 
         self.decoding_method = decoding_method
         self.encoding_method = encoding_method

--- a/geopyspark/geotrellis/render.py
+++ b/geopyspark/geotrellis/render.py
@@ -1,9 +1,6 @@
 from geopyspark.geopyspark_utils import ensure_pyspark
 ensure_pyspark()
 
-from geopyspark.geotrellis.constants import ResampleMethod, LayoutScheme
-from .layer import CachableLayer
-from pyspark.storagelevel import StorageLevel
 import geopyspark.geotrellis.color as color
 from geopyspark.geotrellis import deprecated
 

--- a/geopyspark/geotrellis/tms.py
+++ b/geopyspark/geotrellis/tms.py
@@ -1,9 +1,8 @@
-from PIL import Image
-import numpy as np
 import io
+import numpy as np
 
-from py4j.clientserver import ClientServer, JavaParameters, PythonParameters
 from geopyspark.geotrellis.layer import Pyramid
+
 
 class TileRender(object):
     """A Python implementation of the Scala geopyspark.geotrellis.tms.TileRender
@@ -41,7 +40,7 @@ class TileRender(object):
             print("Reshaping to {}x{} matrix".format(rows, cols))
             tile = np.reshape(np.frombuffer(cells, dtype="uint8"), (1, rows, cols)) # turn tile to array with bands
             print("Rendering tile")
-            image=self.render_function(tile)
+            image = self.render_function(tile)
             print("Saving result")
             bio = io.BytesIO()
             image.save(bio, 'PNG')
@@ -50,7 +49,7 @@ class TileRender(object):
             from traceback import print_exc
             print_exc()
 
-    class Java:
+    class Java(object):
         implements = ["geopyspark.geotrellis.tms.TileRender"]
 
 class TMSServer(object):

--- a/pylintrc
+++ b/pylintrc
@@ -4,6 +4,6 @@ ignore=tests,command,protobuf,geopyspark.geotrellis.converters
 
 [MESSAGE CONTROL]
 
-disable=R,W,I,missing-docstring,too-many-arguments,too-few-public-members,too-few-public-methods,no-member,line-too-long,protected-access,invalid-name,import-error,anomalous-backslash-in-string,too-many-statements,too-many-public-methods,slots-on-old-class,no-name-in-module,too-many-instance-attributes,too-many-lines,bad-builtin,too-many-locals,redefined-builtin,redefined-variable-type,too-many-branches,superfluous-parens,no-else-return,ungrouped-imports,assigning-non-slot
+disable=R,W,I,missing-docstring,too-many-arguments,too-few-public-members,too-few-public-methods,no-member,line-too-long,protected-access,invalid-name,import-error,anomalous-backslash-in-string,too-many-statements,too-many-public-methods,slots-on-old-class,no-name-in-module,too-many-instance-attributes,too-many-lines,bad-builtin,too-many-locals,redefined-builtin,redefined-variable-type,too-many-branches,superfluous-parens,no-else-return,ungrouped-imports,assigning-non-slot,wrong-import-position
 
 reports=no

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,9 @@
+[MASTER]
+
+ignore=tests,command,protobuf,geopyspark.geotrellis.converters
+
+[MESSAGE CONTROL]
+
+disable=R,W,I,missing-docstring,too-many-arguments,too-few-public-members,too-few-public-methods,no-member,line-too-long,protected-access,invalid-name,import-error,anomalous-backslash-in-string,too-many-statements,too-many-public-methods,slots-on-old-class,no-name-in-module,too-many-instance-attributes,too-many-lines,bad-builtin,too-many-locals,redefined-builtin,redefined-variable-type,too-many-branches,superfluous-parens,no-else-return,ungrouped-imports,assigning-non-slot
+
+reports=no


### PR DESCRIPTION
This PR makes it so that Travis will now run `pylint` after the tests. This is done to ensure the GeoPySpark is (mostly) up to the Python coding standard. `pylint` will look for formatting issues rather than logic or type errors.

This PR resolves #302 