### PR TITLE
Band Selection

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
@@ -174,6 +174,12 @@ abstract class RasterRDD[K: ClassTag] extends TileRDD[K] {
 
   def toProtoRDD(): JavaRDD[Array[Byte]]
 
+  def bands(band: Int): RasterRDD[K] =
+    withRDD(rdd.mapValues { multibandTile => multibandTile.subsetBands(band) })
+
+  def bands(bands: java.util.ArrayList[Int]): RasterRDD[K] =
+    withRDD(rdd.mapValues { multibandTile => multibandTile.subsetBands(bands.asScala) })
+
   def collectMetadata(
     extent: java.util.Map[String, Double],
     layout: java.util.Map[String, Int],
@@ -201,7 +207,7 @@ abstract class RasterRDD[K: ClassTag] extends TileRDD[K] {
   protected def cutTiles(layerMetadata: String, resampleMethod: String): TiledRasterRDD[_]
   protected def tileToLayout(tileLayerMetadata: String, resampleMethod: String): TiledRasterRDD[_]
   protected def reproject(target_crs: String, resampleMethod: String): RasterRDD[_]
-  protected def withRDD(result: RDD[(K, MultibandTile)]): RasterRDD[_]
+  protected def withRDD(result: RDD[(K, MultibandTile)]): RasterRDD[K]
 }
 
 class ProjectedRasterRDD(val rdd: RDD[(ProjectedExtent, MultibandTile)]) extends RasterRDD[ProjectedExtent] {

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
@@ -57,6 +57,12 @@ abstract class TiledRasterRDD[K: SpatialComponent: JsonFormat: ClassTag] extends
   def repartition(numPartitions: Int): TiledRasterRDD[K] =
     withRDD(rdd.repartition(numPartitions))
 
+  def bands(band: Int): TiledRasterRDD[K] =
+    withRDD(rdd.mapValues { multibandTile => multibandTile.subsetBands(band) })
+
+  def bands(bands: java.util.ArrayList[Int]): TiledRasterRDD[K] =
+    withRDD(rdd.mapValues { multibandTile => multibandTile.subsetBands(bands.asScala) })
+
   def getZoom: Integer =
     zoomLevel match {
       case None => null

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -11,6 +11,7 @@ from geopyspark.geotrellis.protobufserializer import ProtoBufSerializer
 from geopyspark.geopyspark_utils import ensure_pyspark
 ensure_pyspark()
 
+from py4j.protocol import Py4JJavaError
 from pyspark.storagelevel import StorageLevel
 
 from geopyspark import map_key_input, create_python_rdd
@@ -260,6 +261,17 @@ class RasterLayer(CachableLayer):
 
         return self.tile_to_layout(self.collect_metadata(extent, layout, crs, tile_size),
                                    resample_method)
+
+    def bands(self, band):
+        if isinstance(band, range):
+            band = list(band)
+
+        if isinstance(band, (int, tuple, list)):
+            result = self.srdd.bands(band)
+        else:
+            raise TypeError("band must be an int, tuple, or list. Recieved", type(band), "instead.")
+
+        return RasterLayer(self.pysc, self.rdd_type, result)
 
     def convert_data_type(self, new_type, no_data_value=None):
         """Converts the underlying, raster values to a new ``CellType``.
@@ -559,6 +571,17 @@ class TiledRasterLayer(CachableLayer):
         ser = ProtoBufSerializer.create_image_rdd_serializer(key_type=key)
 
         return create_python_rdd(self.pysc, result, ser)
+
+    def bands(self, band):
+        if isinstance(band, range):
+            band = list(band)
+
+        if isinstance(band, (int, tuple, list)):
+            result = self.srdd.bands(band)
+        else:
+            raise TypeError("band must be an int, tuple, or list. Recieved", type(band), "instead.")
+
+        return TiledRasterLayer(self.pysc, self.rdd_type, result)
 
     def convert_data_type(self, new_type, no_data_value=None):
         """Converts the underlying, raster values to a new ``CellType``.

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -11,7 +11,6 @@ from geopyspark.geotrellis.protobufserializer import ProtoBufSerializer
 from geopyspark.geopyspark_utils import ensure_pyspark
 ensure_pyspark()
 
-from py4j.protocol import Py4JJavaError
 from pyspark.storagelevel import StorageLevel
 
 from geopyspark import map_key_input, create_python_rdd
@@ -272,6 +271,12 @@ class RasterLayer(CachableLayer):
             raise TypeError("band must be an int, tuple, or list. Recieved", type(band), "instead.")
 
         return RasterLayer(self.pysc, self.rdd_type, result)
+
+    def map_tiles(self, func):
+        python_rdd = self.to_numpy_rdd()
+
+        return RasterLayer.from_numpy_rdd(self.pysc, self.rdd_type,
+                                          python_rdd.mapValues(lambda tile: func(tile.cells)))
 
     def convert_data_type(self, new_type, no_data_value=None):
         """Converts the underlying, raster values to a new ``CellType``.
@@ -582,6 +587,13 @@ class TiledRasterLayer(CachableLayer):
             raise TypeError("band must be an int, tuple, or list. Recieved", type(band), "instead.")
 
         return TiledRasterLayer(self.pysc, self.rdd_type, result)
+
+    def map_tiles(self, func):
+        python_rdd = self.to_numpy_rdd()
+
+        return TiledRasterLayer.from_numpy_rdd(self.pysc, self.rdd_type,
+                                               python_rdd.mapValues(lambda tile: func(tile)),
+                                               self.layer_metadata)
 
     def convert_data_type(self, new_type, no_data_value=None):
         """Converts the underlying, raster values to a new ``CellType``.

--- a/geopyspark/tests/band_selection_test.py
+++ b/geopyspark/tests/band_selection_test.py
@@ -1,0 +1,90 @@
+import os
+import unittest
+import numpy as np
+
+import pytest
+
+from shapely.geometry import Point
+from geopyspark.geotrellis import SpatialKey, Tile
+from geopyspark.tests.base_test_class import BaseTestClass
+from geopyspark.geotrellis import cost_distance
+from geopyspark.geotrellis.layer import TiledRasterLayer
+from geopyspark.geotrellis.constants import LayerType
+
+
+class BandSelectionTest(BaseTestClass):
+    band_1 = np.array([
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0, 1.0]])
+
+    band_2 = np.array([
+        [2.0, 2.0, 2.0, 2.0, 2.0],
+        [2.0, 2.0, 2.0, 2.0, 2.0],
+        [2.0, 2.0, 2.0, 2.0, 2.0],
+        [2.0, 2.0, 2.0, 2.0, 2.0],
+        [2.0, 2.0, 2.0, 2.0, 2.0]])
+
+    band_3 = np.array([
+        [3.0, 3.0, 3.0, 3.0, 3.0],
+        [3.0, 3.0, 3.0, 3.0, 3.0],
+        [3.0, 3.0, 3.0, 3.0, 3.0],
+        [3.0, 3.0, 3.0, 3.0, 3.0],
+        [3.0, 3.0, 3.0, 3.0, 3.0]])
+
+    bands = np.array([band_1, band_2, band_3])
+
+    layer = [(SpatialKey(0, 0), Tile(bands, 'FLOAT', -1.0)),
+             (SpatialKey(1, 0), Tile(bands, 'FLOAT', -1.0,)),
+             (SpatialKey(0, 1), Tile(bands, 'FLOAT', -1.0,)),
+             (SpatialKey(1, 1), Tile(bands, 'FLOAT', -1.0,))]
+
+    rdd = BaseTestClass.pysc.parallelize(layer)
+
+    extent = {'xmin': 0.0, 'ymin': 0.0, 'xmax': 33.0, 'ymax': 33.0}
+    layout = {'layoutCols': 2, 'layoutRows': 2, 'tileCols': 5, 'tileRows': 5}
+    metadata = {'cellType': 'float32ud-1.0',
+                'extent': extent,
+                'crs': '+proj=longlat +datum=WGS84 +no_defs ',
+                'bounds': {
+                    'minKey': {'col': 0, 'row': 0},
+                    'maxKey': {'col': 1, 'row': 1}},
+                'layoutDefinition': {
+                    'extent': extent,
+                    'tileLayout': {'tileCols': 5, 'tileRows': 5, 'layoutCols': 2, 'layoutRows': 2}}}
+
+    raster_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, metadata)
+
+    @pytest.fixture(autouse=True)
+    def tearDown(self):
+        yield
+        BaseTestClass.pysc._gateway.close()
+
+    def test_bands_int(self):
+        actual = self.raster_rdd.bands(1).to_numpy_rdd().first()[1]
+        expected = np.array(self.band_2)
+
+        self.assertTrue((expected == actual.cells).all())
+
+    def test_bands_tuple(self):
+        actual = self.raster_rdd.bands((1, 2)).to_numpy_rdd().first()[1]
+        expected = np.array([self.band_2, self.band_3])
+
+        self.assertTrue((expected == actual.cells).all())
+
+    def test_bands_list(self):
+        actual = self.raster_rdd.bands([0, 2]).to_numpy_rdd().first()[1]
+        expected = np.array([self.band_1, self.band_3])
+
+        self.assertTrue((expected == actual.cells).all())
+
+    def test_band_range(self):
+        actual = self.raster_rdd.bands(range(0, 3)).to_numpy_rdd().first()[1]
+        expected = np.array([self.band_1, self.band_2, self.band_3])
+
+        self.assertTrue((expected == actual.cells).all())
+
+if __name__ == "__main__":
+    unittest.main()

--- a/geopyspark/tests/band_selection_test.py
+++ b/geopyspark/tests/band_selection_test.py
@@ -86,5 +86,22 @@ class BandSelectionTest(BaseTestClass):
 
         self.assertTrue((expected == actual.cells).all())
 
+    def test_map_tiles_func(self):
+        def test_func(tile):
+            cells = tile.cells
+            return Tile((cells[0] + cells[1]) / cells[2], tile.cell_type, tile.no_data_value)
+
+        actual = self.raster_rdd.map_tiles(test_func).to_numpy_rdd().first()[1]
+        expected = np.array([self.band_1])
+
+        self.assertTrue((expected == actual.cells).all())
+
+    def test_map_tiles_lambda(self):
+        actual = self.raster_rdd.map_tiles(lambda tile: Tile(tile.cells[0], tile.cell_type,
+                                                             tile.no_data_value)).to_numpy_rdd().first()[1]
+        expected = np.array([self.band_1])
+
+        self.assertTrue((expected == actual.cells).all())
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds to new methods to `RasterLayer` and `TiledRasterLayer` that allows a user to select certain bands or to map over each `Tile` within the layer. These are `bands` and `map_tiles`, respectively. This will allow the user to work with specific bands without having to serialize the wrapped `RDD` to Python itself.

This PR resolves #324 