### PR TITLE
to_png_rdd Method

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/protobuf/tupleMessages.proto
+++ b/geopyspark-backend/geotrellis/src/main/protobuf/tupleMessages.proto
@@ -12,4 +12,5 @@ message ProtoTuple {
   ProtoSpatialKey spatialKey = 3;
   ProtoSpaceTimeKey spaceTimeKey = 4;
   ProtoMultibandTile tiles = 5;
+  bytes imageBytes = 6;
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/PythonTranslator.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/PythonTranslator.scala
@@ -1,5 +1,7 @@
 package geopyspark.geotrellis
 
+import geotrellis.raster._
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.api.java.JavaRDD
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
@@ -564,6 +564,9 @@ class SpatialTiledRasterRDD(
 
   def toProtoRDD(): JavaRDD[Array[Byte]] =
     PythonTranslator.toPython[(SpatialKey, MultibandTile), ProtoTuple](rdd)
+
+  def toPngRDD(pngRDD: RDD[(SpatialKey, Array[Byte])]): JavaRDD[Array[Byte]] =
+    PythonTranslator.toPython[(SpatialKey, Array[Byte]), ProtoTuple](pngRDD)
 }
 
 
@@ -760,6 +763,9 @@ class TemporalTiledRasterRDD(
 
   def toProtoRDD(): JavaRDD[Array[Byte]] =
     PythonTranslator.toPython[(SpaceTimeKey, MultibandTile), ProtoTuple](rdd)
+
+  def toPngRDD(pngRDD: RDD[(SpaceTimeKey, Array[Byte])]): JavaRDD[Array[Byte]] =
+    PythonTranslator.toPython[(SpaceTimeKey, Array[Byte]), ProtoTuple](pngRDD)
 }
 
 
@@ -855,8 +861,8 @@ object SpatialTiledRasterRDD {
 
     SpatialTiledRasterRDD(Some(z), MultibandTileLayerRDD(mbtileRDD, metadata))
   }
-
 }
+
 
 object TemporalTiledRasterRDD {
   def fromProtoEncodedRDD(

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/protobufs/TupleProtoBuf.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/protobufs/TupleProtoBuf.scala
@@ -11,6 +11,8 @@ import geotrellis.raster._
 import geotrellis.vector._
 import geotrellis.spark._
 
+import com.google.protobuf.ByteString
+
 
 trait TupleProtoBuf {
 
@@ -26,6 +28,17 @@ trait TupleProtoBuf {
         multibandTileProtoBufCodec.decode(message.tiles.get))
   }
 
+  implicit def tupleProjectedExtentImageProtoBufCodec =
+    new ProtoBufCodec[(ProjectedExtent, Array[Byte]), ProtoTuple] {
+    def encode(tuple: (ProjectedExtent, Array[Byte])): ProtoTuple =
+      ProtoTuple(
+        projectedExtent = Some(projectedExtentProtoBufCodec.encode(tuple._1)),
+        imageBytes = ByteString.copyFrom(tuple._2))
+
+    def decode(message: ProtoTuple): (ProjectedExtent, Array[Byte]) =
+      throw new Exception("This ProtoBuf message cannot be decoded")
+  }
+
   implicit def tupleTemporalProjectedExtentProtoBufCodec =
     new ProtoBufCodec[(TemporalProjectedExtent, MultibandTile), ProtoTuple] {
     def encode(tuple: (TemporalProjectedExtent, MultibandTile)): ProtoTuple =
@@ -36,6 +49,17 @@ trait TupleProtoBuf {
     def decode(message: ProtoTuple): (TemporalProjectedExtent, MultibandTile) =
       (temporalProjectedExtentProtoBufCodec.decode(message.temporalProjectedExtent.get),
         multibandTileProtoBufCodec.decode(message.tiles.get))
+  }
+
+  implicit def tupleTemporalProjectedExtentImageProtoBufCodec =
+    new ProtoBufCodec[(TemporalProjectedExtent, Array[Byte]), ProtoTuple] {
+    def encode(tuple: (TemporalProjectedExtent, Array[Byte])): ProtoTuple =
+      ProtoTuple(
+        temporalProjectedExtent = Some(temporalProjectedExtentProtoBufCodec.encode(tuple._1)),
+        imageBytes = ByteString.copyFrom(tuple._2))
+
+    def decode(message: ProtoTuple): (TemporalProjectedExtent, Array[Byte]) =
+      throw new Exception("This ProtoBuf message cannot be decoded")
   }
 
   implicit def tupleSpatialKeyProtoBufCodec =
@@ -50,6 +74,17 @@ trait TupleProtoBuf {
         multibandTileProtoBufCodec.decode(message.tiles.get))
   }
 
+  implicit def tupleSpatialKeyImageProtoBufCodec =
+    new ProtoBufCodec[(SpatialKey, Array[Byte]), ProtoTuple] {
+    def encode(tuple: (SpatialKey, Array[Byte])): ProtoTuple =
+      ProtoTuple(
+        spatialKey = Some(spatialKeyProtoBufCodec.encode(tuple._1)),
+        imageBytes = ByteString.copyFrom(tuple._2))
+
+    def decode(message: ProtoTuple): (SpatialKey, Array[Byte]) =
+      throw new Exception("This ProtoBuf message cannot be decoded")
+  }
+
   implicit def tupleSpaceTimeKeyProtoBufCodec =
     new ProtoBufCodec[(SpaceTimeKey, MultibandTile), ProtoTuple] {
     def encode(tuple: (SpaceTimeKey, MultibandTile)): ProtoTuple =
@@ -60,5 +95,16 @@ trait TupleProtoBuf {
     def decode(message: ProtoTuple): (SpaceTimeKey, MultibandTile) =
       (spaceTimeKeyProtoBufCodec.decode(message.spaceTimeKey.get),
         multibandTileProtoBufCodec.decode(message.tiles.get))
+  }
+
+  implicit def tupleSpaceTimeKeyImageProtoBufCodec =
+    new ProtoBufCodec[(SpaceTimeKey, Array[Byte]), ProtoTuple] {
+    def encode(tuple: (SpaceTimeKey, Array[Byte])): ProtoTuple =
+      ProtoTuple(
+        spaceTimeKey = Some(spaceTimeKeyProtoBufCodec.encode(tuple._1)),
+        imageBytes = ByteString.copyFrom(tuple._2))
+
+    def decode(message: ProtoTuple): (SpaceTimeKey, Array[Byte]) =
+      throw new Exception("This ProtoBuf message cannot be decoded")
   }
 }

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -216,6 +216,16 @@ class RasterLayer(CachableLayer):
         return create_python_rdd(self.pysc, result, ser)
 
     def to_png_rdd(self, color_map):
+        """Converts the rasters within this layer to PNGs wich are then converted to bytes.
+        This is returned as a RDD[(K, bytes)].
+
+        Args:
+            color_map (:class:`~geopyspark.geotrellis.color.ColorMap`): A ``ColorMap`` instance
+                used to color the PNGs.
+
+        Returns:
+            RDD[(K, bytes)]
+        """
         result = self.srdd.toPngRDD(color_map.cmap)
         key = map_key_input(LayerType(self.rdd_type).value, False)
         ser = ProtoBufSerializer.create_image_rdd_serializer(key_type=key)
@@ -530,6 +540,17 @@ class TiledRasterLayer(CachableLayer):
         return create_python_rdd(self.pysc, result, ser)
 
     def to_png_rdd(self, color_map):
+        """Converts the rasters within this layer to PNGs wich are then converted to bytes.
+        This is returned as a RDD[(K, bytes)].
+
+        Args:
+            color_map (:class:`~geopyspark.geotrellis.color.ColorMap`): A ``ColorMap`` instance
+                used to color the PNGs.
+
+        Returns:
+            RDD[(K, bytes)]
+        """
+
         result = self.srdd.toPngRDD(color_map.cmap)
         key = map_key_input(LayerType(self.rdd_type).value, True)
         ser = ProtoBufSerializer.create_image_rdd_serializer(key_type=key)

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -215,6 +215,13 @@ class RasterLayer(CachableLayer):
 
         return create_python_rdd(self.pysc, result, ser)
 
+    def to_png_rdd(self, color_map):
+        result = self.srdd.toPngRDD(color_map.cmap)
+        key = map_key_input(LayerType(self.rdd_type).value, False)
+        ser = ProtoBufSerializer.create_image_rdd_serializer(key_type=key)
+
+        return create_python_rdd(self.pysc, result, ser)
+
     def to_tiled_layer(self, extent=None, layout=None, crs=None, tile_size=256,
                        resample_method=ResampleMethod.NEAREST_NEIGHBOR):
         """Converts this ``RasterLayer`` to a ``TiledRasterLayer``.
@@ -519,6 +526,13 @@ class TiledRasterLayer(CachableLayer):
         result = self.srdd.toProtoRDD()
         key = map_key_input(LayerType(self.rdd_type).value, True)
         ser = ProtoBufSerializer.create_tuple_serializer(key_type=key)
+
+        return create_python_rdd(self.pysc, result, ser)
+
+    def to_png_rdd(self, color_map):
+        result = self.srdd.toPngRDD(color_map.cmap)
+        key = map_key_input(LayerType(self.rdd_type).value, True)
+        ser = ProtoBufSerializer.create_image_rdd_serializer(key_type=key)
 
         return create_python_rdd(self.pysc, result, ser)
 

--- a/geopyspark/geotrellis/protobuf/tupleMessages_pb2.py
+++ b/geopyspark/geotrellis/protobuf/tupleMessages_pb2.py
@@ -22,7 +22,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='tupleMessages.proto',
   package='protos',
   syntax='proto3',
-  serialized_pb=_b('\n\x13tupleMessages.proto\x12\x06protos\x1a\x14\x65xtentMessages.proto\x1a\x11keyMessages.proto\x1a\x12tileMessages.proto\"\x93\x02\n\nProtoTuple\x12\x35\n\x0fprojectedExtent\x18\x01 \x01(\x0b\x32\x1c.protos.ProtoProjectedExtent\x12\x45\n\x17temporalProjectedExtent\x18\x02 \x01(\x0b\x32$.protos.ProtoTemporalProjectedExtent\x12+\n\nspatialKey\x18\x03 \x01(\x0b\x32\x17.protos.ProtoSpatialKey\x12/\n\x0cspaceTimeKey\x18\x04 \x01(\x0b\x32\x19.protos.ProtoSpaceTimeKey\x12)\n\x05tiles\x18\x05 \x01(\x0b\x32\x1a.protos.ProtoMultibandTileb\x06proto3')
+  serialized_pb=_b('\n\x13tupleMessages.proto\x12\x06protos\x1a\x14\x65xtentMessages.proto\x1a\x11keyMessages.proto\x1a\x12tileMessages.proto\"\xa7\x02\n\nProtoTuple\x12\x35\n\x0fprojectedExtent\x18\x01 \x01(\x0b\x32\x1c.protos.ProtoProjectedExtent\x12\x45\n\x17temporalProjectedExtent\x18\x02 \x01(\x0b\x32$.protos.ProtoTemporalProjectedExtent\x12+\n\nspatialKey\x18\x03 \x01(\x0b\x32\x17.protos.ProtoSpatialKey\x12/\n\x0cspaceTimeKey\x18\x04 \x01(\x0b\x32\x19.protos.ProtoSpaceTimeKey\x12)\n\x05tiles\x18\x05 \x01(\x0b\x32\x1a.protos.ProtoMultibandTile\x12\x12\n\nimageBytes\x18\x06 \x01(\x0c\x62\x06proto3')
   ,
   dependencies=[extentMessages__pb2.DESCRIPTOR,keyMessages__pb2.DESCRIPTOR,tileMessages__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -72,6 +72,13 @@ _PROTOTUPLE = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='imageBytes', full_name='protos.ProtoTuple.imageBytes', index=5,
+      number=6, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
@@ -85,7 +92,7 @@ _PROTOTUPLE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=93,
-  serialized_end=368,
+  serialized_end=388,
 )
 
 _PROTOTUPLE.fields_by_name['projectedExtent'].message_type = extentMessages__pb2._PROTOPROJECTEDEXTENT

--- a/geopyspark/geotrellis/protobufcodecs.py
+++ b/geopyspark/geotrellis/protobufcodecs.py
@@ -275,6 +275,17 @@ def create_partial_tuple_decoder(key_type):
     return partial(tuple_decoder, key_decoder=key_type)
 
 def image_rdd_decoder(proto_bytes, key_decoder):
+    """Decodes tuple of ``(K, bytes)`` where the bytes are the PNG bytes of the raster and
+    the ``K`` is the raster's corresponding key.
+
+    Args:
+        proto_bytes (bytes): The ProtoBuf encoded bytes of the ProtoBuf class.
+        key_decoder (str): The name of the key type of the tuple.
+
+    Returns:
+        tuple
+    """
+
     tup = tupleMessages_pb2.ProtoTuple.FromString(proto_bytes)
     image_bytes = tup.imageBytes
 
@@ -288,6 +299,16 @@ def image_rdd_decoder(proto_bytes, key_decoder):
         return (from_pb_space_time_key(tup.spaceTimeKey), image_bytes)
 
 def create_partial_image_rdd_decoder(key_type):
+    """Creates a partial, tuple decoder function.
+
+    Args:
+        value_type (str): The type of the value in the tuple.
+
+    Returns:
+        A partial :meth:`~geopyspark.protobufregistry.ProtoBufRegistry.image_rdd_decoder`
+        function that requires ``proto_bytes`` to execute.
+    """
+
     return partial(image_rdd_decoder, key_decoder=key_type)
 
 def _get_decoder(name):

--- a/geopyspark/geotrellis/protobufcodecs.py
+++ b/geopyspark/geotrellis/protobufcodecs.py
@@ -1,5 +1,4 @@
 """Contains the various encoding/decoding methods to bring values to/from Python from Scala."""
-import pickle
 from functools import partial
 import numpy as np
 from geopyspark.geopyspark_utils import ensure_pyspark

--- a/geopyspark/geotrellis/protobufserializer.py
+++ b/geopyspark/geotrellis/protobufserializer.py
@@ -43,6 +43,8 @@ class ProtoBufSerializer(FramedSerializer):
         decoder = _get_decoder(value_type)
         encoder = _get_encoder(value_type)
 
+        return cls(decoder, encoder)
+
     @classmethod
     def create_image_rdd_serializer(cls, key_type):
         decoder = create_partial_image_rdd_decoder(key_type=key_type)

--- a/geopyspark/geotrellis/protobufserializer.py
+++ b/geopyspark/geotrellis/protobufserializer.py
@@ -3,6 +3,7 @@ from geopyspark.geopyspark_utils import ensure_pyspark
 ensure_pyspark()
 from geopyspark.geotrellis.protobufcodecs import (create_partial_tuple_decoder,
                                                   create_partial_tuple_encoder,
+                                                  create_partial_image_rdd_decoder,
                                                   _get_encoder,
                                                   _get_decoder)
 
@@ -41,6 +42,11 @@ class ProtoBufSerializer(FramedSerializer):
     def create_value_serializer(cls, value_type):
         decoder = _get_decoder(value_type)
         encoder = _get_encoder(value_type)
+
+    @classmethod
+    def create_image_rdd_serializer(cls, key_type):
+        decoder = create_partial_image_rdd_decoder(key_type=key_type)
+        encoder = None
 
         return cls(decoder, encoder)
 


### PR DESCRIPTION
This PR adds the `to_png_rdd` method to `RasterLayer` and `TiledRasterLayer`. When called, this will return a `RDD[(K, bytes)]` where the `bytes` the PNG bytes of the raster and the `K` is the corresponding key of the PNG.

This PR resolves #277 