### PR TITLE
Improve Test Coverage 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,24 @@ addons:
       - gfortran
       - oracle-java8-set-default
 
-before_install:
-  - cd geopyspark-backend && ./sbt "project geotrellis-backend" assembly
-  - cp geotrellis/target/scala-2.11/geotrellis-backend-assembly-0.1.0.jar ../geopyspark/jars
-  - cd ..
-
 install:
+  - pushd geopyspark-backend &&
+    ./sbt "project geotrellis-backend" assembly &&
+    cp geotrellis/target/scala-2.11/geotrellis-backend-assembly-0.1.0.jar ../geopyspark/jars &&
+    popd
+  - if [ ! -f archives/spark-2.1.1-bin-hadoop2.7.tgz ]; then
+    pushd archives;
+    wget http://d3kbcqa49mib13.cloudfront.net/spark-2.1.1-bin-hadoop2.7.tgz;
+    popd;
+    fi
+  - tar -xvf archives/spark-2.1.1-bin-hadoop2.7.tgz
   - pip3 install -r requirements.txt
   - pip3 install pyproj
   - pip3 install pylint
+  - if [[ $TRAVIS_PYTHON_VERSION != "3.3" ]]; then
+    pip3 install matplotlib==2.0.0;
+    fi
+  - pip3 install colortools==0.1.2
   - pip3 install .
 
 cache:
@@ -44,10 +53,8 @@ cache:
   - $HOME/.cache/pip
 
 script:
-  - "if [ ! -f archives/spark-2.1.1-bin-hadoop2.7.tgz ]; then pushd archives ; wget http://d3kbcqa49mib13.cloudfront.net/spark-2.1.1-bin-hadoop2.7.tgz; popd; fi"
-  - "tar -xvf archives/spark-2.1.1-bin-hadoop2.7.tgz"
-  - "export SPARK_HOME=./spark-2.1.1-bin-hadoop2.7/"
-  - "export JAVA_HOME=/usr/lib/jvm/java-8-oracle"
+  - export SPARK_HOME=./spark-2.1.1-bin-hadoop2.7/
+  - export JAVA_HOME=/usr/lib/jvm/java-8-oracle
   - pytest -k "schema" geopyspark/tests/schema_tests/
   - pytest -k "not schema" geopyspark/tests/*test.py
   - pylint geopyspark

--- a/geopyspark/__init__.py
+++ b/geopyspark/__init__.py
@@ -68,7 +68,7 @@ def geopyspark_conf(master=None, appName=None, additional_jar_dirs=[]):
         [SparkConf]
 
     Note:
-        The GEOPYSPARK_JARS_DIR environment variable may contain a colon-separated
+        The GEOPYSPARK_JARS_PATH environment variable may contain a colon-separated
         list of directories to search for JAR files to make available via the
         SparkConf.
     """

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -406,7 +406,7 @@ def query(pysc,
             srdd = cached.reader.query(key,
                                        layer_name,
                                        layer_zoom,
-                                       shapely.wkb.dumps(query_geom.to_poly),
+                                       shapely.wkb.dumps(query_geom.to_polygon),
                                        time_intervals,
                                        query_proj,
                                        numPartitions)

--- a/geopyspark/tests/catalog_test.py
+++ b/geopyspark/tests/catalog_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from shapely.geometry import box
 
-from geopyspark.geotrellis import SpatialKey
+from geopyspark.geotrellis import Extent, SpatialKey
 from geopyspark.geotrellis.catalog import read, read_value, query, read_layer_metadata, get_layer_ids
 from geopyspark.geotrellis.constants import LayerType, LayoutScheme
 from geopyspark.geotrellis.geotiff import get
@@ -37,7 +37,7 @@ class CatalogTest(BaseTestClass):
             self.assertDictEqual(actual_layer.layer_metadata.to_dict(),
                                  expected_layer.layer_metadata.to_dict())
 
-    def test_read_value(self):
+    def test_read_value1(self):
         tiled = read_value(BaseTestClass.pysc,
                            LayerType.SPATIAL,
                            self.uri,
@@ -45,6 +45,30 @@ class CatalogTest(BaseTestClass):
                            11,
                            1450,
                            966)
+
+        self.assertEqual(tiled.cells.shape, (1, 256, 256))
+
+    def test_read_value2(self):
+        tiled = read_value(BaseTestClass.pysc,
+                           LayerType.SPATIAL,
+                           self.uri,
+                           self.layer_name,
+                           11,
+                           1450,
+                           966,
+                           options={'a': 0})
+
+        self.assertEqual(tiled.cells.shape, (1, 256, 256))
+
+    def test_read_value3(self):
+        tiled = read_value(BaseTestClass.pysc,
+                           LayerType.SPATIAL,
+                           self.uri,
+                           self.layer_name,
+                           11,
+                           1450,
+                           966,
+                           kwargs={'a': 0})
 
         self.assertEqual(tiled.cells.shape, (1, 256, 256))
 
@@ -59,16 +83,41 @@ class CatalogTest(BaseTestClass):
 
         self.assertEqual(tiled, None)
 
-    def test_query(self):
+    def test_query1(self):
         intersection = box(8348915.46680623, 543988.943201519, 8348915.4669, 543988.943201520)
-        queried = query(BaseTestClass.pysc, LayerType.SPATIAL, self.uri, self.layer_name, 11, intersection)
+        queried = query(BaseTestClass.pysc, LayerType.SPATIAL, self.uri, self.layer_name,
+                        11, intersection,
+                        options={'a': 0})
 
         self.assertEqual(queried.to_numpy_rdd().first()[0], SpatialKey(1450, 996))
 
+    def test_query2(self):
+        intersection = Extent(8348915.46680623, 543988.943201519, 8348915.4669, 543988.943201520)
+        queried = query(BaseTestClass.pysc, LayerType.SPATIAL, self.uri, self.layer_name,
+                        11, intersection,
+                        query_proj=3857, kwargs={'a': 0})
+
+        self.assertEqual(queried.to_numpy_rdd().first()[0], SpatialKey(1450, 996))
+
+    def test_query3(self):
+        intersection = box(8348915.46680623, 543988.943201519, 8348915.4669, 543988.943201520).wkb
+        queried = query(BaseTestClass.pysc, LayerType.SPATIAL, self.uri, self.layer_name,
+                        11, intersection)
+
+        self.assertEqual(queried.to_numpy_rdd().first()[0], SpatialKey(1450, 996))
+
+    def test_query4(self):
+        intersection = 42
+        with pytest.raises(TypeError):
+            queried = query(BaseTestClass.pysc, LayerType.SPATIAL, self.uri, self.layer_name,
+                            11, query_geom=intersection, numPartitions=2)
+            result = queried.to_numpy_rdd().first()[0]
+
     def test_query_partitions(self):
         intersection = box(8348915.46680623, 543988.943201519, 8348915.4669, 543988.943201520)
-        queried = query(BaseTestClass.pysc, LayerType.SPATIAL, self.uri, self.layer_name, 11, intersection,
-                        numPartitions=2)
+        queried = query(BaseTestClass.pysc, LayerType.SPATIAL, self.uri, self.layer_name,
+                        11, intersection, numPartitions=2)
+
         self.assertEqual(queried.to_numpy_rdd().first()[0], SpatialKey(1450, 996))
 
     def test_query_crs(self):
@@ -78,7 +127,20 @@ class CatalogTest(BaseTestClass):
 
         self.assertEqual(queried.to_numpy_rdd().first()[0], SpatialKey(1450, 996))
 
-    def test_read_metadata(self):
+    def test_read_metadata_exception(self):
+        uri = "abcxyz://123"
+        options = {'a': 0, 'b': 1}
+        with pytest.raises(ValueError):
+            layer = read_layer_metadata(BaseTestClass.pysc, LayerType.SPATIAL, uri,
+                                        self.layer_name, 5, options=options)
+
+    def test_read_metadata1(self):
+        layer = read(BaseTestClass.pysc, LayerType.SPATIAL, self.uri, self.layer_name, 5)
+        actual_metadata = layer.layer_metadata
+
+        expected_metadata = read_layer_metadata(BaseTestClass.pysc, LayerType.SPATIAL, self.uri,
+                                                self.layer_name, 5, kwargs={'a': 0})
+    def test_read_metadata2(self):
         layer = read(BaseTestClass.pysc, LayerType.SPATIAL, self.uri, self.layer_name, 5)
         actual_metadata = layer.layer_metadata
 
@@ -87,8 +149,18 @@ class CatalogTest(BaseTestClass):
 
         self.assertEqual(actual_metadata.to_dict(), expected_metadata.to_dict())
 
-    def test_layer_ids(self):
+    def test_layer_ids1(self):
         ids = get_layer_ids(BaseTestClass.pysc, self.uri)
+
+        self.assertTrue(len(ids) == 11)
+
+    def test_layer_ids2(self):
+        ids = get_layer_ids(BaseTestClass.pysc, self.uri, options={'a': 0})
+
+        self.assertTrue(len(ids) == 11)
+
+    def test_layer_ids3(self):
+        ids = get_layer_ids(BaseTestClass.pysc, self.uri, kwargs={'a': 0})
 
         self.assertTrue(len(ids) == 11)
 

--- a/geopyspark/tests/colormap_test.py
+++ b/geopyspark/tests/colormap_test.py
@@ -1,8 +1,10 @@
 import unittest
-import pytest
 import numpy as np
+import pytest
+import struct
 
-from geopyspark.geotrellis.color import ColorMap
+from colortools import Color
+from geopyspark.geotrellis.color import get_colors_from_colors, get_colors_from_matplotlib, ColorMap
 from geopyspark.geotrellis.constants import LayerType
 from geopyspark.geotrellis import SpatialKey, Tile
 from geopyspark.geotrellis.layer import TiledRasterLayer
@@ -12,59 +14,62 @@ from geopyspark.tests.base_test_class import BaseTestClass
 class ColormapTest(BaseTestClass):
     color_list = [0x000000ff, 0x100000ff, 0x200000ff, 0x300000ff, 0x400000ff, 0x500000ff, 0x600000ff, 0x700000ff]
 
+    def test_get_colors_from_colors(self):
+        colors = [Color('red'), Color('green'), Color('blue')]
+        result = get_colors_from_colors(colors)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0], 0xff0000ff)
+
+    def test_get_colors_from_matplotlib(self):
+        result = get_colors_from_matplotlib('viridis', num_colors=42)
+        self.assertEqual(len(result), 42)
+        self.assertEqual(result[0], 0x440154ff)
+
     def test_nlcd(self):
         result = ColorMap.nlcd_colormap(BaseTestClass.pysc)
-        self.assertTrue(result.cmap.map(0) == 0x00000000)
-        self.assertTrue((0x0ffffffff + 1 + result.cmap.map(51)) == 0xBAA65CFF)
-        self.assertTrue((0x0ffffffff + 1 + result.cmap.map(92)) == 0xB6D8F5FF)
+        self.assertEqual(result.cmap.map(0), 0x00000000)
+        self.assertEqual((0x0ffffffff + 1 + result.cmap.map(51)), 0xbaa65cff)
+        self.assertEqual((0x0ffffffff + 1 + result.cmap.map(92)), 0xb6d8f5ff)
 
-    def test_from_break_map1(self):
+    def test_from_break_map_int(self):
         color_list = self.color_list
         break_map = {}
         for i in range(len(color_list)):
             break_map[i] = color_list[i]
         result = ColorMap.from_break_map(BaseTestClass.pysc, break_map)
         self.assertTrue(isinstance(result, ColorMap))
-        self.assertTrue(result.cmap.map(3) == color_list[3])
+        self.assertEqual(result.cmap.map(3), color_list[3])
 
-    def test_from_break_map2(self):
+    def test_from_break_map_float(self):
         color_list = self.color_list
         break_map = {}
         for i in range(len(color_list)):
             break_map[float(i)] = color_list[i]
         result = ColorMap.from_break_map(BaseTestClass.pysc, break_map)
         self.assertTrue(isinstance(result, ColorMap))
-        self.assertTrue(result.cmap.map(3) == color_list[3])
+        self.assertEqual(result.cmap.map(3), color_list[3])
 
-    def test_build1(self):
+    def test_from_break_map_str(self):
         color_list = self.color_list
         break_map = {}
         for i in range(len(color_list)):
-            break_map[i] = color_list[i]
-        result = ColorMap.build(BaseTestClass.pysc, breaks=break_map)
-        self.assertTrue(isinstance(result, ColorMap))
-        self.assertTrue(result.cmap.map(3) == color_list[3])
+            break_map[str(i)] = color_list[i]
+        with pytest.raises(TypeError):
+            result = ColorMap.from_break_map(BaseTestClass.pysc, break_map)
 
-    def test_from_colors1(self):
+    def test_from_colors_int(self):
         color_list = self.color_list
         breaks = range(len(color_list))
         result = ColorMap.from_colors(BaseTestClass.pysc, breaks, color_list)
         self.assertTrue(isinstance(result, ColorMap))
-        self.assertTrue(result.cmap.map(3) == color_list[3])
+        self.assertEqual(result.cmap.map(3), color_list[3])
 
-    def test_from_colors2(self):
+    def test_from_colors_float(self):
         color_list = self.color_list
         breaks = map(float, range(len(color_list)))
         result = ColorMap.from_colors(BaseTestClass.pysc, breaks, color_list)
         self.assertTrue(isinstance(result, ColorMap))
-        self.assertTrue(result.cmap.mapDouble(3.0) == color_list[2]) # XXX
-
-    def test_build2(self):
-        color_list = self.color_list
-        breaks = list(range(len(color_list)))
-        result = ColorMap.build(BaseTestClass.pysc, breaks=breaks, colors=color_list)
-        self.assertTrue(isinstance(result, ColorMap))
-        self.assertTrue(result.cmap.map(3) == color_list[3])
+        self.assertEqual(result.cmap.mapDouble(3.0), color_list[2]) # XXX
 
     def test_from_histogram(self):
         extent = {'xmin': 0.0, 'ymin': 0.0, 'xmax': 33.0, 'ymax': 33.0}
@@ -90,7 +95,36 @@ class ColormapTest(BaseTestClass):
         result = ColorMap.from_histogram(BaseTestClass.pysc, hist, color_list)
         self.assertTrue(isinstance(result, ColorMap))
 
-    def test_build3(self):
+    def test_build_map(self):
+        color_list = self.color_list
+        break_map = {}
+        for i in range(len(color_list)):
+            break_map[i] = color_list[i]
+        result = ColorMap.build(BaseTestClass.pysc, breaks=break_map)
+        self.assertTrue(isinstance(result, ColorMap))
+        self.assertEqual(result.cmap.map(3), color_list[3])
+
+    def test_build_int_list(self):
+        color_list = self.color_list
+        breaks = list(range(len(color_list)))
+        result = ColorMap.build(BaseTestClass.pysc, breaks=breaks, colors=color_list)
+        self.assertTrue(isinstance(result, ColorMap))
+        self.assertEqual(result.cmap.map(3), color_list[3])
+
+    def test_build_color_list(self):
+        color_list = [Color('red'), Color('green'), Color('blue')] # XXX
+        breaks = list(range(len(color_list)))
+        result = ColorMap.build(BaseTestClass.pysc, breaks=breaks, colors=color_list)
+        self.assertTrue(isinstance(result, ColorMap))
+        self.assertEqual(result.cmap.map(2), struct.unpack(">L", bytes(color_list[2].rgba))[0])
+
+    def test_build_color_string(self):
+        breaks = list(range(42))
+        result = ColorMap.build(BaseTestClass.pysc, breaks=breaks, colors='viridis')
+        self.assertTrue(isinstance(result, ColorMap))
+        self.assertEqual(result.cmap.map(0), 0x440154ff)
+
+    def test_build_histogram(self):
         extent = {'xmin': 0.0, 'ymin': 0.0, 'xmax': 33.0, 'ymax': 33.0}
         layout = {'layoutCols': 1, 'layoutRows': 1, 'tileCols': 2, 'tileRows': 4}
         metadata = {'cellType': 'float32ud-1.0',

--- a/geopyspark/tests/colormap_test.py
+++ b/geopyspark/tests/colormap_test.py
@@ -1,7 +1,8 @@
-import unittest
 import numpy as np
 import pytest
 import struct
+import sys
+import unittest
 
 from colortools import Color
 from geopyspark.geotrellis.color import get_colors_from_colors, get_colors_from_matplotlib, ColorMap
@@ -20,6 +21,7 @@ class ColormapTest(BaseTestClass):
         self.assertEqual(len(result), 3)
         self.assertEqual(result[0], 0xff0000ff)
 
+    @pytest.mark.skipif(sys.version_info < (3,4), reason="Python 3.4 or greater needed for matplotlib")
     def test_get_colors_from_matplotlib(self):
         result = get_colors_from_matplotlib('viridis', num_colors=42)
         self.assertEqual(len(result), 42)
@@ -118,6 +120,7 @@ class ColormapTest(BaseTestClass):
         self.assertTrue(isinstance(result, ColorMap))
         self.assertEqual(result.cmap.map(2), struct.unpack(">L", bytes(color_list[2].rgba))[0])
 
+    @pytest.mark.skipif(sys.version_info < (3,4), reason="Python 3.4 or greater needed for matplotlib")
     def test_build_color_string(self):
         breaks = list(range(42))
         result = ColorMap.build(BaseTestClass.pysc, breaks=breaks, colors='viridis')

--- a/geopyspark/tests/colormap_test.py
+++ b/geopyspark/tests/colormap_test.py
@@ -12,11 +12,26 @@ from geopyspark.tests.base_test_class import BaseTestClass
 class ColormapTest(BaseTestClass):
     color_list = [0x000000ff, 0x100000ff, 0x200000ff, 0x300000ff, 0x400000ff, 0x500000ff, 0x600000ff, 0x700000ff]
 
-    def test_from_break_map(self):
+    def test_nlcd(self):
+        result = ColorMap.nlcd_colormap(BaseTestClass.pysc)
+        self.assertTrue(result.cmap.map(0) == 0x00000000)
+        self.assertTrue((0x0ffffffff + 1 + result.cmap.map(51)) == 0xBAA65CFF)
+        self.assertTrue((0x0ffffffff + 1 + result.cmap.map(92)) == 0xB6D8F5FF)
+
+    def test_from_break_map1(self):
         color_list = self.color_list
         break_map = {}
         for i in range(len(color_list)):
             break_map[i] = color_list[i]
+        result = ColorMap.from_break_map(BaseTestClass.pysc, break_map)
+        self.assertTrue(isinstance(result, ColorMap))
+        self.assertTrue(result.cmap.map(3) == color_list[3])
+
+    def test_from_break_map2(self):
+        color_list = self.color_list
+        break_map = {}
+        for i in range(len(color_list)):
+            break_map[float(i)] = color_list[i]
         result = ColorMap.from_break_map(BaseTestClass.pysc, break_map)
         self.assertTrue(isinstance(result, ColorMap))
         self.assertTrue(result.cmap.map(3) == color_list[3])
@@ -30,12 +45,19 @@ class ColormapTest(BaseTestClass):
         self.assertTrue(isinstance(result, ColorMap))
         self.assertTrue(result.cmap.map(3) == color_list[3])
 
-    def test_from_colors(self):
+    def test_from_colors1(self):
         color_list = self.color_list
         breaks = range(len(color_list))
         result = ColorMap.from_colors(BaseTestClass.pysc, breaks, color_list)
         self.assertTrue(isinstance(result, ColorMap))
         self.assertTrue(result.cmap.map(3) == color_list[3])
+
+    def test_from_colors2(self):
+        color_list = self.color_list
+        breaks = map(float, range(len(color_list)))
+        result = ColorMap.from_colors(BaseTestClass.pysc, breaks, color_list)
+        self.assertTrue(isinstance(result, ColorMap))
+        self.assertTrue(result.cmap.mapDouble(3.0) == color_list[2]) # XXX
 
     def test_build2(self):
         color_list = self.color_list


### PR DESCRIPTION
The #269 is to do with improving coverage for `color.py` and `pyramid.py`.

These changes improve coverage of `catalog.py` and `color.py`, `pyramid.py` was already 100% covered.

In `color.py` the only uncovered lines are exceptions that only fire in the case of uninstalled dependencies.

In `catalog.py` the uncovered lines are due to untested backends (38-41, 50-53, 56-73, 80-91, 96-111), the fact that SpaceTime layers are not tested (181), there no test of behavior when the uri is not in the cache (289), and the fact that layer writing is not tested (457-476).

```
geopyspark/geotrellis/catalog.py                159     46    71%   38-41, 50-53, 56-73, 80-91, 96-111, 181, 289, 457-476
geopyspark/geotrellis/color.py                   66      4    94%   47-48, 126-127
```


Fixes locationtech-labs/geopyspark#269