### PR TITLE
Importing is Now Easier

### DIFF
--- a/geopyspark/__init__.py
+++ b/geopyspark/__init__.py
@@ -129,3 +129,12 @@ def geopyspark_conf(master=None, appName=None, additional_jar_dirs=[]):
     conf.set(key='spark.executor.memory', value='8G')
 
     return conf
+
+
+__all__ = ['geopyspark_conf']
+
+
+from . import geotrellis
+from .geotrellis import *
+
+__all__.extend(geotrellis.__all__)

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -415,7 +415,6 @@ from .constants import *
 from .converters import *
 from .cost_distance import *
 from .euclidean_distance import *
-from .geotiff import *
 from .hillshade import *
 from .histogram import *
 from .layer import *
@@ -428,7 +427,7 @@ __all__ += color.__all__
 __all__ += constants.__all__
 __all__ += ['cost_distance']
 __all__ += ['euclidean_distance']
-__all__ += geotiff.__all__
+__all__ += ['geotiff']
 __all__ += ['hillshade']
 __all__ += histogram.__all__
 __all__ += layer.__all__

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -396,7 +396,42 @@ class Metadata(object):
                                                self.tile_layout, self.layout_definition)
 
 
-__all__ = ["catalog", "geotiff", "layer", "cost_distance", "hillshade", "euclidean_distance",
-           "rasterize", "tms"]
+__all__ = ["Tile", "Extent", "ProjectedExtent", "TemporalProjectedExtent", "SpatialKey", "SpaceTimeKey",
+           "Metadata", "TileLayout", "LayoutDefinition", "Bounds", "RasterizerOptions"]
 
+from . import catalog
+from . import color
+from . import constants
 from . import converters
+from . import geotiff
+from . import histogram
+from . import layer
+from . import neighborhood
+from . import tms
+
+from .catalog import *
+from .color import *
+from .constants import *
+from .converters import *
+from .cost_distance import *
+from .euclidean_distance import *
+from .geotiff import *
+from .hillshade import *
+from .histogram import *
+from .layer import *
+from .neighborhood import *
+from .rasterize import *
+from .tms import *
+
+__all__ += catalog.__all__
+__all__ += color.__all__
+__all__ += constants.__all__
+__all__ += ['cost_distance']
+__all__ += ['euclidean_distance']
+__all__ += geotiff.__all__
+__all__ += ['hillshade']
+__all__ += histogram.__all__
+__all__ += layer.__all__
+__all__ += neighborhood.__all__
+__all__ += ['rasterize']
+__all__ += tms.__all__

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -16,6 +16,9 @@ from geopyspark.geotrellis import Metadata, Extent, deprecated
 from geopyspark.geotrellis.layer import TiledRasterLayer
 
 
+__all__ = ["read_layer_metadata", "get_layer_ids", "read_value", "query", "write"]
+
+
 _mapped_cached = {}
 _mapped_serializers = {}
 _cached = namedtuple('Cached', ('store', 'reader', 'value_reader', 'writer'))

--- a/geopyspark/geotrellis/color.py
+++ b/geopyspark/geotrellis/color.py
@@ -9,6 +9,9 @@ ensure_pyspark()
 from geopyspark.geotrellis.constants import ClassificationStrategy
 
 
+__all__ = ["get_colors_from_colors", "get_colors_from_matplotlib", "ColorMap"]
+
+
 def get_colors_from_colors(colors):
     """Returns a list of integer colors from a list of Color objects from the
     colortools package.

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -2,7 +2,8 @@
 from enum import Enum, IntEnum
 
 
-__all__ = ['LayerType', 'LayoutScheme', 'NO_DATA_INT']
+__all__ = ['NO_DATA_INT', 'LayerType', 'LayoutScheme', 'IndexingMethod', 'ResampleMethod', 'TimeUnit',
+           'Operation', 'Neighborhood', 'ClassificationStrategy', 'CellType', 'ColorRamp']
 
 
 """The NoData value for ints in GeoTrellis."""

--- a/geopyspark/geotrellis/cost_distance.py
+++ b/geopyspark/geotrellis/cost_distance.py
@@ -2,6 +2,9 @@ import shapely.wkb
 from geopyspark.geotrellis.layer import TiledRasterLayer
 
 
+__all__ = ['cost_distance']
+
+
 def cost_distance(friction_layer, geometries, max_distance):
     """Performs cost distance of a TileLayer.
 

--- a/geopyspark/geotrellis/euclidean_distance.py
+++ b/geopyspark/geotrellis/euclidean_distance.py
@@ -3,6 +3,9 @@ from geopyspark.geotrellis.constants import LayerType, CellType
 from geopyspark.geotrellis.layer import TiledRasterLayer
 
 
+__all__ = ['euclidean_distance']
+
+
 def euclidean_distance(pysc, geometry, source_crs, zoom, cellType=CellType.FLOAT64):
     """Calculates the Euclidean distance of a Shapely geometry.
 

--- a/geopyspark/geotrellis/geotiff.py
+++ b/geopyspark/geotrellis/geotiff.py
@@ -6,6 +6,9 @@ from geopyspark.geotrellis.constants import LayerType
 from geopyspark.geotrellis.layer import RasterLayer
 
 
+__all__ = ['get']
+
+
 def get(pysc,
         layer_type,
         uri,

--- a/geopyspark/geotrellis/hillshade.py
+++ b/geopyspark/geotrellis/hillshade.py
@@ -1,6 +1,8 @@
 from geopyspark.geotrellis.layer import TiledRasterLayer
 
 
+__all__ = ['hillshade']
+
 def hillshade(tiled_raster_layer, band=0, azimuth=315.0, altitude=45.0, z_factor=1.0):
     """Computes Hillshade (shaded relief) from a raster.
 

--- a/geopyspark/geotrellis/histogram.py
+++ b/geopyspark/geotrellis/histogram.py
@@ -3,6 +3,9 @@ class.
 """
 
 
+__all__ = ['Histogram']
+
+
 class Histogram(object):
     """A wrapper class for a GeoTrellis Histogram.
 

--- a/geopyspark/geotrellis/neighborhood.py
+++ b/geopyspark/geotrellis/neighborhood.py
@@ -6,6 +6,9 @@ Note:
 """
 
 
+__all__ = ['Square', 'Circle', 'Wedge', 'Nesw', 'Annulus']
+
+
 class Neighborhood(object):
     def __init__(self, name, param_1, param_2=None, param_3=None):
         """The base class of the all of the neighborhoods.

--- a/geopyspark/geotrellis/rasterize.py
+++ b/geopyspark/geotrellis/rasterize.py
@@ -3,6 +3,9 @@ from geopyspark.geotrellis.constants import LayerType, CellType
 from geopyspark.geotrellis.layer import TiledRasterLayer
 
 
+__all__ = ['rasterize']
+
+
 def rasterize(pysc, geoms, crs, zoom, fill_value, cell_type=CellType.FLOAT64, options=None, numPartitions=None):
     """Rasterizes a Shapely geometries.
 

--- a/geopyspark/geotrellis/tms.py
+++ b/geopyspark/geotrellis/tms.py
@@ -4,6 +4,9 @@ import numpy as np
 from geopyspark.geotrellis.layer import Pyramid
 
 
+__all__ = ['TileRender', 'TMSServer']
+
+
 class TileRender(object):
     """A Python implementation of the Scala geopyspark.geotrellis.tms.TileRender
     interface.  Permits a callback from Scala to Python to allow for custom

--- a/geopyspark/tests/costdistance_test.py
+++ b/geopyspark/tests/costdistance_test.py
@@ -51,8 +51,8 @@ class CostDistanceTest(BaseTestClass):
             k = kv[0]
             return (k.col == 0 and k.row == 1)
 
-        result = cost_distance.cost_distance(self.raster_rdd,
-                                             geometries=[Point(13, 13)], max_distance=144000.0)
+        result = cost_distance(self.raster_rdd,
+                               geometries=[Point(13, 13)], max_distance=144000.0)
 
         tile = result.to_numpy_rdd().filter(zero_one).first()[1]
         point_distance = tile.cells[0][1][3]
@@ -63,8 +63,8 @@ class CostDistanceTest(BaseTestClass):
             k = kv[0]
             return (k.col == 0 and k.row == 1)
 
-        result = cost_distance.cost_distance(self.raster_rdd,
-                                             geometries=[Point(13, 13)], max_distance=144000)
+        result = cost_distance(self.raster_rdd,
+                               geometries=[Point(13, 13)], max_distance=144000)
 
         tile = result.to_numpy_rdd().filter(zero_one).first()[1]
         point_distance = tile.cells[0][1][3]
@@ -75,8 +75,8 @@ class CostDistanceTest(BaseTestClass):
             k = kv[0]
             return (k.col == 0 and k.row == 1)
 
-        result = cost_distance.cost_distance(self.raster_rdd,
-                                             geometries=[Point(13, 13)], max_distance=float('inf'))
+        result = cost_distance(self.raster_rdd,
+                               geometries=[Point(13, 13)], max_distance=float('inf'))
 
         tile = result.to_numpy_rdd().filter(zero_one).first()[1]
         point_distance = tile.cells[0][0][0]

--- a/geopyspark/tests/euclidean_distance_test.py
+++ b/geopyspark/tests/euclidean_distance_test.py
@@ -48,7 +48,7 @@ class EuclideanDistanceTest(BaseTestClass):
             x, y = gridToMap(layoutDefinition, spatialKey, px, py)
             return geom.distance(Point(x, y))
 
-        tiled = euclidean_distance.euclidean_distance(BaseTestClass.pysc, self.pts_wm, 3857, 7)
+        tiled = euclidean_distance(BaseTestClass.pysc, self.pts_wm, 3857, 7)
         result = tiled.stitch().cells[0]
 
         arr = np.zeros((256,256), dtype=float)

--- a/geopyspark/tests/hillshade_test.py
+++ b/geopyspark/tests/hillshade_test.py
@@ -45,7 +45,7 @@ class HillshadeTest(BaseTestClass):
         BaseTestClass.pysc._gateway.close()
 
     def test_hillshade(self):
-        result = hillshade.hillshade(self.raster_rdd, band=0, azimuth=99.0, altitude=33.0, z_factor=0.0)
+        result = hillshade(self.raster_rdd, band=0, azimuth=99.0, altitude=33.0, z_factor=0.0)
 
         data = result.to_numpy_rdd().first()[1].cells[0][0][0]
         self.assertEqual(data, 63)

--- a/geopyspark/tests/rasterize_test.py
+++ b/geopyspark/tests/rasterize_test.py
@@ -22,11 +22,11 @@ class RasterizeTest(BaseTestClass):
     def test_whole_area(self):
         polygon = Polygon([(0, 11), (11, 11), (11, 0), (0, 0)])
 
-        raster_rdd = rasterize.rasterize(BaseTestClass.pysc,
-                                         [polygon],
-                                         "EPSG:3857",
-                                         11,
-                                         1)
+        raster_rdd = rasterize(BaseTestClass.pysc,
+                               [polygon],
+                               "EPSG:3857",
+                               11,
+                               1)
 
         cells = raster_rdd.to_numpy_rdd().first()[1].cells
 
@@ -36,11 +36,11 @@ class RasterizeTest(BaseTestClass):
     def test_whole_area_integer_crs(self):
         polygon = Polygon([(0, 11), (11, 11), (11, 0), (0, 0)])
 
-        raster_rdd = rasterize.rasterize(BaseTestClass.pysc,
-                                         [polygon],
-                                         3857,
-                                         11,
-                                         1)
+        raster_rdd = rasterize(BaseTestClass.pysc,
+                               [polygon],
+                               3857,
+                               11,
+                               1)
 
         cells = raster_rdd.to_numpy_rdd().first()[1].cells
 


### PR DESCRIPTION
This PR makes it so that now all functions, classes, and objects that will be used by the user can be imported with just one statement. **Note**: backend classes and functions like `ProtoBufSerializer` and `ensure_pyspark` will not be included with the new import statement. In addition, scripts that import `cost_distance`, `euclidean_distance`, `hillshade`, or `rasterize` may break depending on these modules are imported.

Before this PR:
```python
from geopyspark import geopyspark_conf
from geopyspark.geotrellis import geotiff, catalog

from pyspark import SparkContext

conf = geopyspark_conf(master="local[*]", appName="example")
pysc = SparkContext(conf=conf)

raster_layer = geotiff.get(pysc, "spatial", "some-path.tif")
tiled_layer = raster_layer.to_tiled_layer()
pyramided = tiled_layer.pyramid(start_zoom=12, end_zoom=1)
for level in pyramided.levels.values():
    catalog.write("/path/to/my/catalog", "catalog-name", level)
```

Now:
```python
import geopyspark as gp

from pyspark import SparkContext

conf = gp.geopyspark_conf(master="local[*]", appName="example")
pysc = SparkContext(conf=conf)

raster_layer = gp.get(pysc, gp.LayerType.SPATIAL, "some-path.tif")
tiled_layer = raster_layer.to_tiled_layer()
pyramided = tiled_layer.pyramid(start_zoom=12, end_zoom=1)
for level in pyramided.levels.values():
    gp.write("/path/to/my/catalog", "catalog-name", level)
```