### PR TITLE
tile_to_layout Now Works For TiledRasterLayer

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
@@ -130,6 +130,15 @@ abstract class TiledRasterRDD[K: SpatialComponent: JsonFormat: ClassTag] extends
   ): TiledRasterRDD[K]
 
   def tileToLayout(
+    extent: java.util.Map[String, Double],
+    tileLayout: java.util.Map[String, Int],
+    resampleMethod: String
+  ): TiledRasterRDD[K] =
+    tileToLayout(
+      LayoutDefinition(extent.toExtent, tileLayout.toTileLayout),
+      resampleMethod)
+
+  protected def tileToLayout(
     layoutDefinition: LayoutDefinition,
     resampleMethod: String
   ): TiledRasterRDD[K]

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -925,12 +925,12 @@ class TiledRasterLayer(CachableLayer):
 
         return [multibandtile_decoder(tile) for tile in array_of_tiles]
 
-    def tile_to_layout(self, layout, resample_method=ResampleMethod.NEAREST_NEIGHBOR):
+    def tile_to_layout(self, layout_definition, resample_method=ResampleMethod.NEAREST_NEIGHBOR):
         """Cut tiles to a given layout and merge overlapping tiles. This will produce unique keys.
 
         Args:
-            layout (:obj:`~geopyspark.geotrellis.TileLayout`): Specify the ``TileLayout`` to cut
-                to.
+            layout_definition (:obj:`~geopyspark.geotrellis.LayoutDefinition`): Specify the
+                ``LayoutDefinition`` to cut to.
             resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
                 The resample method to use for the reprojection. If none is specified, then
                 ``ResampleMethods.NEAREST_NEIGHBOR`` is used.
@@ -939,10 +939,9 @@ class TiledRasterLayer(CachableLayer):
             :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
         """
 
-        if not isinstance(layout, dict):
-            layout = layout._asdict()
-
-        srdd = self.srdd.tileToLayout(layout, ResampleMethod(resample_method).value)
+        srdd = self.srdd.tileToLayout(layout_definition.extent._asdict(),
+                                      layout_definition.tileLayout._asdict(),
+                                      ResampleMethod(resample_method).value)
 
         return TiledRasterLayer(self.pysc, self.layer_type, srdd)
 

--- a/geopyspark/tests/tiled_raster_layer_test.py
+++ b/geopyspark/tests/tiled_raster_layer_test.py
@@ -1,0 +1,36 @@
+import unittest
+import pytest
+
+from geopyspark.geotrellis.constants import LayerType
+from geopyspark.tests.python_test_utils import geotiff_test_path
+from geopyspark.geotrellis import Extent, LayoutDefinition
+from geopyspark.geotrellis.geotiff import get
+from geopyspark.tests.base_test_class import BaseTestClass
+
+
+class TiledRasterLayerTest(BaseTestClass):
+    dir_path = geotiff_test_path("all-ones.tif")
+    result = get(BaseTestClass.pysc, LayerType.SPATIAL, dir_path)
+    tiled_layer = result.to_tiled_layer()
+
+    @pytest.fixture(autouse=True)
+    def tearDown(self):
+        yield
+        BaseTestClass.pysc._gateway.close()
+
+    def test_tile_to_layout(self):
+        layout_definition = self.tiled_layer.layer_metadata.layout_definition
+        new_extent = Extent(layout_definition.extent.xmin,
+                            layout_definition.extent.ymin,
+                            layout_definition.extent.xmax + 15.0,
+                            layout_definition.extent.ymax + 15.0)
+
+        new_layout_definition = LayoutDefinition(extent=new_extent, tileLayout=layout_definition.tileLayout)
+
+        actual = self.tiled_layer.tile_to_layout(new_layout_definition).layer_metadata.layout_definition.extent
+
+        self.assertEqual(actual, new_extent)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR fixes a bug where `tile_to_layout` wouldn't work due to not sending the correct parameters to the Scala method.

This PR resolves #361 