### PR TITLE
User-defined Python rendering functions for TMS display

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tms/RenderFunction.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tms/RenderFunction.scala
@@ -4,9 +4,12 @@ import geotrellis.raster._
 import geotrellis.raster.render._
 
 trait TileRender {
-  def render(tile: Tile): Array[Byte]
+  def requiresEncoding(): Boolean
+  def render(tile: MultibandTile): Array[Byte] = ???
+  def renderEncoded(buffer: Array[Byte]): Array[Byte] = ???
 }
 
 class RenderFromCM(cm: ColorMap) extends TileRender {
-  def render(tile: Tile) = tile.renderPng(cm).bytes
+  def requiresEncoding() = false
+  override def render(tile: MultibandTile) = tile.band(0).renderPng(cm).bytes
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tms/Server.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tms/Server.scala
@@ -105,7 +105,7 @@ object TMSServer {
     val level_map = levels.asScala.map { case (zoom, rdd) =>
       zoom -> rdd.map{ case (key, mbtile) => key -> mbtile.band(band) }
     }
-    val route = new SpatialRddRoute(level_map, display)
+    val route = new SpatialRddRoute(level_map, display, AkkaSystem.system)
     new TMSServer(route)
   }
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tms/Server.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tms/Server.scala
@@ -79,6 +79,13 @@ object TMSServer {
     new TMSServer(route)
   }
 
+  def serveS3CatalogCustom(bucket: String, root: String, catalog: String, display: TileRender): TMSServer = {
+    import geotrellis.spark.io.s3._
+    val reader = S3ValueReader(bucket, root)
+    val route = new ValueReaderRoute(reader, catalog, display)
+    new TMSServer(route)
+  }
+
   def serveRemoteTMSLayer(patternURL: String): TMSServer = {
     val route = new ExternalTMSServerRoute(patternURL)
     new TMSServer(route)
@@ -90,6 +97,15 @@ object TMSServer {
       zoom -> rdd.map{ case (key, mbtile) => key -> mbtile.band(band) }
     }
     val route = new SpatialRddRoute(level_map, new RenderFromCM(cm), AkkaSystem.system)
+    new TMSServer(route)
+  }
+
+  def serveSpatialRddCustom(levels: java.util.Map[Int, RDD[(SpatialKey, MultibandTile)]], display: TileRender, band: Int): TMSServer = {
+    import scala.collection.JavaConverters._
+    val level_map = levels.asScala.map { case (zoom, rdd) =>
+      zoom -> rdd.map{ case (key, mbtile) => key -> mbtile.band(band) }
+    }
+    val route = new SpatialRddRoute(level_map, display)
     new TMSServer(route)
   }
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tms/TmsRoutes.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tms/TmsRoutes.scala
@@ -62,7 +62,16 @@ class ValueReaderRoute(
         Future {
           val reader = layers.getOrElseUpdate(zoom, valueReader.reader[SpatialKey, Tile](LayerId(catalog, zoom)))
           val tile: Tile = reader(key)
-          val bytes: Array[Byte] = time(s"Rendering tile @ $key (zoom=$zoom)"){ rf.render(tile) }
+          val bytes: Array[Byte] = time(s"Rendering tile @ $key (zoom=$zoom)"){
+            if (rf.requiresEncoding()) {
+              // println("Encoding version")
+              rf.renderEncoded(geopyspark.geotrellis.PythonTranslator.toPython(MultibandTile(tile)))
+            } else {
+              // println("Non-encoding version")
+              rf.render(MultibandTile(tile)) 
+            }
+          }
+          // println(s"Got back $bytes from renderer")
           HttpEntity(`image/png`, bytes)
         }
       }
@@ -141,7 +150,13 @@ class RDDLookup(
                 promise success (results
                   .find{ case (rddKey, _) => rddKey == key } 
                   .map{ case (_, tile) => 
-                        HttpResponse(entity = HttpEntity(ContentType(MediaTypes.`image/png`), rf.render(tile))) 
+                        val bytes: Array[Byte] =
+                          if (rf.requiresEncoding()) {
+                            rf.renderEncoded(geopyspark.geotrellis.PythonTranslator.toPython(MultibandTile(tile)))
+                          } else {
+                            rf.render(MultibandTile(tile)) 
+                          }
+                        HttpResponse(entity = HttpEntity(ContentType(MediaTypes.`image/png`), bytes)) 
                       }
                 )
               }}

--- a/geopyspark/geotrellis/tms.py
+++ b/geopyspark/geotrellis/tms.py
@@ -1,8 +1,9 @@
 import io
 import numpy as np
 
+from geopyspark.geotrellis.color import ColorMap
 from geopyspark.geotrellis.layer import Pyramid
-
+from geopyspark.geotrellis.protobufcodecs import multibandtile_decoder
 
 class TileRender(object):
     """A Python implementation of the Scala geopyspark.geotrellis.tms.TileRender
@@ -20,10 +21,14 @@ class TileRender(object):
         Returns:
             [TileRender]
         """
+        print("Created Python TileRender object")
         # render_function: numpyarry => Image
         self.render_function = render_function
 
-    def render(self, cells, cols, rows): # return `bytes`
+    def requiresEncoding(self):
+        return True
+
+    def renderEncoded(self, scala_array): # return `bytes`
         """A function to convert an array to an image.
 
         Args:
@@ -35,13 +40,15 @@ class TileRender(object):
         Returns:
             [bytes] representing an image
         """
+        # self.sc._gateway.jvm.System.out.println("Python renderer called!")
         try:
-            # tile = np.array(list(cells)) # turn tile to array with bands
-            print("Reshaping to {}x{} matrix".format(rows, cols))
-            tile = np.reshape(np.frombuffer(cells, dtype="uint8"), (1, rows, cols)) # turn tile to array with bands
-            print("Rendering tile")
-            image = self.render_function(tile)
-            print("Saving result")
+            tile = multibandtile_decoder(scala_array)
+            # self.sc._gateway.jvm.System.out.println("Received tile of type {}".format(str(type(tile))))
+            cells = tile.cells
+            bands, rows, cols = cells.shape
+            # self.sc._gateway.jvm.System.out.println("Rendering {}x{} tile ({} bands)".format(rows, cols, bands))
+            image = self.render_function(cells)
+            # self.sc._gateway.jvm.System.out.println("Saving result")
             bio = io.BytesIO()
             image.save(bio, 'PNG')
             return bio.getvalue()
@@ -49,7 +56,7 @@ class TileRender(object):
             from traceback import print_exc
             print_exc()
 
-    class Java(object):
+    class Java:
         implements = ["geopyspark.geotrellis.tms.TileRender"]
 
 class TMSServer(object):
@@ -57,26 +64,32 @@ class TMSServer(object):
         self.pysc = pysc
         self.server = server
         self.handshake = ''
-        self.pysc._gateway.start_callback_server()
+        pysc._gateway.start_callback_server()
 
     def set_handshake(self, handshake):
         self.server.set_handshake(handshake)
         self.handshake = handshake
 
     @classmethod
-    def s3_catalog_tms_server(cls, pysc, bucket, root, catalog, color_map):
+    def s3_catalog_tms_server(cls, pysc, bucket, root, catalog, display):
         """A function to create a TMS server for a catalog stored in an S3 bucket.
 
         Args:
             bucket (string): The name of the S3 bucket
             root (string): The key in the bucket containing the catalog
             catalog (string): The name of the catalog
-            color_map (ColorMap): A ColorMap to use in rendering the catalog tiles
+            display (ColorMap, TileRender): A ColorMap to use in rendering the catalog tiles
 
         Returns:
             [TMSServer]
         """
-        server = pysc._gateway.jvm.geopyspark.geotrellis.tms.TMSServer.serveS3Catalog(bucket, root, catalog, color_map.cmap)
+        if isinstance(display, ColorMap):
+            server = pysc._gateway.jvm.geopyspark.geotrellis.tms.TMSServer.serveS3Catalog(bucket, root, catalog, display.cmap)
+        elif isinstance(display, TileRender):
+            server = pysc._gateway.jvm.geopyspark.geotrellis.tms.TMSServer.serveS3CatalogCustom(bucket, root, catalog, display)
+        else:
+            raise ValueError("Must specify the display parameter as a ColorMap or TileRender object")
+
         return cls(pysc, server)
 
     @classmethod
@@ -97,9 +110,27 @@ class TMSServer(object):
         return cls(pysc, server)
 
     @classmethod
-    def rdd_tms_server(cls, pysc, pyramid, color_map):
+    def rdd_tms_server(cls, pysc, pyramid, display):
+        """Creates a TMS server for displaying a Pyramided RDD.
+
+        Args:
+            pysc (SparkContext): The current SparkContext
+            pyramid (Pyramid): The pyramided RDD
+            display (ColorMap, TileRender): A color map or TileRender object
+                that will be used for display.
+
+        Returns:
+            [TMSServer]
+        """
         if isinstance(pyramid, list):
             pyramid = Pyramid(pyramid)
         rdd_levels = {k: v.srdd.rdd() for k, v in pyramid.levels.items()}
-        server = pysc._gateway.jvm.geopyspark.geotrellis.tms.TMSServer.serveSpatialRdd(rdd_levels, color_map.cmap, 0)
+
+        if isinstance(display, ColorMap):
+            server = pysc._gateway.jvm.geopyspark.geotrellis.tms.TMSServer.serveSpatialRdd(rdd_levels, display.cmap, 0)
+        elif isinstance(display, TileRender):
+            server = pysc._gateway.jvm.geopyspark.geotrellis.tms.TMSServer.serveSpatialRddCustom(rdd_levels, display, 0)
+        else:
+            raise ValueError("Must specify the display parameter as a ColorMap or TileRender object")
+        
         return cls(pysc, server)

--- a/geopyspark/geotrellis/tms.py
+++ b/geopyspark/geotrellis/tms.py
@@ -132,5 +132,5 @@ class TMSServer(object):
             server = pysc._gateway.jvm.geopyspark.geotrellis.tms.TMSServer.serveSpatialRddCustom(rdd_levels, display, 0)
         else:
             raise ValueError("Must specify the display parameter as a ColorMap or TileRender object")
-        
+
         return cls(pysc, server)


### PR DESCRIPTION
There may be cases where a user wishes to define a custom rendering function in Python that will transform a numpy array into a bytes representation of an image, the input array having shape (#bands, #rows, #cols).  This PR enables that capability.  Given a function from nparray to image bytes, we wrap that function in a `TileRender` object and pass it to either `TMSServer.rdd_tms_server` or `.s3_catalog_tms_server`.  The results will be slower to display, but adds a measure of flexibility.

_As a note, it appears that Py4J exception reporting when Scala invokes a Python function that results in errors is the pits.  One will either encounter a NullPointerException or receive the cryptic error message `py4j.Py4JException: An exception was raised by the Python Proxy. Return Message: x`.  In these cases, more explicit testing of the rendering function within Python itself is warranted._

Fixes #281

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>