### PR TITLE
No Data Value Fix

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/protobufs/TileProtoBuf.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/protobufs/TileProtoBuf.scala
@@ -130,27 +130,10 @@ trait TileProtoBuf {
       val ct = messageToCellType(messageCellType)
 
       message.cellType.get.dataType.toString match {
-        case "BIT" =>
-            ArrayTile(message.uint32Cells.toArray, message.cols, message.rows).interpretAs(ct)
-
-        case ("BYTE" | "SHORT") =>
-          if (messageCellType.hasNoData)
-            ArrayTile(message.sint32Cells.toArray, message.cols, message.rows)
-              .interpretAs(ct)
-              .map { x => if (x == Int.MinValue) messageCellType.nd.toInt else x }
-          else
-            ArrayTile(message.sint32Cells.toArray, message.cols, message.rows).interpretAs(ct)
-
-        case ("UBYTE" | "USHORT") =>
-          if (messageCellType.hasNoData)
-            ArrayTile(message.uint32Cells.toArray, message.cols, message.rows)
-              .interpretAs(ct)
-              .map { x => if (x == Int.MaxValue) messageCellType.nd.toInt else x }
-          else
-            ArrayTile(message.uint32Cells.toArray, message.cols, message.rows).interpretAs(ct)
-
-        case "INT" =>
-            ArrayTile(message.sint32Cells.toArray, message.cols, message.rows).interpretAs(ct)
+        case ("BYTE" | "SHORT" | "INT") =>
+          RawArrayTile(message.sint32Cells.toArray, message.cols, message.rows).interpretAs(ct)
+        case ("BIT" | "UBYTE" | "USHORT") =>
+          RawArrayTile(message.uint32Cells.toArray, message.cols, message.rows).interpretAs(ct)
         case "FLOAT" =>
           ArrayTile(message.floatCells.toArray, message.cols, message.rows).interpretAs(ct)
         case "DOUBLE" =>

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/protobufs/TileProtoBuf.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/protobufs/TileProtoBuf.scala
@@ -114,10 +114,18 @@ trait TileProtoBuf {
           cellType = Some(protoCellType))
 
       protoCellType.dataType.toString match {
-        case ("INT" | "BYTE" | "SHORT") =>
-          initialProtoTile.withSint32Cells(tile.toArray())
-        case ("UBYTE" | "USHORT" | "BIT") =>
+        case "BIT" =>
           initialProtoTile.withUint32Cells(tile.toArray())
+        case "BYTE" =>
+          initialProtoTile.withSint32Cells(tile.interpretAs(ByteCellType).toArray())
+        case "UBYTE" =>
+          initialProtoTile.withUint32Cells(tile.interpretAs(UByteCellType).toArray())
+        case "SHORT" =>
+          initialProtoTile.withSint32Cells(tile.interpretAs(ShortCellType).toArray())
+        case "USHORT" =>
+          initialProtoTile.withUint32Cells(tile.interpretAs(UShortCellType).toArray())
+        case "INT" =>
+          initialProtoTile.withSint32Cells(tile.toArray())
         case "FLOAT" =>
           initialProtoTile.withFloatCells(tile.asInstanceOf[FloatArrayTile].array)
         case "DOUBLE" =>

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -8,6 +8,8 @@ __all__ = ['LayerType', 'LayoutScheme', 'NO_DATA_INT']
 """The NoData value for ints in GeoTrellis."""
 NO_DATA_INT = -2147483648
 
+SCALA_MAX_INT = 2147483648
+
 
 class LayerType(Enum):
     """The type of the key within the tuple of the wrapped RDD."""

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -8,8 +8,6 @@ __all__ = ['LayerType', 'LayoutScheme', 'NO_DATA_INT']
 """The NoData value for ints in GeoTrellis."""
 NO_DATA_INT = -2147483648
 
-SCALA_MAX_INT = 2147483648
-
 
 class LayerType(Enum):
     """The type of the key within the tuple of the wrapped RDD."""

--- a/geopyspark/geotrellis/protobufcodecs.py
+++ b/geopyspark/geotrellis/protobufcodecs.py
@@ -6,7 +6,6 @@ ensure_pyspark()
 
 from geopyspark.geotrellis import (Extent, ProjectedExtent, TemporalProjectedExtent, SpatialKey,
                                    SpaceTimeKey, Tile)
-from geopyspark.geotrellis.constants import NO_DATA_INT, SCALA_MAX_INT
 
 from geopyspark.geotrellis.protobuf.tileMessages_pb2 import ProtoTile, ProtoMultibandTile, ProtoCellType
 from geopyspark.geotrellis.protobuf import keyMessages_pb2
@@ -33,15 +32,15 @@ def from_pb_tile(tile, no_data_value=None, data_type=None):
         data_type = _mapped_data_types[tile.cellType.dataType]
 
     if data_type == 'BIT':
-        cells = np.int8([no_data_value if x == SCALA_MAX_INT else x for x in tile.uint32Cells])
+        cells = np.int8(tile.uint32Cells[:])
     elif data_type == 'BYTE':
-        cells = np.int8([no_data_value if x == NO_DATA_INT else x for x in tile.sint32Cells])
+        cells = np.int8(tile.sint32Cells[:])
     elif data_type == 'UBYTE':
-        cells = np.uint8([no_data_value if x == SCALA_MAX_INT else x for x in tile.uint32Cells])
+        cells = np.uint8(tile.uint32Cells[:])
     elif data_type == 'SHORT':
-        cells = np.int16([no_data_value if x == NO_DATA_INT else x for x in tile.sint32Cells])
+        cells = np.int16(tile.sint32Cells[:])
     elif data_type == 'USHORT':
-        cells = np.uint16([no_data_value if x == SCALA_MAX_INT else x for x in tile.uint32Cells])
+        cells = np.uint16(tile.uint32Cells[:])
     elif data_type == 'INT':
         cells = np.int32(tile.sint32Cells[:])
     elif data_type == 'FLOAT':


### PR DESCRIPTION
This PR fixes an error that occurs when encoding/decoding no data values. The cause of this issue has to do with how ProtoBuf encoded the no data values and how numpy represented these new values.

For more information, see the issue this PR resolves #320 