### PR TITLE
Print Methods For Some GeoPySpark Classes

### DIFF
--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -443,6 +443,12 @@ class RasterLayer(CachableLayer):
         min_max = self.srdd.getMinMax()
         return (min_max._1(), min_max._2())
 
+    def __str__(self):
+        return "RasterLayer(layer_type={})".format(self.layer_type)
+
+    def __repr__(self):
+        return "RasterLayer(layer_type={})".format(self.layer_type)
+
 
 class TiledRasterLayer(CachableLayer):
     """Wraps a RDD of tiled, GeoTrellis rasters.
@@ -1129,6 +1135,14 @@ class TiledRasterLayer(CachableLayer):
     def __rtruediv__(self, value):
         return self._process_operation(value, self.srdd.reverseLocalDivide)
 
+    def __str__(self):
+        return "TiledRasterLayer(layer_type={}, zoom_level={}, is_floating_point_layer={})".format(
+            self.layer_type, self.zoom_level, self.is_floating_point_layer)
+
+    def __repr__(self):
+        return "TiledRasterLayer(layer_type={}, zoom_level={}, is_floating_point_layer={})".format(
+            self.layer_type, self.zoom_level, self.is_floating_point_layer)
+
 
 def _common_entries(*dcts):
     """Zip two dictionaries together by keys"""
@@ -1252,3 +1266,11 @@ class Pyramid(CachableLayer):
             return Pyramid({k: l.__rtruediv__(r) for k, l, r in _common_entries(self.levels, value.levels)})
         else:
             return Pyramid({k: l.__rtruediv__(value) for k, l in self.levels.items()})
+
+    def __str__(self):
+        return "Pyramid(layer_type={}, max_zoom={}, num_levels={}, is_cached={})".format(
+            self.layer_type, self.max_zoom, len(self.levels), self.is_cached)
+
+    def __repr__(self):
+        return "Pyramid(layer_type={}, max_zoom={}, num_levels={}, is_cached={})".format(
+            self.layer_type, self.max_zoom, len(self.levels), self.is_cached)

--- a/geopyspark/geotrellis/neighborhood.py
+++ b/geopyspark/geotrellis/neighborhood.py
@@ -56,6 +56,12 @@ class Square(Neighborhood):
         Neighborhood.__init__(self, name="Square", param_1=extent)
         self.extent = extent
 
+    def __str__(self):
+        return "Square(extent={})".format(self.param_1)
+
+    def __repr__(self):
+        return "Square(extent={})".format(self.param_1)
+
 
 class Circle(Neighborhood):
     """A circle neighborhood.
@@ -80,6 +86,12 @@ class Circle(Neighborhood):
         Neighborhood.__init__(self, name="Circle", param_1=radius)
         self.radius = radius
 
+    def __str__(self):
+        return "Circle(radius={})".format(self.param_1)
+
+    def __repr__(self):
+        return "Circle(radius={})".format(self.param_1)
+
 
 class Nesw(Neighborhood):
     """A neighborhood that includes a column and row intersection for the focus.
@@ -100,6 +112,12 @@ class Nesw(Neighborhood):
     def __init__(self, extent):
         Neighborhood.__init__(self, name="Nesw", param_1=extent)
         self.extent = extent
+
+    def __str__(self):
+        return "Nesw(extent={})".format(self.param_1)
+
+    def __repr__(self):
+        return "Nesw(extent={})".format(self.param_1)
 
 
 class Wedge(Neighborhood):
@@ -126,6 +144,14 @@ class Wedge(Neighborhood):
         self.start_angle = start_angle
         self.end_angle = end_angle
 
+    def __str__(self):
+        return "Wedge(radius={}, start_angle={}, end_angle={})".format(self.param_1, self.param_2,
+                                                                       self.param_3)
+
+    def __repr__(self):
+        return "Wedge(radius={}, start_angle={}, end_angle={})".format(self.param_1, self.param_2,
+                                                                       self.param_3)
+
 
 class Annulus(Neighborhood):
     """An Annulus neighborhood.
@@ -147,3 +173,9 @@ class Annulus(Neighborhood):
         Neighborhood.__init__(self, name="Annulus", param_1=inner_radius, param_2=outer_radius)
         self.inner_radius = inner_radius
         self.outer_radius = outer_radius
+
+    def __str__(self):
+        return "Annulus(inner_radius={}, outer_radius={})".format(self.param_1, self.param_2)
+
+    def __repr__(self):
+        return "Annulus(inner_radius={}, outer_radius={})".format(self.param_1, self.param_2)


### PR DESCRIPTION
This PR adds `__str__` and `__repr__` methods to some of the classes in GeoPySpark. Now, it'll be easier to understand the properties of an instance of one of these classes. For example, if you were to print an instance of the `Square` class this is what you'd get, `<geopyspark.geotrellis.neighborhood.Square at 0x7f0d059b4a58>`. With this PR, though, this will be the new output `Square(extent=1.0)`.

This PR resolves #344 