### PR TITLE
to_geotiff_rdd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ install:
   - pip3 install -r requirements.txt
   - pip3 install pyproj
   - pip3 install pylint
+  - if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then
+    pip3 install pathlib;
+    fi
   - if [[ $TRAVIS_PYTHON_VERSION != "3.3" ]]; then
     pip3 install matplotlib==2.0.0;
     fi

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Constants.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Constants.scala
@@ -40,4 +40,10 @@ object Constants {
   final val LESSTHAN = "LessThan"
   final val LESSTHANOREQUALTO = "LessThanOrEqualTo"
   final val EXACT = "Exact"
+
+  final val NOCOMPRESSION = "NoCompression"
+  final val DEFLATECOMPRESSION = "DeflateCompression"
+
+  final val STRIPED = "Striped"
+  final val TILED = "Tiled"
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
@@ -200,15 +200,12 @@ abstract class RasterRDD[K: ClassTag] extends TileRDD[K] {
     withRDD(rdd.mapValues { multibandTile => multibandTile.subsetBands(bands.asScala) })
 
   def toGeoTiffRDD(
-    storageMethod: String,
-    rowsPerStrip: Int,
-    tileDimensions: java.util.ArrayList[Int],
+    storageMethod: StorageMethod,
     compression: String,
     colorSpace: Int,
     headTags: java.util.Map[String, String],
     bandTags: java.util.ArrayList[java.util.Map[String, String]]
   ): JavaRDD[Array[Byte]] = {
-    val storage = TileRDD.getStorageMethod(storageMethod, rowsPerStrip, tileDimensions)
     val tags =
       if (headTags.isEmpty || bandTags.isEmpty)
         Tags.empty
@@ -216,10 +213,35 @@ abstract class RasterRDD[K: ClassTag] extends TileRDD[K] {
         Tags(headTags.asScala.toMap,
           bandTags.toArray.map(_.asInstanceOf[scala.collection.immutable.Map[String, String]]).toList)
 
-    val options = GeoTiffOptions(storage,
+    val options = GeoTiffOptions(
+      storageMethod,
       TileRDD.getCompression(compression),
       colorSpace,
       None)
+
+    toGeoTiffRDD(tags, options)
+  }
+
+  def toGeoTiffRDD(
+    storageMethod: StorageMethod,
+    compression: String,
+    colorSpace: Int,
+    colorMap: ColorMap,
+    headTags: java.util.Map[String, String],
+    bandTags: java.util.ArrayList[java.util.Map[String, String]]
+  ): JavaRDD[Array[Byte]] = {
+    val tags =
+      if (headTags.isEmpty || bandTags.isEmpty)
+        Tags.empty
+      else
+        Tags(headTags.asScala.toMap,
+          bandTags.toArray.map(_.asInstanceOf[scala.collection.immutable.Map[String, String]]).toList)
+
+    val options = GeoTiffOptions(
+      storageMethod,
+      TileRDD.getCompression(compression),
+      colorSpace,
+      Some(IndexedColorMap.fromColorMap(colorMap)))
 
     toGeoTiffRDD(tags, options)
   }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
@@ -70,7 +70,7 @@ object TileRDD {
     (storageMethod, rowsPerStrip) match {
       case (STRIPED, 0) => Striped()
       case (STRIPED, x) => Striped(x)
-      case (TILED, _) => Tiled(tileDimensions.get(0), tileDimensions.get(2))
+      case (TILED, _) => Tiled(tileDimensions.get(0), tileDimensions.get(1))
     }
 
   def getCompression(compressionType: String): Compression =
@@ -220,32 +220,6 @@ abstract class RasterRDD[K: ClassTag] extends TileRDD[K] {
       TileRDD.getCompression(compression),
       colorSpace,
       None)
-
-    toGeoTiffRDD(tags, options)
-  }
-
-  def toGeoTiffRDD(
-    storageMethod: String,
-    rowsPerStrip: Int,
-    tileDimensions: java.util.ArrayList[Int],
-    compression: String,
-    colorSpace: Int,
-    colorMap: ColorMap,
-    headTags: java.util.Map[String, String],
-    bandTags: java.util.ArrayList[java.util.Map[String, String]]
-  ): JavaRDD[Array[Byte]] = {
-    val storage = TileRDD.getStorageMethod(storageMethod, rowsPerStrip, tileDimensions)
-    val tags =
-      if (headTags.isEmpty || bandTags.isEmpty)
-        Tags.empty
-      else
-        Tags(headTags.asScala.toMap,
-          bandTags.toArray.map(_.asInstanceOf[scala.collection.immutable.Map[String, String]]).toList)
-
-    val options = GeoTiffOptions(storage,
-      TileRDD.getCompression(compression),
-      colorSpace,
-      Some(IndexedColorMap.fromColorMap(colorMap)))
 
     toGeoTiffRDD(tags, options)
   }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
@@ -10,6 +10,8 @@ import geotrellis.raster._
 import geotrellis.raster.resample._
 import geotrellis.raster.render._
 import geotrellis.raster.histogram.Histogram
+import geotrellis.raster.io.geotiff._
+import geotrellis.raster.io.geotiff.compression._
 import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.json._
@@ -59,6 +61,23 @@ object TileRDD {
       .recover({ case e => CRS.fromEpsgCode(crs.toInt) })
       .toOption
   }
+
+  def getStorageMethod(
+    storageMethod: String,
+    rowsPerStrip: Int,
+    tileDimensions: java.util.ArrayList[Int]
+  ): StorageMethod =
+    (storageMethod, rowsPerStrip) match {
+      case (STRIPED, 0) => Striped()
+      case (STRIPED, x) => Striped(x)
+      case (TILED, _) => Tiled(tileDimensions.get(0), tileDimensions.get(2))
+    }
+
+  def getCompression(compressionType: String): Compression =
+    compressionType match {
+      case NOCOMPRESSION => NoCompression
+      case DEFLATECOMPRESSION => DeflateCompression
+    }
 }
 
 abstract class TileRDD[K: ClassTag] {
@@ -180,6 +199,62 @@ abstract class RasterRDD[K: ClassTag] extends TileRDD[K] {
   def bands(bands: java.util.ArrayList[Int]): RasterRDD[K] =
     withRDD(rdd.mapValues { multibandTile => multibandTile.subsetBands(bands.asScala) })
 
+  def toGeoTiffRDD(
+    storageMethod: String,
+    rowsPerStrip: Int,
+    tileDimensions: java.util.ArrayList[Int],
+    compression: String,
+    colorSpace: Int,
+    headTags: java.util.Map[String, String],
+    bandTags: java.util.ArrayList[java.util.Map[String, String]]
+  ): JavaRDD[Array[Byte]] = {
+    val storage = TileRDD.getStorageMethod(storageMethod, rowsPerStrip, tileDimensions)
+    val tags =
+      if (headTags.isEmpty || bandTags.isEmpty)
+        Tags.empty
+      else
+        Tags(headTags.asScala.toMap,
+          bandTags.toArray.map(_.asInstanceOf[scala.collection.immutable.Map[String, String]]).toList)
+
+    val options = GeoTiffOptions(storage,
+      TileRDD.getCompression(compression),
+      colorSpace,
+      None)
+
+    toGeoTiffRDD(tags, options)
+  }
+
+  def toGeoTiffRDD(
+    storageMethod: String,
+    rowsPerStrip: Int,
+    tileDimensions: java.util.ArrayList[Int],
+    compression: String,
+    colorSpace: Int,
+    colorMap: ColorMap,
+    headTags: java.util.Map[String, String],
+    bandTags: java.util.ArrayList[java.util.Map[String, String]]
+  ): JavaRDD[Array[Byte]] = {
+    val storage = TileRDD.getStorageMethod(storageMethod, rowsPerStrip, tileDimensions)
+    val tags =
+      if (headTags.isEmpty || bandTags.isEmpty)
+        Tags.empty
+      else
+        Tags(headTags.asScala.toMap,
+          bandTags.toArray.map(_.asInstanceOf[scala.collection.immutable.Map[String, String]]).toList)
+
+    val options = GeoTiffOptions(storage,
+      TileRDD.getCompression(compression),
+      colorSpace,
+      Some(IndexedColorMap.fromColorMap(colorMap)))
+
+    toGeoTiffRDD(tags, options)
+  }
+
+  def toGeoTiffRDD(
+    tags: Tags,
+    geotiffOptions: GeoTiffOptions
+  ): JavaRDD[Array[Byte]]
+
   def collectMetadata(
     extent: java.util.Map[String, Double],
     layout: java.util.Map[String, Int],
@@ -257,6 +332,17 @@ class ProjectedRasterRDD(val rdd: RDD[(ProjectedExtent, MultibandTile)]) extends
 
   def toPngRDD(pngRDD: RDD[(ProjectedExtent, Array[Byte])]): JavaRDD[Array[Byte]] =
     PythonTranslator.toPython[(ProjectedExtent, Array[Byte]), ProtoTuple](pngRDD)
+
+  def toGeoTiffRDD(
+    tags: Tags,
+    geotiffOptions: GeoTiffOptions
+  ): JavaRDD[Array[Byte]] = {
+    val geotiffRDD = rdd.map { x =>
+      (x._1, MultibandGeoTiff(x._2, x._1.extent, x._1.crs, tags, geotiffOptions).toByteArray)
+    }
+
+    PythonTranslator.toPython[(ProjectedExtent, Array[Byte]), ProtoTuple](geotiffRDD)
+  }
 }
 
 
@@ -308,6 +394,17 @@ class TemporalRasterRDD(val rdd: RDD[(TemporalProjectedExtent, MultibandTile)]) 
 
   def toPngRDD(pngRDD: RDD[(TemporalProjectedExtent, Array[Byte])]): JavaRDD[Array[Byte]] =
     PythonTranslator.toPython[(TemporalProjectedExtent, Array[Byte]), ProtoTuple](pngRDD)
+
+  def toGeoTiffRDD(
+    tags: Tags,
+    geotiffOptions: GeoTiffOptions
+  ): JavaRDD[Array[Byte]] = {
+    val geotiffRDD = rdd.map { x =>
+      (x._1, MultibandGeoTiff(x._2, x._1.extent, x._1.crs, tags, geotiffOptions).toByteArray)
+    }
+
+    PythonTranslator.toPython[(TemporalProjectedExtent, Array[Byte]), ProtoTuple](geotiffRDD)
+  }
 }
 
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
@@ -80,15 +80,12 @@ abstract class TiledRasterRDD[K: SpatialComponent: JsonFormat: ClassTag] extends
   ): TiledRasterRDD[K]
 
   def toGeoTiffRDD(
-    storageMethod: String,
-    rowsPerStrip: Int,
-    tileDimensions: java.util.ArrayList[Int],
+    storageMethod: StorageMethod,
     compression: String,
     colorSpace: Int,
     headTags: java.util.Map[String, String],
     bandTags: java.util.ArrayList[java.util.Map[String, String]]
   ): JavaRDD[Array[Byte]] = {
-    val storage = TileRDD.getStorageMethod(storageMethod, rowsPerStrip, tileDimensions)
     val tags =
       if (headTags.isEmpty || bandTags.isEmpty)
         Tags.empty
@@ -96,7 +93,8 @@ abstract class TiledRasterRDD[K: SpatialComponent: JsonFormat: ClassTag] extends
         Tags(headTags.asScala.toMap,
           bandTags.toArray.map(_.asInstanceOf[scala.collection.immutable.Map[String, String]]).toList)
 
-    val options = GeoTiffOptions(storage,
+    val options = GeoTiffOptions(
+      storageMethod,
       TileRDD.getCompression(compression),
       colorSpace,
       None)
@@ -105,16 +103,13 @@ abstract class TiledRasterRDD[K: SpatialComponent: JsonFormat: ClassTag] extends
   }
 
   def toGeoTiffRDD(
-    storageMethod: String,
-    rowsPerStrip: Int,
-    tileDimensions: java.util.ArrayList[Int],
+    storageMethod: StorageMethod,
     compression: String,
     colorSpace: Int,
     colorMap: ColorMap,
     headTags: java.util.Map[String, String],
     bandTags: java.util.ArrayList[java.util.Map[String, String]]
   ): JavaRDD[Array[Byte]] = {
-    val storage = TileRDD.getStorageMethod(storageMethod, rowsPerStrip, tileDimensions)
     val tags =
       if (headTags.isEmpty || bandTags.isEmpty)
         Tags.empty
@@ -122,7 +117,8 @@ abstract class TiledRasterRDD[K: SpatialComponent: JsonFormat: ClassTag] extends
         Tags(headTags.asScala.toMap,
           bandTags.toArray.map(_.asInstanceOf[scala.collection.immutable.Map[String, String]]).toList)
 
-    val options = GeoTiffOptions(storage,
+    val options = GeoTiffOptions(
+      storageMethod,
       TileRDD.getCompression(compression),
       colorSpace,
       Some(IndexedColorMap.fromColorMap(colorMap)))

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
@@ -79,58 +79,6 @@ abstract class TiledRasterRDD[K: SpatialComponent: JsonFormat: ClassTag] extends
     resampleMethod: String
   ): TiledRasterRDD[K]
 
-  def toGeoTiffRDD(
-    storageMethod: StorageMethod,
-    compression: String,
-    colorSpace: Int,
-    headTags: java.util.Map[String, String],
-    bandTags: java.util.ArrayList[java.util.Map[String, String]]
-  ): JavaRDD[Array[Byte]] = {
-    val tags =
-      if (headTags.isEmpty || bandTags.isEmpty)
-        Tags.empty
-      else
-        Tags(headTags.asScala.toMap,
-          bandTags.toArray.map(_.asInstanceOf[scala.collection.immutable.Map[String, String]]).toList)
-
-    val options = GeoTiffOptions(
-      storageMethod,
-      TileRDD.getCompression(compression),
-      colorSpace,
-      None)
-
-    toGeoTiffRDD(tags, options)
-  }
-
-  def toGeoTiffRDD(
-    storageMethod: StorageMethod,
-    compression: String,
-    colorSpace: Int,
-    colorMap: ColorMap,
-    headTags: java.util.Map[String, String],
-    bandTags: java.util.ArrayList[java.util.Map[String, String]]
-  ): JavaRDD[Array[Byte]] = {
-    val tags =
-      if (headTags.isEmpty || bandTags.isEmpty)
-        Tags.empty
-      else
-        Tags(headTags.asScala.toMap,
-          bandTags.toArray.map(_.asInstanceOf[scala.collection.immutable.Map[String, String]]).toList)
-
-    val options = GeoTiffOptions(
-      storageMethod,
-      TileRDD.getCompression(compression),
-      colorSpace,
-      Some(IndexedColorMap.fromColorMap(colorMap)))
-
-    toGeoTiffRDD(tags, options)
-  }
-
-  def toGeoTiffRDD(
-    tags: Tags,
-    geotiffOptions: GeoTiffOptions
-  ): JavaRDD[Array[Byte]]
-
   def layerMetadata: String = rdd.metadata.toJson.prettyPrint
 
   def mask(wkbs: java.util.ArrayList[Array[Byte]]): TiledRasterRDD[K] = {

--- a/geopyspark-backend/project/Version.scala
+++ b/geopyspark-backend/project/Version.scala
@@ -1,6 +1,6 @@
 object Version {
   val geopyspark = "0.1.0"
-  val geotrellis = "1.2.0-M1-SNAPSHOT"
+  val geotrellis = "1.2.0-SNAPSHOT"
   val scala       = "2.11.11"
   val crossScala  = Seq("2.11.11", "2.10.6")
   val scalaTest   = "2.2.0"

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -179,11 +179,15 @@ class ColorRamp(Enum):
 
 
 class StorageMethod(Enum):
+    """Internal storage methods for GeoTiffs."""
+
     STRIPED = "Striped"
     TILED = "Tiled"
 
 
 class ColorSpace(IntEnum):
+    """Color space types for GeoTiffs."""
+
     WHITE_IS_ZERO = 0
     BLACK_IS_ZERO = 1
     RGB = 2
@@ -201,5 +205,7 @@ class ColorSpace(IntEnum):
 
 
 class Compression(Enum):
+    """Compression methods for GeoTiffs."""
+
     NO_COMPRESSION = "NoCompression"
     DEFLATE_COMPRESSION = "DeflateCompression"

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -1,5 +1,5 @@
 """Constants that are used by ``geopyspark.geotrellis`` classes, methods, and functions."""
-from enum import Enum
+from enum import Enum, IntEnum
 
 
 __all__ = ['LayerType', 'LayoutScheme', 'NO_DATA_INT']
@@ -176,3 +176,30 @@ class ColorRamp(Enum):
     HEATMAP_LIGHT_PURPLE_TO_DARK_PURPLE_TO_WHITE = "HeatmapLightPurpleToDarkPurpleToWhite"
     CLASSIFICATION_BOLD_LAND_USE = "ClassificationBoldLandUse"
     CLASSIFICATION_MUTED_TERRAIN = "ClassificationMutedTerrain"
+
+
+class StorageMethod(Enum):
+    STRIPED = "Striped"
+    TILED = "Tiled"
+
+
+class ColorSpace(IntEnum):
+    WHITE_IS_ZERO = 0
+    BLACK_IS_ZERO = 1
+    RGB = 2
+    PALETTE = 3
+    TRANSPARENCY_MASK = 4
+    CMYK = 5
+    Y_CB_CR = 6
+    CIE_LAB = 8
+    ICC_LAB = 9
+    ITU_LAB = 10
+    CFA = 32803
+    LINEAR_RAW = 34892
+    LOG_L = 32844
+    LOG_LUV = 32845
+
+
+class Compression(Enum):
+    NO_COMPRESSION = "NoCompression"
+    DEFLATE_COMPRESSION = "DeflateCompression"

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -275,6 +275,37 @@ class RasterLayer(CachableLayer):
                        color_map=None,
                        head_tags=None,
                        band_tags=None):
+        """Converts the rasters within this layer to GeoTiffs which are then converted to bytes.
+        This is returned as a ``RDD[(K, bytes)]``. Where ``K`` is either ``ProjectedExtent`` or
+        ``TemporalProjectedExtent``.
+
+        Args:
+            storage_method (str or :class:`~geopyspark.geotrellis.constants.StorageMethod`, optional): How
+                the segments within the GeoTiffs should be arranged. Default is
+                ``StorageMethod.STRIPED``.
+            rows_per_strip (int, optional): How many rows should be in each strip segment of the
+                GeoTiffs if ``storage_method`` is ``StorageMethod.STRIPED``. If ``None``, then the
+                strip size will default to a value that is 8K or less.
+            tile_dimensions ((int, int), optional): The length and width for each tile segment of the GeoTiff
+                if ``storage_method`` is ``StorageMethod.TILED``. If ``None`` then the default size
+                is ``(256, 256)``.
+            compression (str or :class:`~geopyspark.geotrellis.constants.Compression`, optional): How the
+                data should be compressed. Defaults to ``Compression.NO_COMPRESSION``.
+            color_space (str or :class:`~geopyspark.geotrellis.constants.ColorSpace`, optional): How the
+                colors should be organized in the GeoTiffs. Defaults to
+                ``ColorSpace.BLACK_IS_ZERO``.
+            color_map (:class:`~geopyspark.geotrellis.color.ColorMap`, optional): A ``ColorMap``
+                instance used to color the GeoTiffs to a different gradient.
+            head_tags (dict, optional): A ``dict`` where each key and value is a ``str``.
+            band_tags (list, optional): A ``list`` of ``dict``\s where each key and value is a
+                ``str``.
+
+            Note:
+                For more information on the contents of the tags, see www.gdal.org/gdal_datamodel.html
+
+        Returns:
+            RDD[(K, bytes)]
+        """
 
         result = _to_geotiff_rdd(self.pysc, self.srdd, storage_method, rows_per_strip, tile_dimensions,
                                  compression, color_space, color_map, head_tags, band_tags)
@@ -730,6 +761,37 @@ class TiledRasterLayer(CachableLayer):
                        color_map=None,
                        head_tags=None,
                        band_tags=None):
+        """Converts the rasters within this layer to GeoTiffs which are then converted to bytes.
+        This is returned as a ``RDD[(K, bytes)]``. Where ``K`` is either ``SpatialKey`` or
+        ``SpaceTimeKey``.
+
+        Args:
+            storage_method (str or :class:`~geopyspark.geotrellis.constants.StorageMethod`, optional): How
+                the segments within the GeoTiffs should be arranged. Default is
+                ``StorageMethod.STRIPED``.
+            rows_per_strip (int, optional): How many rows should be in each strip segment of the
+                GeoTiffs if ``storage_method`` is ``StorageMethod.STRIPED``. If ``None``, then the
+                strip size will default to a value that is 8K or less.
+            tile_dimensions ((int, int), optional): The length and width for each tile segment of the GeoTiff
+                if ``storage_method`` is ``StorageMethod.TILED``. If ``None`` then the default size
+                is ``(256, 256)``.
+            compression (str or :class:`~geopyspark.geotrellis.constants.Compression`, optional): How the
+                data should be compressed. Defaults to ``Compression.NO_COMPRESSION``.
+            color_space (str or :class:`~geopyspark.geotrellis.constants.ColorSpace`, optional): How the
+                colors should be organized in the GeoTiffs. Defaults to
+                ``ColorSpace.BLACK_IS_ZERO``.
+            color_map (:class:`~geopyspark.geotrellis.color.ColorMap`, optional): A ``ColorMap``
+                instance used to color the GeoTiffs to a different gradient.
+            head_tags (dict, optional): A ``dict`` where each key and value is a ``str``.
+            band_tags (list, optional): A ``list`` of ``dict``\s where each key and value is a
+                ``str``.
+
+            Note:
+                For more information on the contents of the tags, see www.gdal.org/gdal_datamodel.html
+
+        Returns:
+            RDD[(K, bytes)]
+        """
 
         result = _to_geotiff_rdd(self.pysc, self.srdd, storage_method, rows_per_strip, tile_dimensions,
                                  compression, color_space, color_map, head_tags, band_tags)

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -236,7 +236,6 @@ class RasterLayer(CachableLayer):
         return create_python_rdd(self.pysc, result, ser)
 
     def to_geotiff_rdd(self,
-                       layer_metadata,
                        storage_method=StorageMethod.STRIPED,
                        rows_per_strip=None,
                        tile_dimensions=(256, 256),

--- a/geopyspark/tests/base_test_class.py
+++ b/geopyspark/tests/base_test_class.py
@@ -20,6 +20,8 @@ class BaseTestClass(unittest.TestCase):
         master_str = "local[*]"
 
     conf = geopyspark_conf(master=master_str, appName="test")
+    conf.set('spark.kryoserializer.buffer.max', value='1G')
+    conf.set('spark.ui.enabled', True)
 
     if 'TRAVIS' in os.environ:
         conf.set(key='spark.driver.memory', value='2G')

--- a/geopyspark/tests/to_geotiff_rdd_test.py
+++ b/geopyspark/tests/to_geotiff_rdd_test.py
@@ -1,0 +1,27 @@
+import unittest
+from os import walk, path
+import rasterio
+import pytest
+
+from geopyspark.geotrellis.constants import LayerType
+from geopyspark.tests.python_test_utils import geotiff_test_path
+from geopyspark.geotrellis.geotiff import get
+from geopyspark.tests.base_test_class import BaseTestClass
+
+
+class ToGeoTiffTest(BaseTestClass):
+    dir_path = geotiff_test_path("srtm_52_11.tif")
+    rdd = get(BaseTestClass.pysc, LayerType.SPATIAL, dir_path)
+    metadata = rdd.collect_metadata()
+
+    @pytest.fixture(autouse=True)
+    def tearDown(self):
+        yield
+        BaseTestClass.pysc._gateway.close()
+
+    def test_to_geotiff_rdd_rasterlayer(self):
+        geotiff_rdd = self.rdd.to_geotiff_rdd(self.metadata, rows_per_strip=256)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/geopyspark/tests/to_geotiff_rdd_test.py
+++ b/geopyspark/tests/to_geotiff_rdd_test.py
@@ -1,18 +1,32 @@
+import io
 import unittest
 from os import walk, path
+import tempfile
+import pathlib
 import rasterio
 import pytest
 
+from geopyspark.geotrellis import Tile
 from geopyspark.geotrellis.constants import LayerType
-from geopyspark.tests.python_test_utils import geotiff_test_path
 from geopyspark.geotrellis.geotiff import get
+from geopyspark.tests.python_test_utils import geotiff_test_path
 from geopyspark.tests.base_test_class import BaseTestClass
 
 
 class ToGeoTiffTest(BaseTestClass):
     dir_path = geotiff_test_path("srtm_52_11.tif")
-    rdd = get(BaseTestClass.pysc, LayerType.SPATIAL, dir_path)
+    rdd = get(BaseTestClass.pysc, LayerType.SPATIAL, dir_path, max_tile_size=256, num_partitions=15)
     metadata = rdd.collect_metadata()
+
+    mapped_types = {
+        'int8': 'BYTE',
+        'uint8': 'UBYTE',
+        'int16': 'SHORT',
+        'uint16': 'USHORT',
+        'int32': 'INT',
+        'float': 'FLOAT',
+        'double': 'DOUBLE'
+    }
 
     @pytest.fixture(autouse=True)
     def tearDown(self):
@@ -20,7 +34,60 @@ class ToGeoTiffTest(BaseTestClass):
         BaseTestClass.pysc._gateway.close()
 
     def test_to_geotiff_rdd_rasterlayer(self):
-        geotiff_rdd = self.rdd.to_geotiff_rdd(self.metadata, rows_per_strip=256)
+        geotiff_rdd = self.rdd.to_geotiff_rdd(storage_method="Tiled",
+                                              tile_dimensions=(128, 128),
+                                              #compression="DeflateCompression",
+                                              color_space=0,
+                                              head_tags={'INTERLEAVE': 'BAND'})
+
+        geotiff_bytes = geotiff_rdd.first()[1]
+
+        with tempfile.NamedTemporaryFile() as temp:
+            temp.write(geotiff_bytes)
+            temp_path = pathlib.Path(temp.name)
+
+            with rasterio.open(str(temp_path)) as src:
+                self.assertTrue(src.is_tiled)
+
+                profile = src.profile
+
+                self.assertEqual(profile['blockxsize'], 128)
+                self.assertEqual(profile['blockysize'], 128)
+                self.assertEqual(profile['interleave'], 'band')
+
+
+    def test_to_geotiff_rdd_tiledrasterlayer(self):
+        tiled_rdd = self.rdd.to_tiled_layer()
+        #tiled_collected = tiled_rdd.to_numpy_rdd().map(lambda x: x[1]).collect()
+        tiled_collected = tiled_rdd.to_numpy_rdd().first()[1]
+
+        geotiff_rdd = tiled_rdd.to_geotiff_rdd()
+        #geotiff_collected = geotiff_rdd.map(lambda x: x[1]).collect()
+        geotiff_collected = geotiff_rdd.first()[1]
+
+        def to_geotiff(x):
+            with tempfile.NamedTemporaryFile() as temp:
+                temp.write(x)
+                temp_path = pathlib.Path(temp.name)
+
+                with rasterio.open(str(temp_path)) as src:
+                    self.assertFalse(src.is_tiled)
+                    data = src.read()
+                    return Tile(data, self.mapped_types[str(data.dtype)], src.nodata)
+
+        #rasterio_geotiffs = list(map(to_geotiff, geotiff_collected))
+        rasterio_geotiff = to_geotiff(geotiff_collected)
+
+        self.assertTrue((tiled_collected.cells == rasterio_geotiff.cells).all())
+        self.assertEqual(tiled_collected.cell_type, rasterio_geotiff.cell_type)
+        self.assertEqual(tiled_collected.no_data_value, rasterio_geotiff.no_data_value)
+
+        '''
+        for x, y in zip(tiled_collected, rasterio_geotiffs):
+            self.assertTrue((x.cells == y.cells).all())
+            self.assertEqual(x.cell_type, y.cell_type)
+            self.assertEqual(x.no_data_value, y.no_data_value)
+        '''
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds the `to_geotiff_rdd` method to RasterLayer and TiledRasterLayer. When called, this will return a RDD[(K, bytes)] where the bytes the GeoTiff bytes of the raster and the K is the corresponding key of the GeoTiff.

This PR is based on another, open PR #327 

This PR resolves #278 