### PR TITLE
Neighborhod Classes Can Now be Initialized

### DIFF
--- a/geopyspark/geotrellis/neighborhood.py
+++ b/geopyspark/geotrellis/neighborhood.py
@@ -53,7 +53,7 @@ class Square(Neighborhood):
             name (str): The name of the neighborhood which is, "square".
         """
 
-        Neighborhood.__init__(name="Square", param_1=extent)
+        Neighborhood.__init__(self, name="Square", param_1=extent)
         self.extent = extent
 
 
@@ -77,7 +77,7 @@ class Circle(Neighborhood):
     """
 
     def __init__(self, radius):
-        Neighborhood.__init__(name="Circle", param_1=radius)
+        Neighborhood.__init__(self, name="Circle", param_1=radius)
         self.radius = radius
 
 
@@ -98,7 +98,7 @@ class Nesw(Neighborhood):
     """
 
     def __init__(self, extent):
-        Neighborhood.__init__(name="Nesw", param_1=extent)
+        Neighborhood.__init__(self, name="Nesw", param_1=extent)
         self.extent = extent
 
 
@@ -121,7 +121,7 @@ class Wedge(Neighborhood):
     """
 
     def __init__(self, radius, start_angle, end_angle):
-        Neighborhood.__init__(name="Wedge", param_1=radius, param_2=start_angle, param_3=end_angle)
+        Neighborhood.__init__(self, name="Wedge", param_1=radius, param_2=start_angle, param_3=end_angle)
         self.radius = radius
         self.start_angle = start_angle
         self.end_angle = end_angle
@@ -144,6 +144,6 @@ class Annulus(Neighborhood):
     """
 
     def __init__(self, inner_radius, outer_radius):
-        Neighborhood.__init__(name="Annulus", param_1=inner_radius, param_2=outer_radius)
+        Neighborhood.__init__(self, name="Annulus", param_1=inner_radius, param_2=outer_radius)
         self.inner_radius = inner_radius
         self.outer_radius = outer_radius

--- a/geopyspark/tests/focal_test.py
+++ b/geopyspark/tests/focal_test.py
@@ -51,7 +51,6 @@ class FocalTest(BaseTestClass):
 
         self.assertTrue(result.to_numpy_rdd().first()[1].cells[0][1][0] >= 6)
 
-    '''
     def test_focal_sum_int(self):
         result = self.raster_rdd.focal(
             operation=Operation.SUM,
@@ -85,7 +84,6 @@ class FocalTest(BaseTestClass):
                                        param_1=2, param_2=1)
 
         self.assertEqual(result.to_numpy_rdd().first()[1].cells[0][0][0], -1)
-    '''
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR makes it so that `Neighborhood` classes can now be created and uncomments out the `focal` that were removed from testing.

This PR resolves #330 