### PR TITLE
Docstrings Update

### DIFF
--- a/geopyspark/__init__.py
+++ b/geopyspark/__init__.py
@@ -12,10 +12,12 @@ from pyspark.serializers import AutoBatchedSerializer
 
 
 def map_key_input(key_type, is_boundable):
-    """Gets the mapped GeoTrellis type from the `key_type`.
+    """Gets the mapped GeoTrellis type from the ``key_type``.
+
     Args:
         key_type (str): The type of the ``K`` in the tuple, ``(K, V)`` in the RDD.
         is_boundable (bool): Is ``K`` boundable.
+
     Returns:
         The corresponding GeoTrellis type.
     """
@@ -37,12 +39,14 @@ def map_key_input(key_type, is_boundable):
 
 def create_python_rdd(pysc, jrdd, serializer):
     """Creates a Python RDD from a RDD from Scala.
+
     Args:
         jrdd (org.apache.spark.api.java.JavaRDD): The RDD that came from Scala.
         serializer (:class:`~geopyspark.AvroSerializer` or pyspark.serializers.AutoBatchedSerializer(AvroSerializer)):
             An instance of ``AvroSerializer`` that is either alone, or wrapped by ``AutoBatchedSerializer``.
+
     Returns:
-        ``pyspark.RDD``
+        RDD
     """
 
     if isinstance(serializer, AutoBatchedSerializer):
@@ -54,24 +58,25 @@ def geopyspark_conf(master=None, appName=None, additional_jar_dirs=[]):
     """Construct the base SparkConf for use with GeoPySpark.  This configuration
     object may be used as is , or may be adjusted according to the user's needs.
 
+    Note:
+        The GEOPYSPARK_JARS_PATH environment variable may contain a colon-separated
+        list of directories to search for JAR files to make available via the
+        SparkConf.
+
     Args:
         master (string): The master URL to connect to, such as "local" to run
             locally with one thread, "local[4]" to run locally with 4 cores, or
             "spark://master:7077" to run on a Spark standalone cluster.
         appName (string): The name of the application, as seen in the Spark
             console
-        additional_jar_dirs (optional, list): A list of directory locations that
+        additional_jar_dirs (list, optional): A list of directory locations that
             might contain JAR files needed by the current script.  Already
             includes $(cwd)/jars.
 
     Returns:
-        [SparkConf]
-
-    Note:
-        The GEOPYSPARK_JARS_PATH environment variable may contain a colon-separated
-        list of directories to search for JAR files to make available via the
-        SparkConf.
+        SparkConf
     """
+
     conf = SparkConf()
 
     if not appName:

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -26,8 +26,9 @@ def deprecated(func):
 Tile = namedtuple("Tile", 'cells cell_type no_data_value')
 """Represents a raster in GeoPySpark.
 
-    Note: All rasters in GeoPySpark are represented as having multiple bands,
-    even if the original raster just contained one.
+    Note:
+        All rasters in GeoPySpark are represented as having multiple bands, even if the original
+        raster just contained one.
 
     Args:
         cells (nd.array): The raster data itself. It is contained within a NumPy array.
@@ -318,7 +319,6 @@ class Metadata(object):
                 self.no_data_value = NO_DATA_INT
             else:
                 self.no_data_value = float('nan')
-
 
     @classmethod
     def from_dict(cls, metadata_dict):

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -157,7 +157,6 @@ def read_layer_metadata(pysc,
         options (dict, optional): Additional parameters for reading the layer for specific backends.
             The dictionary is only used for ``Cassandra`` and ``HBase``, no other backend requires
             this to be set.
-        numPartitions (int, optional): Sets RDD partition count when reading from catalog.
         **kwargs: The optional parameters can also be set as keywords arguments. The keywords must
             be in camel case. If both options and keywords are set, then the options will be used.
 
@@ -194,7 +193,7 @@ def get_layer_ids(pysc,
         uri (str): The Uniform Resource Identifier used to point towards the desired GeoTrellis
             catalog to be read from. The shape of this string varies depending on backend.
         options (dict, optional): Additional parameters for reading the layer for specific backends.
-            The dictionary is only used for Cassandra and HBase, no other backend requires this
+            The dictionary is only used for ``Cassandra`` and ``HBase``, no other backend requires this
             to be set.
         **kwargs: The optional parameters can also be set as keywords arguments. The keywords must
             be in camel case. If both options and keywords are set, then the options will be used.
@@ -228,8 +227,7 @@ def read(pysc,
          options=None,
          numPartitions=None,
          **kwargs):
-
-    """Deprecated in favor of geopyspark.geotrellis.catalog.query."""
+    """Deprecated in favor of :meth:`~geopyspark.geotrellis.catalog.query`."""
 
     return query(pysc, layer_type, uri, layer_name, layer_zoom, options=options,
                  numPartitions=numPartitions)
@@ -244,8 +242,7 @@ def read_value(pysc,
                zdt=None,
                options=None,
                **kwargs):
-
-    """Reads a single tile from a GeoTrellis catalog.
+    """Reads a single ``Tile`` from a GeoTrellis catalog.
     Unlike other functions in this module, this will not return a ``TiledRasterLayer``, but rather a
     GeoPySpark formatted raster. This is the function to use when creating a tile server.
 
@@ -272,7 +269,7 @@ def read_value(pysc,
             be in camel case. If both options and keywords are set, then the options will be used.
 
     Returns:
-        :ref:`raster` or ``None``
+        :class:`~geopyspark.geotrellis.Tile`
     """
 
     if not _in_bounds(pysc, layer_type, uri, layer_name, layer_zoom, col, row):
@@ -315,7 +312,6 @@ def query(pysc,
           options=None,
           numPartitions=None,
           **kwargs):
-
     """Queries a single, zoom layer from a GeoTrellis catalog given spatial and/or time parameters.
     Unlike read, this method will only return part of the layer that intersects the specified
     region.
@@ -333,7 +329,7 @@ def query(pysc,
             catalog to be read from. The shape of this string varies depending on backend.
         layer_name (str): The name of the GeoTrellis catalog to be querried.
         layer_zoom (int): The zoom level of the layer that is to be querried.
-        query_geom (bytes or shapely.geometry or :class:`~geopyspark.geotrellis.data_structures.Extent`, Optional):
+        query_geom (bytes or shapely.geometry or :class:`~geopyspark.geotrellis.Extent`, Optional):
             The desired spatial area to be returned. Can either be a string, a shapely geometry, or
             instance of ``Extent``, or a WKB verson of the geometry.
 
@@ -364,6 +360,7 @@ def query(pysc,
         :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
 
     """
+
     if options:
         options = options
     elif kwargs:
@@ -431,7 +428,6 @@ def write(uri,
           time_unit=None,
           options=None,
           **kwargs):
-
     """Writes a tile layer to a specified destination.
 
     Args:
@@ -441,9 +437,10 @@ def write(uri,
         layer_zoom (int): The zoom level the layer should be saved at.
         tiled_raster_rdd (:class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`): The
             ``TiledRasterLayer`` to be saved.
-        index_strategy (str): The method used to orginize the saved data. Depending on the type of
-            data within the layer, only certain methods are available. The default method used is,
-            ``ZORDER``.
+        index_strategy (str or :class:`~geopyspark.geotrellis.constants.IndexingMethod`): The
+            method used to orginize the saved data. Depending on the type of data within the layer,
+            only certain methods are available. Can either be a string or a ``IndexingMethod``
+            attribute.  The default method used is, ``ZORDER``.
         time_unit (str, optional): Which time unit should be used when saving spatial-temporal data.
             While this is set to None as default, it must be set if saving spatial-temporal data.
             Depending on the indexing method chosen, different time units are used.
@@ -452,8 +449,8 @@ def write(uri,
             requires this to be set.
         **kwargs: The optional parameters can also be set as keywords arguements. The keywords must
             be in camel case. If both options and keywords are set, then the options will be used.
-
     """
+
     if options:
         options = options
     elif kwargs:

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -148,8 +148,9 @@ def read_layer_metadata(pysc,
 
     Args:
         pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
-        layer_type (str): What the spatial type of the geotiffs are. This is
-            represented by the constants: ``SPATIAL`` and ``SPACETIME``.
+        layer_type (str or :class:`geopyspark.geotrellis.constants.LayerType`): What the spatial type
+            of the geotiffs are. This is represented by either constants within ``LayerType`` or by
+            a string.
         uri (str): The Uniform Resource Identifier used to point towards the desired GeoTrellis
             catalog to be read from. The shape of this string varies depending on backend.
         layer_name (str): The name of the GeoTrellis catalog to be read from.
@@ -251,8 +252,9 @@ def read_value(pysc,
 
     Args:
         pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
-        layer_type (str): What the spatial type of the geotiffs are. This is
-            represented by the constants: ``SPATIAL`` and ``SPACETIME``.
+        layer_type (str or :class:`geopyspark.geotrellis.constants.LayerType`): What the spatial type
+            of the geotiffs are. This is represented by either constants within ``LayerType`` or by
+            a string.
         uri (str): The Uniform Resource Identifier used to point towards the desired GeoTrellis
             catalog to be read from. The shape of this string varies depending on backend.
         layer_name (str): The name of the GeoTrellis catalog to be read from.
@@ -322,9 +324,9 @@ def query(pysc,
 
     Args:
         pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
-        layer_type (str): What the spatial type of the geotiffs are. This is
-            represented by the constants: ``SPATIAL`` and ``SPACETIME``. Note: All of the
-            GeoTiffs must have the same saptial type.
+        layer_type (str or :class:`geopyspark.geotrellis.constants.LayerType`): What the spatial type
+            of the geotiffs are. This is represented by either constants within ``LayerType`` or by
+            a string.
         uri (str): The Uniform Resource Identifier used to point towards the desired GeoTrellis
             catalog to be read from. The shape of this string varies depending on backend.
         layer_name (str): The name of the GeoTrellis catalog to be querried.
@@ -440,7 +442,7 @@ def write(uri,
         index_strategy (str or :class:`~geopyspark.geotrellis.constants.IndexingMethod`): The
             method used to orginize the saved data. Depending on the type of data within the layer,
             only certain methods are available. Can either be a string or a ``IndexingMethod``
-            attribute.  The default method used is, ``ZORDER``.
+            attribute.  The default method used is, ``IndexingMethod.ZORDER``.
         time_unit (str, optional): Which time unit should be used when saving spatial-temporal data.
             While this is set to None as default, it must be set if saving spatial-temporal data.
             Depending on the indexing method chosen, different time units are used.

--- a/geopyspark/geotrellis/color.py
+++ b/geopyspark/geotrellis/color.py
@@ -14,7 +14,7 @@ def get_colors_from_colors(colors):
     colortools package.
 
     Args:
-        colors ([Color]): A list of color stops using colortools.Color
+        colors ([colortools.Color]): A list of color stops using colortools.Color
 
     Returns:
         [int]
@@ -74,10 +74,10 @@ class ColorMap(object):
     """A class that wraps a GeoTrellis ColorMap class.
 
     Args:
-        cmap (py4j.JavaObject): The ``JavaObject`` that represents the GeoTrellis ColorMap.
+        cmap (py4j.java_gateway.JavaObject): The ``JavaObject`` that represents the GeoTrellis ColorMap.
 
     Attributes:
-        cmap (py4j.JavaObject): The ``JavaObject`` that represents the GeoTrellis ColorMap.
+        cmap (py4j.java_gateway.JavaObject): The ``JavaObject`` that represents the GeoTrellis ColorMap.
     """
 
     def __init__(self, cmap):
@@ -87,7 +87,7 @@ class ColorMap(object):
     def build(cls, pysc, breaks=None, colors=None,
               no_data_color=0x00000000, fallback=0x00000000,
               classification_strategy=ClassificationStrategy.LESS_THAN_OR_EQUAL_TO):
-        """Given breaks and colors, build a ColorMap object.
+        """Given breaks and colors, build a ``ColorMap`` object.
 
         Args:
             pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
@@ -104,7 +104,7 @@ class ColorMap(object):
                 value in the mapping
             classification_strategy (str or :class:`~geopyspark.geotrellis.constants.ClassificationStrategy`, optional):
                 A string giving the strategy for converting tile values to colors. e.g., if
-                ``LessThanOrEqualTo`` is specified, and the break map is
+                ``ClassificationStrategy.LESS_THAN_OR_EQUAL_TO`` is specified, and the break map is
                 {3: 0xff0000ff, 4: 0x00ff00ff}, then values up to 3 map to red, values from above 3
                 and up to and including 4 become green, and values over 4 become the fallback color.
 
@@ -148,7 +148,7 @@ class ColorMap(object):
                 value in the mapping
             classification_strategy (str or :class:`~geopyspark.geotrellis.constants.ClassificationStrategy`, optional):
                 A string giving the strategy for converting tile values to colors. e.g., if
-                ``LessThanOrEqualTo`` is specified, and the break map is
+                ``ClassificationStrategy.LESS_THAN_OR_EQUAL_TO`` is specified, and the break map is
                 {3: 0xff0000ff, 4: 0x00ff00ff}, then values up to 3 map to red, values from above 3
                 and up to and including 4 become green, and values over 4 become the fallback color.
 
@@ -171,7 +171,7 @@ class ColorMap(object):
     def from_colors(cls, pysc, breaks, color_list,
                     no_data_color=0x00000000, fallback=0x00000000,
                     classification_strategy=ClassificationStrategy.LESS_THAN_OR_EQUAL_TO):
-        """Converts lists of values and colors to a ColorMap.
+        """Converts lists of values and colors to a ``ColorMap``.
 
         Args:
             pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
@@ -185,7 +185,7 @@ class ColorMap(object):
                 value in the mapping
             classification_strategy (str or :class:`~geopyspark.geotrellis.constants.ClassificationStrategy`, optional):
                 A string giving the strategy for converting tile values to colors. e.g., if
-                ``LessThanOrEqualTo`` is specified, and the break map is
+                ``ClassificationStrategy.LESS_THAN_OR_EQUAL_TO`` is specified, and the break map is
                 {3: 0xff0000ff, 4: 0x00ff00ff}, then values up to 3 map to red, values from above 3
                 and up to and including 4 become green, and values over 4 become the fallback color.
 
@@ -207,7 +207,7 @@ class ColorMap(object):
     def from_histogram(cls, pysc, histogram, color_list,
                        no_data_color=0x00000000, fallback=0x00000000,
                        classification_strategy=ClassificationStrategy.LESS_THAN_OR_EQUAL_TO):
-        """Converts a wrapped GeoTrellis histogram into a ColorMap.
+        """Converts a wrapped GeoTrellis histogram into a ``ColorMap``.
 
         Args:
             pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
@@ -221,7 +221,7 @@ class ColorMap(object):
                 value in the mapping
             classification_strategy (str or :class:`~geopyspark.geotrellis.constants.ClassificationStrategy`, optional):
                 A string giving the strategy for converting tile values to colors. e.g., if
-                ``LessThanOrEqualTo`` is specified, and the break map is
+                ``ClassificationStrategy.LESS_THAN_OR_EQUAL_TO`` is specified, and the break map is
                 {3: 0xff0000ff, 4: 0x00ff00ff}, then values up to 3 map to red, values from above 3
                 and up to and including 4 become green, and values over 4 become the fallback color.
 

--- a/geopyspark/geotrellis/color.py
+++ b/geopyspark/geotrellis/color.py
@@ -1,3 +1,6 @@
+"""This module contains functions needed to create color maps used in coloring tiles,
+PNGs, and GeoTiffs.
+"""
 import struct
 from geopyspark.geotrellis.histogram import Histogram
 from geopyspark.geopyspark_utils import ensure_pyspark
@@ -16,31 +19,21 @@ def get_colors_from_colors(colors):
     Returns:
         [int]
     """
+
     return [struct.unpack(">L", bytes(c.rgba))[0] for c in colors]
 
 def get_colors_from_matplotlib(ramp_name, num_colors=1<<8):
     """Returns a list of color breaks from the color ramps defined by Matplotlib.
 
     Args:
-        ramp_name (str): The name of a matplotlib color ramp; options are
-            'viridis', 'plasma', 'inferno', 'magma', 'Greys', 'Purples', 'Blues',
-            'Greens', 'Oranges', 'Reds', 'YlOrBr', 'YlOrRd', 'OrRd', 'PuRd',
-            'RdPu', 'BuPu', 'GnBu', 'PuBu', 'YlGnBu', 'PuBuGn', 'BuGn', 'YlGn',
-            'binary', 'gist_yarg', 'gist_gray', 'gray', 'bone', 'pink', 'spring',
-            'summer', 'autumn', 'winter', 'cool', 'Wistia', 'hot', 'afmhot',
-            'gist_heat', 'copper', 'PiYG', 'PRGn', 'BrBG', 'PuOr', 'RdGy', 'RdBu',
-            'RdYlBu', 'RdYlGn', 'Spectral', 'coolwarm', 'bwr', 'seismic',
-            'Pastel1', 'Pastel2', 'Paired', 'Accent', 'Dark2', 'Set1', 'Set2',
-            'Set3', 'tab10', 'tab20', 'tab20b', 'tab20c', 'flag', 'prism',
-            'ocean', 'gist_earth', 'terrain', 'gist_stern', 'gnuplot',
-            'gnuplot2', 'CMRmap', 'cubehelix', 'brg', 'hsv', 'gist_rainy
-            'rainbow', 'jet', 'nipy_spectral', 'gist_ncar'.  See the matplotlib
-            documentation for details on each color ramp.
+        ramp_name (str): The name of a matplotlib color ramp. See the matplotlib documentation for
+            a list of names and details on each color ramp.
         num_colors (int, optional): The number of color breaks to derive from the named map.
 
     Returns:
         [int]
     """
+
     try:
         import colortools
         import matplotlib.cm as mpc
@@ -50,8 +43,8 @@ def get_colors_from_matplotlib(ramp_name, num_colors=1<<8):
     ramp = mpc.get_cmap(ramp_name)
     return  [struct.unpack('>L', bytes(map(lambda x: int(x*255), ramp(x / (num_colors - 1)))))[0] for x in range(0, num_colors)]
 
-"""A dict giving the color mapping from NLCD values to colors
-"""
+
+"""A dict giving the color mapping from NLCD values to colors."""
 nlcd_color_map = {
     0  : 0x00000000,
     11 : 0x526095FF,     # Open Water
@@ -76,9 +69,17 @@ nlcd_color_map = {
     91 : 0xB6D8F5FF,     # Woody Wetlands
     92 : 0xB6D8F5FF}    # Emergent Herbaceous Wetlands
 
+
 class ColorMap(object):
-    """A class to represent a color map
+    """A class that wraps a GeoTrellis ColorMap class.
+
+    Args:
+        cmap (py4j.JavaObject): The ``JavaObject`` that represents the GeoTrellis ColorMap.
+
+    Attributes:
+        cmap (py4j.JavaObject): The ``JavaObject`` that represents the GeoTrellis ColorMap.
     """
+
     def __init__(self, cmap):
         self.cmap = cmap
 
@@ -86,32 +87,31 @@ class ColorMap(object):
     def build(cls, pysc, breaks=None, colors=None,
               no_data_color=0x00000000, fallback=0x00000000,
               classification_strategy=ClassificationStrategy.LESS_THAN_OR_EQUAL_TO):
-
         """Given breaks and colors, build a ColorMap object.
 
         Args:
             pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
-            breaks (dict, list, Histogram): If a ``dict`` then a mapping from tile values
-                to colors, the latter represented as integers---e.g., 0xff000080 is red at
-                half opacity.  If a ``list`` then tile values that specify breaks in the
-                color mapping.  If a ``Histogram`` then a histogram from which breaks can
-                be derived.
-            colors (str, list):  If a ``str`` then the name of a matplotlib color ramp.
+            breaks (dict or list or :class:`~geopyspark.geotrellis.Histogram`): If a ``dict`` then a
+                mapping from tile values to colors, the latter represented as integers
+                e.g., 0xff000080 is red at half opacity. If a ``list`` then tile values that
+                specify breaks in the color mapping. If a ``Histogram`` then a histogram from which
+                breaks can be derived.
+            colors (str or list):  If a ``str`` then the name of a matplotlib color ramp.
                 If a ``list`` then either a list of colortools ``Color`` objects or a list
                 of integers containing packed RGBA values.
             no_data_color(int, optional): A color to replace NODATA values with
             fallback (int, optional): A color to replace cells that have no
                 value in the mapping
-            classification_strategy (string, optional): A string giving the strategy
-                for converting tile values to colors.  E.g., if
-                LessThanOrEqualTo is specified, and the break map is
-                {3: 0xff0000ff, 4: 0x00ff00ff}, then values up to 3 map to red,
-                values from above 3 and up to and including 4 become green, and
-                values over 4 become the fallback color.
+            classification_strategy (str or :class:`~geopyspark.geotrellis.constants.ClassificationStrategy`, optional):
+                A string giving the strategy for converting tile values to colors. e.g., if
+                ``LessThanOrEqualTo`` is specified, and the break map is
+                {3: 0xff0000ff, 4: 0x00ff00ff}, then values up to 3 map to red, values from above 3
+                and up to and including 4 become green, and values over 4 become the fallback color.
 
         Returns:
-            [ColorMap]
+            :class:`~geopyspark.geotrellis.color.ColorMap`
         """
+
         if isinstance(colors, str):
             color_list = get_colors_from_matplotlib(colors)
         elif isinstance(colors, list) and all(isinstance(c, int) for c in colors):
@@ -142,19 +142,18 @@ class ColorMap(object):
         Args:
             pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
             break_map (dict): A mapping from tile values to colors, the latter
-                represented as integers---e.g., 0xff000080 is red at half opacity.
+                represented as integers e.g., 0xff000080 is red at half opacity.
             no_data_color(int, optional): A color to replace NODATA values with
             fallback (int, optional): A color to replace cells that have no
                 value in the mapping
-            classification_strategy (string, optional): A string giving the strategy
-                for converting tile values to colors.  E.g., if
-                LessThanOrEqualTo is specified, and the break map is
-                {3: 0xff0000ff, 4: 0x00ff00ff}, then values up to 3 map to red,
-                values from above 3 and up to and including 4 become green, and
-                values over 4 become the fallback color.
+            classification_strategy (str or :class:`~geopyspark.geotrellis.constants.ClassificationStrategy`, optional):
+                A string giving the strategy for converting tile values to colors. e.g., if
+                ``LessThanOrEqualTo`` is specified, and the break map is
+                {3: 0xff0000ff, 4: 0x00ff00ff}, then values up to 3 map to red, values from above 3
+                and up to and including 4 become green, and values over 4 become the fallback color.
 
         Returns:
-            [ColorMap]
+            :class:`~geopyspark.geotrellis.color.ColorMap`
         """
 
         if all(isinstance(x, int) for x in break_map.keys()):
@@ -177,22 +176,21 @@ class ColorMap(object):
         Args:
             pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
             breaks (list): The tile values that specify breaks in the color
-                mapping
-            color_list (int list): The colors corresponding to the values in the
+                mapping.
+            color_list ([int]): The colors corresponding to the values in the
                 breaks list, represented as integers---e.g., 0xff000080 is red
                 at half opacity.
             no_data_color(int, optional): A color to replace NODATA values with
             fallback (int, optional): A color to replace cells that have no
                 value in the mapping
-            classification_strategy (string, optional): A string giving the strategy
-                for converting tile values to colors.  E.g., if
-                LessThanOrEqualTo is specified, and the break map is
-                {3: 0xff0000ff, 4: 0x00ff00ff}, then values up to 3 map to red,
-                values from above 3 and up to and including 4 become green, and
-                values over 4 become the fallback color.
+            classification_strategy (str or :class:`~geopyspark.geotrellis.constants.ClassificationStrategy`, optional):
+                A string giving the strategy for converting tile values to colors. e.g., if
+                ``LessThanOrEqualTo`` is specified, and the break map is
+                {3: 0xff0000ff, 4: 0x00ff00ff}, then values up to 3 map to red, values from above 3
+                and up to and including 4 become green, and values over 4 become the fallback color.
 
         Returns:
-            [ColorMap]
+            :class:`~geopyspark.geotrellis.color.ColorMap`
         """
 
         if all(isinstance(x, int) for x in breaks):
@@ -209,27 +207,26 @@ class ColorMap(object):
     def from_histogram(cls, pysc, histogram, color_list,
                        no_data_color=0x00000000, fallback=0x00000000,
                        classification_strategy=ClassificationStrategy.LESS_THAN_OR_EQUAL_TO):
-
         """Converts a wrapped GeoTrellis histogram into a ColorMap.
 
         Args:
             pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
-            histogram (Histogram): A wrapped GeoTrellis histogram object; specifies breaks
-            color_list (int list): The colors corresponding to the values in the
-                breaks list, represented as integers---e.g., 0xff000080 is red
+            histogram (:class:`~geopyspark.geotrellis.Histogram`): A ``Histogram`` instance;
+                specifies breaks
+            color_list ([int]): The colors corresponding to the values in the
+                breaks list, represented as integers e.g., 0xff000080 is red
                 at half opacity.
             no_data_color(int, optional): A color to replace NODATA values with
             fallback (int, optional): A color to replace cells that have no
                 value in the mapping
-            classification_strategy (string, optional): A string giving the strategy
-                for converting tile values to colors.  E.g., if
-                LessThanOrEqualTo is specified, and the break map is
-                {3: 0xff0000ff, 4: 0x00ff00ff}, then values up to 3 map to red,
-                values from above 3 and up to and including 4 become green, and
-                values over 4 become the fallback color.
+            classification_strategy (str or :class:`~geopyspark.geotrellis.constants.ClassificationStrategy`, optional):
+                A string giving the strategy for converting tile values to colors. e.g., if
+                ``LessThanOrEqualTo`` is specified, and the break map is
+                {3: 0xff0000ff, 4: 0x00ff00ff}, then values up to 3 map to red, values from above 3
+                and up to and including 4 become green, and values over 4 become the fallback color.
 
         Returns:
-            [ColorMap]
+            :class:`~geopyspark.geotrellis.color.ColorMap`
         """
 
         fn = pysc._gateway.jvm.geopyspark.geotrellis.ColorMapUtils.fromHistogram
@@ -244,6 +241,7 @@ class ColorMap(object):
             pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
 
         Returns:
-            [ColorMap]
+            :class:`~geopyspark.geotrellis.color.ColorMap`
         """
+
         return ColorMap.from_break_map(pysc, nlcd_color_map)

--- a/geopyspark/geotrellis/cost_distance.py
+++ b/geopyspark/geotrellis/cost_distance.py
@@ -13,7 +13,8 @@ def cost_distance(friction_layer, geometries, max_distance):
 
             Note:
                 All geometries must be in the same CRS as the TileLayer.
-        max_distance (int, float): The maximum cost that a path may reach before the operation.
+
+        max_distance (int or float): The maximum cost that a path may reach before the operation.
             stops. This value can be an ``int`` or ``float``.
 
     Returns:

--- a/geopyspark/geotrellis/euclidean_distance.py
+++ b/geopyspark/geotrellis/euclidean_distance.py
@@ -13,7 +13,7 @@ def euclidean_distance(pysc, geometry, source_crs, zoom, cellType=CellType.FLOAT
         source_crs (str or int): The CRS of the input geometry.
         zoom (int): The zoom level of the output raster.
         cellType (str or :class:`~geopyspark.geotrellis.constants.CellType`, optional): The data
-            type of the cells for the new layer. If not specified, then ``FLOAT64`` is used.
+            type of the cells for the new layer. If not specified, then ``CellType.FLOAT64`` is used.
 
     Note:
         This function may run very slowly for polygonal inputs if they cover many cells of

--- a/geopyspark/geotrellis/euclidean_distance.py
+++ b/geopyspark/geotrellis/euclidean_distance.py
@@ -1,9 +1,9 @@
 import shapely.wkb
-from geopyspark.geotrellis.constants import LayerType
+from geopyspark.geotrellis.constants import LayerType, CellType
 from geopyspark.geotrellis.layer import TiledRasterLayer
 
 
-def euclidean_distance(pysc, geometry, source_crs, zoom, cellType='float64'):
+def euclidean_distance(pysc, geometry, source_crs, zoom, cellType=CellType.FLOAT64):
     """Calculates the Euclidean distance of a Shapely geometry.
 
     Args:
@@ -12,6 +12,8 @@ def euclidean_distance(pysc, geometry, source_crs, zoom, cellType='float64'):
             for.
         source_crs (str or int): The CRS of the input geometry.
         zoom (int): The zoom level of the output raster.
+        cellType (str or :class:`~geopyspark.geotrellis.constants.CellType`, optional): The data
+            type of the cells for the new layer. If not specified, then ``FLOAT64`` is used.
 
     Note:
         This function may run very slowly for polygonal inputs if they cover many cells of
@@ -27,6 +29,6 @@ def euclidean_distance(pysc, geometry, source_crs, zoom, cellType='float64'):
     srdd = pysc._gateway.jvm.geopyspark.geotrellis.SpatialTiledRasterRDD.euclideanDistance(pysc._jsc.sc(),
                                                                                            shapely.wkb.dumps(geometry),
                                                                                            source_crs,
-                                                                                           cellType,
+                                                                                           CellType(cellType).value,
                                                                                            zoom)
     return TiledRasterLayer(pysc, LayerType.SPATIAL, srdd)

--- a/geopyspark/geotrellis/geotiff.py
+++ b/geopyspark/geotrellis/geotiff.py
@@ -16,17 +16,18 @@ def get(pysc,
         time_tag=None,
         time_format=None,
         s3_client=None):
-
     """Creates a ``RasterLayer`` from GeoTiffs that are located on the local file system, ``HDFS``,
     or ``S3``.
 
     Args:
         pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
-        layer_type (str): What the spatial type of the geotiffs are. This is
-            represented by the constants: ``SPATIAL`` and ``SPACETIME``.
+        layer_type (str or :class:`geopyspark.geotrellis.constants.LayerType`): What the spatial type
+            of the geotiffs are. This is represented by either constants within ``LayerType`` or by
+            a string.
 
             Note:
                 All of the GeoTiffs must have the same saptial type.
+
         uri (str): The path to a given file/directory.
         crs (str, optional): The CRS that the output tiles should be
             in. The CRS must be in the well-known name format. If ``None``,

--- a/geopyspark/geotrellis/hillshade.py
+++ b/geopyspark/geotrellis/hillshade.py
@@ -16,9 +16,13 @@ def hillshade(tiled_raster_layer, band=0, azimuth=315.0, altitude=45.0, z_factor
     Args:
         band (int) [default = 0]: The band of the raster to base the
             hillshade calculation on.
-        azimuth (float) [default = 315]
-        altitude (float) [default = 45]
-        z_factor (float) [default = 1.0]
+        azimuth (float): The azimuth angle of the source of light. Default value is 315.0.
+        altitude (float): The angle of the altitude of the light above the horizon. Default is
+            45.0.
+        z_factor (float): How many x and y units in a single z unit. Default value is 1.0.
+
+    Returns:
+        :class:`~geopyspark.geotrellis.layer.TiledRasterLayer`
     """
 
     srdd = tiled_raster_layer.srdd.hillshade(tiled_raster_layer.pysc._jsc.sc(), azimuth,

--- a/geopyspark/geotrellis/hillshade.py
+++ b/geopyspark/geotrellis/hillshade.py
@@ -14,8 +14,7 @@ def hillshade(tiled_raster_layer, band=0, azimuth=315.0, altitude=45.0, z_factor
     `description <http://goo.gl/DtVDQ>`_ of Hillshade.
 
     Args:
-        band (int) [default = 0]: The band of the raster to base the
-            hillshade calculation on.
+        band (int): The band of the raster to base the hillshade calculation on. Default is 0.
         azimuth (float): The azimuth angle of the source of light. Default value is 315.0.
         altitude (float): The angle of the altitude of the light above the horizon. Default is
             45.0.

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -255,7 +255,7 @@ class RasterLayer(CachableLayer):
         return create_python_rdd(self.pysc, result, ser)
 
     def to_png_rdd(self, color_map):
-        """Converts the rasters within this layer to PNGs wich are then converted to bytes.
+        """Converts the rasters within this layer to PNGs which are then converted to bytes.
         This is returned as a RDD[(K, bytes)].
 
         Args:
@@ -412,7 +412,6 @@ class RasterLayer(CachableLayer):
             :class:`~geopyspark.geotrellis.rdd.RasterLayer`
 
         Raises:
-            ValueError: When an unsupported cell type is entered.
             ValueError: If ``no_data_value`` is set and the ``new_type`` contains raw values.
             ValueError: If ``no_data_value`` is set and ``new_type`` is a boolean.
         """
@@ -575,6 +574,7 @@ class RasterLayer(CachableLayer):
         Returns:
             (float, float)
         """
+
         min_max = self.srdd.getMinMax()
         return (min_max._1(), min_max._2())
 
@@ -655,7 +655,7 @@ class TiledRasterLayer(CachableLayer):
             :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
         """
 
-        key = map_key_input(LayerType(rdd_type).value, True)
+        key = map_key_input(LayerType(layer_type).value, True)
         ser = ProtoBufSerializer.create_tuple_serializer(key_type=key)
         reserialized_rdd = numpy_rdd._reserialize(ser)
 
@@ -691,7 +691,7 @@ class TiledRasterLayer(CachableLayer):
         return create_python_rdd(self.pysc, result, ser)
 
     def to_png_rdd(self, color_map):
-        """Converts the rasters within this layer to PNGs wich are then converted to bytes.
+        """Converts the rasters within this layer to PNGs which are then converted to bytes.
         This is returned as a RDD[(K, bytes)].
 
         Args:
@@ -821,7 +821,6 @@ class TiledRasterLayer(CachableLayer):
             :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
 
         Raises:
-            ValueError: When an unsupported cell type is entered.
             ValueError: If ``no_data_value`` is set and the ``new_type`` contains raw values.
             ValueError: If ``no_data_value`` is set and ``new_type`` is a boolean.
         """

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -113,12 +113,14 @@ class CachableLayer(object):
         RDD container, srdd, which implements the persist() and unpersist()
         methods.
         """
+
         return [self.srdd]
 
     def cache(self):
         """
         Persist this RDD with the default storage level (C{MEMORY_ONLY}).
         """
+
         self.persist()
         return self
 
@@ -179,15 +181,17 @@ class RasterLayer(CachableLayer):
 
     Args:
         pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
-        layer_type (str): What the spatial type of the geotiffs are. This is
-            represented by the constants: ``SPATIAL`` and ``SPACETIME``.
+        layer_type (str or :class:`geopyspark.geotrellis.constants.LayerType`): What the spatial type
+            of the geotiffs are. This is represented by either constants within ``LayerType`` or by
+            a string.
         srdd (py4j.java_gateway.JavaObject): The coresponding Scala class. This is what allows
             ``RasterLayer`` to access the various Scala methods.
 
     Attributes:
         pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
-        layer_type (str): What the spatial type of the geotiffs are. This is
-            represented by the constants: ``SPATIAL`` and ``SPACETIME``.
+        layer_type (str or :class:`geopyspark.geotrellis.constants.LayerType`): What the spatial type
+            of the geotiffs are. This is represented by either constants within ``LayerType`` or by
+            a string.
         srdd (py4j.java_gateway.JavaObject): The coresponding Scala class. This is what allows
             ``RasterLayer`` to access the various Scala methods.
     """
@@ -206,8 +210,9 @@ class RasterLayer(CachableLayer):
 
         Args:
             pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
-            layer_type (str): What the spatial type of the geotiffs are. This is
-                represented by the constants: ``SPATIAL`` and ``SPACETIME``.
+            layer_type (str or :class:`geopyspark.geotrellis.constants.LayerType`): What the spatial type
+                of the geotiffs are. This is represented by either constants within ``LayerType`` or by
+                a string.
             numpy_rdd (pyspark.RDD): A PySpark RDD that contains tuples of either
                 :class:`~geopyspark.geotrellis.ProjectedExtent`\s or
                 :class:`~geopyspark.geotrellis.TemporalProjectedExtent`\s and rasters that
@@ -240,7 +245,7 @@ class RasterLayer(CachableLayer):
             operation and should be used with caution.
 
         Returns:
-            ``pyspark.RDD``
+            RDD
         """
 
         result = self.srdd.toProtoRDD()
@@ -260,6 +265,7 @@ class RasterLayer(CachableLayer):
         Returns:
             RDD[(K, bytes)]
         """
+
         result = self.srdd.toPngRDD(color_map.cmap)
         key = map_key_input(LayerType(self.layer_type).value, False)
         ser = ProtoBufSerializer.create_image_rdd_serializer(key_type=key)
@@ -329,10 +335,9 @@ class RasterLayer(CachableLayer):
                 also specify ``extent``.
             crs (str or int, optional): Ignore CRS from records and use given one instead.
             tile_size (int, optional): Pixel dimensions of each tile, if not using layout.
-            resample_method (str, optional): The resample method to use for the reprojection.
-                This is represented by the following constants: ``ResampleMethods.NEAREST_NEIGHBOR``, ``BILINEAR``,
-                ``CUBICCONVOLUTION``, ``LANCZOS``, ``AVERAGE``, ``MODE``, ``MEDIAN``, ``MAX``, and
-                ``MIN``. If none is specified, then ``ResampleMethods.NEAREST_NEIGHBOR`` is used.
+            resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
+                The resample method to use for the reprojection. If none is specified, then
+                ``ResampleMethods.NEAREST_NEIGHBOR`` is used.
 
         Note:
             ``extent`` and ``layout`` must both be defined if they are to be used.
@@ -399,8 +404,8 @@ class RasterLayer(CachableLayer):
         """Converts the underlying, raster values to a new ``CellType``.
 
         Args:
-            new_type (str): The string representation of the ``CellType`` to convert to. It is
-                represented by a constant such as ``INT16``, ``FLOAT64``, etc.
+            new_type (str or :class:`~geopyspark.geotrellis.constants.CellType`): The data type the
+                cells should be to converted to.
             no_data_value (int or float, optional): The value that should be marked as NoData.
 
         Returns:
@@ -477,10 +482,9 @@ class RasterLayer(CachableLayer):
         Args:
             target_crs (str or int): The CRS to reproject to. Can either be the EPSG code,
                 well-known name, or a PROJ.4 projection string.
-            resample_method (str, optional): The resample method to use for the reprojection.
-                This is represented by the following constants: ``NEAREST_NEIGHBOR``, ``BILINEAR``,
-                ``CUBICCONVOLUTION``, ``LANCZOS``, ``AVERAGE``, ``MODE``, ``MEDIAN``, ``MAX``, and
-                ``MIN``. If none is specified, then ``NEAREST_NEIGHBOR`` is used.
+            resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
+                The resample method to use for the reprojection. If none is specified, then
+                ``ResampleMethods.NEAREST_NEIGHBOR`` is used.
 
         Returns:
             :class:`~geopyspark.geotrellis.rdd.RasterLayer`
@@ -498,10 +502,9 @@ class RasterLayer(CachableLayer):
         Args:
             layer_metadata (:class:`~geopyspark.geotrellis.Metadata`): The
                 ``Metadata`` of the ``RasterLayer`` instance.
-            resample_method (str, optional): The resample method to use for the reprojection.
-                This is represented by the following constants: ``NEAREST_NEIGHBOR``, ``BILINEAR``,
-                ``CUBICCONVOLUTION``, ``LANCZOS``, ``AVERAGE``, ``MODE``, ``MEDIAN``, ``MAX``, and
-                ``MIN``. If none is specified, then ``NEAREST_NEIGHBOR`` is used.
+            resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
+                The resample method to use for the reprojection. If none is specified, then
+                ``ResampleMethods.NEAREST_NEIGHBOR`` is used.
 
         Returns:
             :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
@@ -519,10 +522,9 @@ class RasterLayer(CachableLayer):
         Args:
             layer_metadata (:class:`~geopyspark.geotrellis.Metadata`): The
                 ``Metadata`` of the ``RasterLayer`` instance.
-            resample_method (str, optional): The resample method to use for the reprojection.
-                This is represented by the following constants: ``NEAREST_NEIGHBOR``, ``BILINEAR``,
-                ``CUBICCONVOLUTION``, ``LANCZOS``, ``AVERAGE``, ``MODE``, ``MEDIAN``, ``MAX``, and
-                ``MIN``. If none is specified, then ``NEAREST_NEIGHBOR`` is used.
+            resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
+                The resample method to use for the reprojection. If none is specified, then
+                ``ResampleMethods.NEAREST_NEIGHBOR`` is used.
 
         Returns:
             :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
@@ -545,10 +547,9 @@ class RasterLayer(CachableLayer):
                 its values are the new value the cells within the break should become.
             data_type (type): The type of the values within the rasters. Can either be ``int`` or
                 ``float``.
-            classification_strategy (str, optional): How the cells should be classified along the breaks.
-                This is represented by the following constants: ``GREATERTHAN``,
-                ``GREATERTHANOREQUALTO``, ``LESSTHAN``, ``LESSTHANOREQUALTO``, and ``EXACT``. If
-                unspecified, then ``LESSTHANOREQUALTO`` will be used.
+            classification_strategy (str or :class:`~geopyspark.geotrellis.constants.ClassificationStrategy`, optional):
+                How the cells should be classified along the breaks. If unspecified, then
+                ``ClassificationStrategy.LESS_THAN_OR_EQUAL_TO`` will be used.
             replace_nodata_with (data_type, optional): When remapping values, nodata values must be
                 treated separately.  If nodata values are intended to be replaced during the
                 reclassify, this variable should be set to the intended value.  If unspecified,
@@ -596,15 +597,17 @@ class TiledRasterLayer(CachableLayer):
 
     Args:
         pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
-        layer_type (str): What the spatial type of the geotiffs are. This is represented by the
-            constants: ``SPATIAL`` and ``SPACETIME``.
+        layer_type (str or :class:`geopyspark.geotrellis.constants.LayerType`): What the spatial type
+            of the geotiffs are. This is represented by either constants within ``LayerType`` or by
+            a string.
         srdd (py4j.java_gateway.JavaObject): The coresponding Scala class. This is what allows
             ``TiledRasterLayer`` to access the various Scala methods.
 
     Attributes:
         pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
-        layer_type (str): What the spatial type of the geotiffs are. This is represented by the
-            constants: ``SPATIAL` and ``SPACETIME``.
+        layer_type (str or :class:`geopyspark.geotrellis.constants.LayerType`): What the spatial type
+            of the geotiffs are. This is represented by either constants within ``LayerType`` or by
+            a string.
         srdd (py4j.java_gateway.JavaObject): The coresponding Scala class. This is what allows
             ``RasterLayer`` to access the various Scala methods.
         is_floating_point_layer (bool): Whether the data within the ``TiledRasterLayer`` is floating
@@ -623,11 +626,13 @@ class TiledRasterLayer(CachableLayer):
     @property
     def layer_metadata(self):
         """Layer metadata associated with this layer."""
+
         return Metadata.from_dict(json.loads(self.srdd.layerMetadata()))
 
     @property
     def zoom_level(self):
         """The zoom level of the Layer. Can be ``None``."""
+
         return self.srdd.getZoom()
 
     @classmethod
@@ -636,8 +641,9 @@ class TiledRasterLayer(CachableLayer):
 
         Args:
             pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
-            layer_type (str): What the spatial type of the geotiffs are. This is represented by the
-                constants: ``SPATIAL`` and ``SPACETIME``.
+            layer_type (str or :class:`geopyspark.geotrellis.constants.LayerType`): What the spatial type
+                of the geotiffs are. This is represented by either constants within ``LayerType`` or by
+                a string.
             numpy_rdd (pyspark.RDD): A PySpark RDD that contains tuples of either
                 :class:`~geopyspark.geotrellis.SpatialKey` or
                 :class:`~geopyspark.geotrellis.SpaceTimeKey` and rasters that are represented by a
@@ -648,7 +654,8 @@ class TiledRasterLayer(CachableLayer):
         Returns:
             :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
         """
-        key = map_key_input(LayerType(layer_type).value, True)
+
+        key = map_key_input(LayerType(rdd_type).value, True)
         ser = ProtoBufSerializer.create_tuple_serializer(key_type=key)
         reserialized_rdd = numpy_rdd._reserialize(ser)
 
@@ -674,8 +681,9 @@ class TiledRasterLayer(CachableLayer):
             operation and should be used with caution.
 
         Returns:
-            ``pyspark.RDD``
+            RDD
         """
+
         result = self.srdd.toProtoRDD()
         key = map_key_input(LayerType(self.layer_type).value, True)
         ser = ProtoBufSerializer.create_tuple_serializer(key_type=key)
@@ -805,8 +813,8 @@ class TiledRasterLayer(CachableLayer):
         """Converts the underlying, raster values to a new ``CellType``.
 
         Args:
-            new_type (str): The string representation of the ``CellType`` to convert to. It is
-                represented by a constant such as ``INT16``, ``FLOAT64``, etc.
+            new_type (str or :class:`~geopyspark.geotrellis.constants.CellType`): The data type the
+                cells should be to converted to.
             no_data_value (int or float, optional): The value that should be marked as NoData.
 
         Returns:
@@ -843,16 +851,15 @@ class TiledRasterLayer(CachableLayer):
                 extent, must also specify ``layout``.
             layout (:obj:`~geopyspark.geotrellis.TileLayout`, optional): Specify the tile layout,
                 must also specify ``extent``.
-            scheme (str, optional): Which LayoutScheme should be used. Represented by the
-                constants: ``FLOAT`` and ``ZOOM``. If not specified, then ``FLOAT`` is used.
+            scheme (str or :class:`~geopyspark.geotrellis.constants.LayoutScheme`, optional): Which
+                scheme should be used. If not specified, then ``LayoutScheme.FLOAT`` is used.
             tile_size (int, optional): Pixel dimensions of each tile, if not using layout.
             resolution_threshold (double, optional): The percent difference between a cell size
                 and a zoom level along with the resolution difference between the zoom level and
                 the next one that is tolerated to snap to the lower-resolution zoom.
-            resample_method (str, optional): The resample method to use for the reprojection.
-                This is represented by the following constants: ``NEAREST_NEIGHBOR``, ``BILINEAR``,
-                ``CUBICCONVOLUTION``, ``LANCZOS``, ``AVERAGE``, ``MODE``, ``MEDIAN``, ``MAX``, and
-                ``MIN``. If none is specified, then ``NEAREST_NEIGHBOR`` is used.
+            resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
+                The resample method to use for the reprojection. If none is specified, then
+                ``ResampleMethods.NEAREST_NEIGHBOR`` is used.
 
         Note:
             ``extent`` and ``layout`` must both be defined if they are to be used.
@@ -898,7 +905,7 @@ class TiledRasterLayer(CachableLayer):
             A list of numpy arrays (the tiles)
 
         Raises:
-            ValueError: If using lookup on a non ``SPATIAL`` ``TiledRasterLayer``.
+            ValueError: If using lookup on a non ``LayerType.SPATIAL`` ``TiledRasterLayer``.
             IndexError: If col and row are not within the ``TiledRasterLayer``\'s bounds.
         """
         if self.layer_type != LayerType.SPATIAL:
@@ -925,10 +932,9 @@ class TiledRasterLayer(CachableLayer):
         Args:
             layout (:obj:`~geopyspark.geotrellis.TileLayout`): Specify the ``TileLayout`` to cut
                 to.
-            resample_method (str, optional): The resample method to use for the reprojection.
-                This is represented by the following constants: ``NEAREST_NEIGHBOR``, ``BILINEAR``,
-                ``CUBICCONVOLUTION``, ``LANCZOS``, ``AVERAGE``, ``MODE``, ``MEDIAN``, ``MAX``, and
-                ``MIN``. If none is specified, then ``NEAREST_NEIGHBOR`` is used.
+            resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
+                The resample method to use for the reprojection. If none is specified, then
+                ``ResampleMethods.NEAREST_NEIGHBOR`` is used.
 
         Returns:
             :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
@@ -942,7 +948,11 @@ class TiledRasterLayer(CachableLayer):
         return TiledRasterLayer(self.pysc, self.layer_type, srdd)
 
     def pyramid(self, end_zoom, start_zoom=None, resample_method=ResampleMethod.NEAREST_NEIGHBOR):
-        """Creates a pyramid of GeoTrellis layers where each layer reprsents a given zoom.
+        """Creates a ``Pyramid`` instance.
+
+        Note:
+            This method will only work if the tiles within the layer's layout are sizes of
+            multiples of 2.
 
         Args:
             end_zoom (int): The zoom level where pyramiding should end. Represents
@@ -950,16 +960,14 @@ class TiledRasterLayer(CachableLayer):
             start_zoom (int, Optional): The zoom level where pyramiding should begin. Represents
                 the level that is most zoomed in. If None, then will use the zoom level from
                 :meth:`~geopyspark.geotrellis.rdd.TiledRasterLayer.zoom_level`.
-            resample_method (str, optional): The resample method to use for the reprojection.
-                This is represented by the following constants: ``NEAREST_NEIGHBOR``, ``BILINEAR``,
-                ``CUBICCONVOLUTION``, ``LANCZOS``, ``AVERAGE``, ``MODE``, ``MEDIAN``, ``MAX``, and
-                ``MIN``. If none is specified, then ``NEAREST_NEIGHBOR`` is used.
+            resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
+                The resample method to use for the reprojection. If none is specified, then
+                ``ResampleMethods.NEAREST_NEIGHBOR`` is used.
 
         Returns:
-            ``[TiledRasterLayers]``.
+            :class:`~geopyspark.geotrellis.layer.Pyramid`.
 
         Raises:
-            ValueError: If the given ``resample_method`` is not known.
             ValueError: If the col and row count is not a power of 2.
         """
 
@@ -981,7 +989,8 @@ class TiledRasterLayer(CachableLayer):
         return Pyramid([TiledRasterLayer(self.pysc, self.layer_type, srdd) for srdd in result])
 
     def pyramid_non_power_of_two(self, col_power, row_power, end_zoom, start_zoom=None, resample_method=ResampleMethod.NEAREST_NEIGHBOR):
-        """Creates a pyramid of GeoTrellis layers where each layer reprsents a given zoom.
+        """Creates a ``Pyramid`` instance. This will work even if the tiles' sizes are not
+        multiples of 2.
 
         Args:
             col_power (int): The number of tile columns will be two to the power of this number
@@ -991,13 +1000,12 @@ class TiledRasterLayer(CachableLayer):
             start_zoom (int, Optional): The zoom level where pyramiding should begin. Represents
                 the level that is most zoomed in. If None, then will use the zoom level from
                 :meth:`~geopyspark.geotrellis.rdd.TiledRasterLayer.zoom_level`.
-            resample_method (str, optional): The resample method to use for the reprojection.
-                This is represented by the following constants: ``NEAREST_NEIGHBOR``, ``BILINEAR``,
-                ``CUBICCONVOLUTION``, ``LANCZOS``, ``AVERAGE``, ``MODE``, ``MEDIAN``, ``MAX``, and
-                ``MIN``. If none is specified, then ``NEAREST_NEIGHBOR`` is used.
+            resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
+                The resample method to use for the reprojection. If none is specified, then
+                ``ResampleMethods.NEAREST_NEIGHBOR`` is used.
 
         Returns:
-            ``[TiledRasterLayers]``.
+            :class:`~geopyspark.geotrellis.layer.Pyramid`.
 
         Raises:
             ValueError: If the given ``resample_method`` is not known.
@@ -1013,13 +1021,11 @@ class TiledRasterLayer(CachableLayer):
         """Performs the given focal operation on the layers contained in the Layer.
 
         Args:
-            operation (str): The focal operation. Represented by constants: ``SUM``, ``MIN``,
-                ``MAX``, ``MEAN``, ``MEDIAN``, ``MODE``, ``STANDARDDEVIATION``, ``ASPECT``, and
-                ``SLOPE``.
+            operation (str or :class:`~geopyspark.geotrellis.constants.Operation`): The focal
+                operation to be performed.
             neighborhood (str or :class:`~geopyspark.geotrellis.neighborhood.Neighborhood`, optional):
                 The type of neighborhood to use in the focal operation. This can be represented by
-                either an instance of ``Neighborhood``, or by the constants: ``ANNULUS``, ``NEWS``,
-                ``SQUARE``, ``WEDGE``, and ``CIRCLE``. Defaults to ``None``.
+                either an instance of ``Neighborhood``, or by a constant.
             param_1 (int or float, optional): If using ``SLOPE``, then this is the zFactor, else it
                 is the first argument of ``neighborhood``.
             param_2 (int or float, optional): The second argument of the ``neighborhood``.
@@ -1073,10 +1079,10 @@ class TiledRasterLayer(CachableLayer):
         """Stitch all of the rasters within the Layer into one raster.
 
         Note:
-            This can only be used on ``SPATIAL`` ``TiledRasterLayers``.
+            This can only be used on ``LayerType.SPATIAL`` ``TiledRasterLayer``\s.
 
         Returns:
-            :ref:`raster`
+            :obj:`~geopyspark.geotrellis.Tile`
         """
 
         if self.layer_type != LayerType.SPATIAL:
@@ -1090,15 +1096,12 @@ class TiledRasterLayer(CachableLayer):
         """Stitch all of the rasters within the Layer into one raster.
 
         Args:
-            path: The path of the geotiff to save.
-            crop_bounds: Optional bounds with which to crop the raster before saving.
-            crop_dimensions: Optional cols and rows of the image to save
+            path (str): The path of the geotiff to save.
+            crop_bounds (list, optional): bounds with which to crop the raster before saving.
+            crop_dimensions (list, optional): cols and rows of the image to save
 
         Note:
-            This can only be used on `SPATIAL` TiledRasterLayers.
-
-        Returns:
-            None
+            This can only be used on ``LayerType.SPATIAL`` ``TiledRasterLayer``\s.
         """
 
         if self.layer_type != LayerType.SPATIAL:
@@ -1113,8 +1116,6 @@ class TiledRasterLayer(CachableLayer):
             raise Exception("crop_dimensions requires crop_bounds")
         else:
             self.srdd.save_stitched(path)
-
-        return None
 
     def mask(self, geometries):
         """Masks the ``TiledRasterLayer`` so that only values that intersect the geometries will
@@ -1148,10 +1149,9 @@ class TiledRasterLayer(CachableLayer):
                 its values are the new value the cells within the break should become.
             data_type (type): The type of the values within the rasters. Can either be ``int`` or
                 ``float``.
-            classification_strategy (str, optional): How the cells should be classified along the breaks.
-                This is represented by the following constants: ``GREATERTHAN``,
-                ``GREATERTHANOREQUALTO``, ``LESSTHAN``, ``LESSTHANOREQUALTO``, and ``EXACT``. If
-                unspecified, then ``LESSTHANOREQUALTO`` will be used.
+            classification_strategy (str or :class:`~geopyspark.geotrellis.constants.ClassificationStrategy`, optional):
+                How the cells should be classified along the breaks. If unspecified, then
+                ``ClassificationStrategy.LESS_THAN_OR_EQUAL_TO`` will be used.
             replace_nodata_with (data_type, optional): When remapping values, nodata values must be
                 treated separately.  If nodata values are intended to be replaced during the
                 reclassify, this variable should be set to the intended value.  If unspecified,
@@ -1178,6 +1178,7 @@ class TiledRasterLayer(CachableLayer):
         Returns:
             ``(float, float)``
         """
+
         min_max = self.srdd.getMinMax()
         return (min_max._1(), min_max._2())
 
@@ -1189,9 +1190,11 @@ class TiledRasterLayer(CachableLayer):
             old_max (float): Old maximum.
             new_min (float): New minimum to normalize to.
             new_max (float): New maximum to normalize to.
+
         Returns:
             :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
         """
+
         srdd = self.srdd.normalize(old_min, old_max, new_min, new_max)
 
         return TiledRasterLayer(self.pysc, self.layer_type, srdd)
@@ -1400,8 +1403,8 @@ class Pyramid(CachableLayer):
 
     Attributes:
         pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
-        layer_type (str): What the spatial type of the geotiffs are. This is
-            represented by the constants: ``SPATIAL`` and ``SPACETIME``.
+        layer_type (str or :class:`~geopyspark.geotrellis.constants.LayerType`): What the spatial
+            type of the geotiffs are.
         levels (dict): A dict of ``TiledRasterLayer``\s where the value is the layer itself
             and the key is its given zoom level.
         max_zoom (int): The highest zoom level of the pyramid.

--- a/geopyspark/geotrellis/protobufcodecs.py
+++ b/geopyspark/geotrellis/protobufcodecs.py
@@ -114,8 +114,7 @@ def from_pb_extent(pb_extent):
     """Creates an ``Extent`` from a ``ProtoExtent``.
 
     Args:
-        pb_extent (:class:`~geopyspark.protobuf.extentMessages_pb2.ProtoExtent`): An instance
-            of ``ProtoExtent``.
+        pb_extent (ProtoExtent): An instance of ``ProtoExtent``.
 
     Returns:
         :class:`~geopyspark.geotrellis.Extent`
@@ -140,8 +139,7 @@ def from_pb_projected_extent(pb_projected_extent):
     """Creates a ``ProjectedExtent`` from a ``ProtoProjectedExtent``.
 
     Args:
-        pb_projected_extent (:class:`~geopyspark.protobuf.extentMessages_pb2.ProtoProjectedExtent`):
-            An instance of ``ProtoProjectedExtent``.
+        pb_projected_extent (ProtoProjectedExtent): An instance of ``ProtoProjectedExtent``.
 
     Returns:
         :class:`~geopyspark.geotrellis.ProjectedExtent`
@@ -171,8 +169,8 @@ def from_pb_temporal_projected_extent(pb_temporal_projected_extent):
     """Creates a ``TemporalProjectedExtent`` from a ``ProtoTemporalProjectedExtent``.
 
     Args:
-        pb_temporal_projected_extent (:class:`~geopyspark.protobuf.extentMessages_pb2.ProtoTemporalProjectedExtent`):
-            An instance of ``ProtoTemporalProjectedExtent``.
+        pb_temporal_projected_extent (ProtoTemporalProjectedExtent): An instance of
+            ``ProtoTemporalProjectedExtent``.
 
     Returns:
         :class:`~geopyspark.geotrellis.TemporalProjectedExtent`
@@ -204,8 +202,7 @@ def from_pb_spatial_key(pb_spatial_key):
     """Creates a ``SpatialKey`` from a ``ProtoSpatialKey``.
 
     Args:
-        pb_spatial_key (:class:`~geopyspark.protobuf.keyMessages_pb2.ProtoSpatialKey`):
-            An instance of ``ProtoSpatialKey``.
+        pb_spatial_key (ProtoSpatialKey): An instance of ``ProtoSpatialKey``.
 
     Returns:
         :obj:`~geopyspark.geotrellis.SpatialKey`
@@ -230,8 +227,7 @@ def from_pb_space_time_key(pb_space_time_key):
     """Creates a ``SpaceTimeKey`` from a ``ProtoSpaceTimeKey``.
 
     Args:
-        pb_space_time_key (:class:`~geopyspark.protobuf.keyMessages_pb2.ProtoSpaceTimeKey`):
-            An instance of ``ProtoSpaceTimeKey``.
+        pb_space_time_key (ProtoSpaceTimeKey): An instance of ``ProtoSpaceTimeKey``.
 
     Returns:
         :obj:`~geopyspark.geotrellis.SpaceTimeKey`
@@ -356,7 +352,7 @@ def to_pb_tile(obj):
         obj (:obj:`~geopyspark.geotrellis.Tile`): An instance of ``Tile``.
 
     Returns:
-        :class:`~geopyspark.protobuf.tileMessages_pb2.ProtoTile`
+        ProtoTile
     """
 
     cells = obj.cells
@@ -428,7 +424,7 @@ def to_pb_multibandtile(obj):
         obj (:obj:`~geopyspark.geotrellis.Tile`): An instance of ``Tile``.
 
     Returns:
-        :class:`~geopyspark.protobuf.tileMessages_pb2.ProtoMultibandTile`
+        ProtoMultibandTile
     """
 
     cells = obj.cells
@@ -464,7 +460,7 @@ def to_pb_extent(obj):
         obj (:class:`~geopyspark.geotrellis.Extent`): An instance of ``Extent``.
 
     Returns:
-        :class:`~geopyspark.protobuf.extentMessages_pb2.ProtoExtent`
+        ProtoExtent
     """
 
     ex = extentMessages_pb2.ProtoExtent()
@@ -496,7 +492,7 @@ def to_pb_projected_extent(obj):
             ``ProjectedExtent``.
 
     Returns:
-        :class:`~geopyspark.protobuf.extentMessages_pb2.ProtoProjectedExtent`
+        ProtoProjectedExtent
     """
 
     pex = extentMessages_pb2.ProtoProjectedExtent()
@@ -535,7 +531,7 @@ def to_pb_temporal_projected_extent(obj):
             ``TemporalProjectedExtent``.
 
     Returns:
-        :class:`~geopyspark.protobuf.extentMessages_pb2.ProtoTemporalProjectedExtent`
+        ProtoTemporalProjectedExtent
     """
 
     tpex = extentMessages_pb2.ProtoTemporalProjectedExtent()
@@ -574,7 +570,7 @@ def to_pb_spatial_key(obj):
         obj (:obj:`~geopyspark.geotrellis.SpatialKey`): An instance of ``SpatialKey``.
 
     Returns:
-        :class:`~geopyspark.protobuf.keyMessages_pb2.ProtoSpatialKey`
+        ProtoSpatialKey
     """
 
     spatial_key = keyMessages_pb2.ProtoSpatialKey()
@@ -603,7 +599,7 @@ def to_pb_space_time_key(obj):
         obj (:obj:`~geopyspark.geotrellis.SpaceTimeKey`): An instance of ``SpaceTimeKey``.
 
     Returns:
-        :class:`~geopyspark.protobuf.keyMessages_pb2.ProtoSpaceTimeKey`
+        ProtoSpaceTimeKey
     """
 
     space_time_key = keyMessages_pb2.ProtoSpaceTimeKey()

--- a/geopyspark/geotrellis/protobufcodecs.py
+++ b/geopyspark/geotrellis/protobufcodecs.py
@@ -28,6 +28,15 @@ _mapped_data_types = {
 
 
 def from_pb_tile(tile, no_data_value=None, data_type=None):
+    """Creates a ``Tile`` from ``ProtoTile``.
+
+    Args:
+        tile (ProtoTile): The ``ProtoTile`` instance to be converted.
+
+    Returns:
+        :obj:`~geopyspark.geotrellis.Tile`
+    """
+
     if not data_type:
         data_type = _mapped_data_types[tile.cellType.dataType]
 
@@ -51,13 +60,13 @@ def from_pb_tile(tile, no_data_value=None, data_type=None):
     return cells.reshape(tile.rows, tile.cols)
 
 def tile_decoder(proto_bytes):
-    """Decodes a ``TILE`` into Python.
+    """Deserializes the ``ProtoTile`` bytes into Python.
 
     Args:
         proto_bytes (bytes): The ProtoBuf encoded bytes of the ProtoBuf class.
 
     Returns:
-        :ref:`Tile <raster>`
+        :obj:`~geopyspark.geotrellis.Tile`
     """
 
     tile = ProtoTile.FromString(proto_bytes)
@@ -70,6 +79,15 @@ def tile_decoder(proto_bytes):
         return Tile(np.array([from_pb_tile(tile)]), cell_type, None)
 
 def from_pb_multibandtile(multibandtile):
+    """Creates a ``Tile`` from ``ProtoMultibandTile``.
+
+    Args:
+        multibandtile (ProtoTile): The ``ProtoMultibandTile`` instance to be converted.
+
+    Returns:
+        :obj:`~geopyspark.geotrellis.Tile`
+    """
+
     cell_type = _mapped_data_types[multibandtile.tiles[0].cellType.dataType]
 
     if multibandtile.tiles[0].cellType.hasNoData:
@@ -81,13 +99,13 @@ def from_pb_multibandtile(multibandtile):
         return Tile(bands, cell_type, None)
 
 def multibandtile_decoder(proto_bytes):
-    """Decodes a ``TILE`` into Python.
+    """Deserializes ``ProtoMultibandTile`` bytes into Python.
 
     Args:
         proto_bytes (bytes): The ProtoBuf encoded bytes of the ProtoBuf class.
 
     Returns:
-        :ref:`Tile <raster>`
+        :obj:`~geopyspark.geotrellis.Tile`
     """
 
     return from_pb_multibandtile(ProtoMultibandTile.FromString(proto_bytes))
@@ -106,7 +124,7 @@ def from_pb_extent(pb_extent):
     return Extent(pb_extent.xmin, pb_extent.ymin, pb_extent.xmax, pb_extent.ymax)
 
 def extent_decoder(proto_bytes):
-    """Decodes an ``Extent`` into Python.
+    """Deserializes ``ProtoExtent`` bytes into Python.
 
     Args:
         proto_bytes (bytes): The ProtoBuf encoded bytes of the ProtoBuf class.
@@ -137,7 +155,7 @@ def from_pb_projected_extent(pb_projected_extent):
                                proj4=pb_projected_extent.crs.proj4)
 
 def projected_extent_decoder(proto_bytes):
-    """Decodes a ``TemporalProjectedExtent`` into Python.
+    """Deserializes ``ProtoProjectedExtent`` bytes into Python.
 
     Args:
         proto_bytes (bytes): The ProtoBuf encoded bytes of the ProtoBuf class.
@@ -170,7 +188,7 @@ def from_pb_temporal_projected_extent(pb_temporal_projected_extent):
                                        instant=pb_temporal_projected_extent.instant)
 
 def temporal_projected_extent_decoder(proto_bytes):
-    """Decodes a ``TemproalProjectedExtent`` into Python.
+    """Deserializes ``ProtoTemporalProjectedExtent`` bytes into Python.
 
     Args:
         proto_bytes (bytes): The ProtoBuf encoded bytes of the ProtoBuf class.
@@ -196,7 +214,7 @@ def from_pb_spatial_key(pb_spatial_key):
     return SpatialKey(col=pb_spatial_key.col, row=pb_spatial_key.row)
 
 def spatial_key_decoder(proto_bytes):
-    """Decodes a ``SpatialKey`` into Python.
+    """Deserializes ``ProtoSpatialKey`` bytes into Python.
 
     Args:
         proto_bytes (bytes): The ProtoBuf encoded bytes of the ProtoBuf class.
@@ -223,7 +241,7 @@ def from_pb_space_time_key(pb_space_time_key):
                         instant=pb_space_time_key.instant)
 
 def space_time_key_decoder(proto_bytes):
-    """Decodes a ``SpaceTimeKey`` into Python.
+    """Deserializes ``ProtoSpaceTime`` bytes into Python.
 
     Args:
         proto_bytes (bytes): The ProtoBuf encoded bytes of the ProtoBuf class.
@@ -236,7 +254,7 @@ def space_time_key_decoder(proto_bytes):
     return from_pb_space_time_key(pb_space_time_key)
 
 def tuple_decoder(proto_bytes, key_decoder):
-    """Decodes a tuple into Python.
+    """Deserializes ``ProtoTuple`` bytes into Python.
 
     Note:
         The value of the tuple is always assumed to be a :ref:`Tile <raster>`,
@@ -332,6 +350,15 @@ def _get_decoder(name):
 # ENCODERS
 
 def to_pb_tile(obj):
+    """Converts an instance of ``Tile`` to ``ProtoTile``.
+
+    Args:
+        obj (:obj:`~geopyspark.geotrellis.Tile`): An instance of ``Tile``.
+
+    Returns:
+        :class:`~geopyspark.protobuf.tileMessages_pb2.ProtoTile`
+    """
+
     cells = obj.cells
     data_type = obj.cell_type
 
@@ -382,10 +409,10 @@ def to_pb_tile(obj):
 
 
 def tile_encoder(obj):
-    """Decodes a ``TILE`` into bytes.
+    """Encodes a ``TILE`` into ``ProtoTile`` bytes.
 
     Args:
-        obj (:ref:`Tile <raster>`): An instance of ``Extent``.
+        obj (:obj:`~geopyspark.geotrellis.Tile`): An instance of ``Tile``.
 
     Returns:
         bytes
@@ -395,6 +422,15 @@ def tile_encoder(obj):
 
 
 def to_pb_multibandtile(obj):
+    """Converts an instance of ``Tile`` to ``ProtoMultibandTile``.
+
+    Args:
+        obj (:obj:`~geopyspark.geotrellis.Tile`): An instance of ``Tile``.
+
+    Returns:
+        :class:`~geopyspark.protobuf.tileMessages_pb2.ProtoMultibandTile`
+    """
+
     cells = obj.cells
     if cells.ndim == 2:
         cells = np.expand_dims(cells, 0)
@@ -410,10 +446,10 @@ def to_pb_multibandtile(obj):
     return multibandtile
 
 def multibandtile_encoder(obj):
-    """Decodes a ``TILE`` into bytes.
+    """Encodes a ``TILE`` into ``ProtoMultibandTile`` bytes.
 
     Args:
-        obj (:ref:`Tile <raster>`): An instance of ``Extent``.
+        obj (:obj:`~geopyspark.geotrellis.Tile`): An instance of ``Tile``.
 
     Returns:
         bytes
@@ -441,7 +477,7 @@ def to_pb_extent(obj):
     return ex
 
 def extent_encoder(obj):
-    """Encodes an ``Extent`` into bytes.
+    """Encodes an ``Extent`` into ``ProtoExtent`` bytes.
 
     Args:
         obj (:class:`~geopyspark.geotrellis.Extent`): An instance of ``Extent``.
@@ -479,7 +515,7 @@ def to_pb_projected_extent(obj):
     return pex
 
 def projected_extent_encoder(obj):
-    """Encodes a ``ProjectedExtent`` into bytes.
+    """Encodes a ``ProjectedExtent`` into ``ProtoProjectedExtent`` bytes.
 
     Args:
         obj (:class:`~geopyspark.geotrellis.ProjectedExtent`): An instance of
@@ -519,7 +555,7 @@ def to_pb_temporal_projected_extent(obj):
     return tpex
 
 def temporal_projected_extent_encoder(obj):
-    """Encodes a ``TemproalProjectedExtent`` into bytes.
+    """Encodes a ``TemproalProjectedExtent`` into ``ProtoTemporalProjectedExtent`` bytes.
 
     Args:
         obj (:class:`~geopyspark.geotrellis.TemporalProjectedExtent`): An instance of
@@ -549,7 +585,7 @@ def to_pb_spatial_key(obj):
     return spatial_key
 
 def spatial_key_encoder(obj):
-    """Encodes a ``SpatialKey`` into bytes.
+    """Encodes a ``SpatialKey`` into ``ProtoSpatialKey`` bytes.
 
     Args:
         obj (:obj:`~geopyspark.geotrellis.SpatialKey`): An instance of ``SpatialKey``.
@@ -579,7 +615,7 @@ def to_pb_space_time_key(obj):
     return space_time_key
 
 def space_time_key_encoder(obj):
-    """Encodes a ``SpaceTimeKey`` into bytes.
+    """Encodes a ``SpaceTimeKey`` into ``ProtoSpaceTimeKey`` bytes.
 
     Args:
         obj (:obj:`~geopyspark.geotrellis.SpaceTimeKey`): An instance of ``SpaceTimeKey``.
@@ -591,7 +627,7 @@ def space_time_key_encoder(obj):
     return to_pb_space_time_key(obj).SerializeToString()
 
 def tuple_encoder(obj, key_encoder):
-    """Encodes a tuple into bytes.
+    """Encodes a tuple into ``ProtoTuple`` bytes.
 
     Note:
         The value of the tuple is always assumed to be a :ref:`Tile <raster>`,

--- a/geopyspark/geotrellis/rasterize.py
+++ b/geopyspark/geotrellis/rasterize.py
@@ -11,7 +11,7 @@ def rasterize(pysc, geoms, crs, zoom, fill_value, cell_type=CellType.FLOAT64, op
         geoms ([shapely.geometry]): List of shapely geometries to rasterize.
         crs (str or int): The CRS of the input geometry.
         zoom (int): The zoom level of the output raster.
-        fill_value: Value to burn into pixels intersectiong geometry
+        fill_value (int or float): Value to burn into pixels intersectiong geometry
         cell_type (str or :class:`~geopyspark.geotrellis.constants.CellType`): Which data type the
             cells should be when created. Defaults to ``CellType.FLOAT64``.
         options (:class:`~geopyspark.geotrellis.RasterizerOptions`): Pixel intersection options.
@@ -19,6 +19,7 @@ def rasterize(pysc, geoms, crs, zoom, fill_value, cell_type=CellType.FLOAT64, op
     Returns:
         :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
     """
+
     if isinstance(crs, int):
         crs = str(crs)
 

--- a/geopyspark/geotrellis/tms.py
+++ b/geopyspark/geotrellis/tms.py
@@ -8,6 +8,7 @@ class TileRender(object):
     """A Python implementation of the Scala geopyspark.geotrellis.tms.TileRender
     interface.  Permits a callback from Scala to Python to allow for custom
     rendering functions.
+
     Args:
         render_function (numpy.ndarray => bytes): A function to convert a numpy
             array to a collection of bytes giving a binary image file.


### PR DESCRIPTION
This PR updates and expands the various docstrings in the `geopyspark.geotrellis` sub-package. Since almost all of the modules the user needs to use are located here, docstrings outside this sub-package were thus not the focus of this PR or of 0.2.

This PR is based on two, already open PRs: #342 and #341