### PR TITLE
write Will Now Work When Passed an IndexingMethod

### DIFF
--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -471,9 +471,9 @@ def write(uri,
     if tiled_raster_rdd.rdd_type == LayerType.SPATIAL:
         cached.writer.writeSpatial(layer_name,
                                    tiled_raster_rdd.srdd,
-                                   index_strategy)
+                                   IndexingMethod(index_strategy).value)
     else:
         cached.writer.writeTemporal(layer_name,
                                     tiled_raster_rdd.srdd,
                                     time_unit,
-                                    index_strategy)
+                                    IndexingMethod(index_strategy).value)


### PR DESCRIPTION
This PR fixes a bug where passing in an `IndexingMethod` to `write` will cause it to fail because the method was never converted to a string.

This PR resolves #315 