### PR TITLE
Tile Class Methods

### DIFF
--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -23,8 +23,8 @@ def deprecated(func):
     return new_func
 
 
-Tile = namedtuple("Tile", 'cells cell_type no_data_value')
-"""Represents a raster in GeoPySpark.
+class Tile(namedtuple("Tile", 'cells cell_type no_data_value')):
+    """Represents a raster in GeoPySpark.
 
     Note:
         All rasters in GeoPySpark are represented as having multiple bands, even if the original
@@ -33,12 +33,76 @@ Tile = namedtuple("Tile", 'cells cell_type no_data_value')
     Args:
         cells (nd.array): The raster data itself. It is contained within a NumPy array.
         data_type (str): The data type of the values within ``data`` if they were in Scala.
-        no_data_value: The value that represents no data in raster. This can be
+        no_data_value: The value that represents no data value in the raster. This can be
             represented by a variety of types depending on the value type of the raster.
 
-    Returns:
-        :obj:`~geopyspark.geotrellis.Tile`
-"""
+    Attributes:
+        cells (nd.array): The raster data itself. It is contained within a NumPy array.
+        data_type (str): The data type of the values within ``data`` if they were in Scala.
+        no_data_value: The value that represents no data value in the raster. This can be
+            represented by a variety of types depending on the value type of the raster.
+    """
+
+    __slots__ = []
+
+    @staticmethod
+    def dtype_to_cell_type(dtype):
+        """Converts a ``np.dtype`` to the corresponding GeoPySpark ``cell_type``.
+
+        Note:
+            ``bool``, ``complex64``, ``complex128``, and ``complex256``, are currently not
+            supported ``np.dtype``\s.
+
+        Args:
+            dtype (np.dtype): The ``dtype`` of the numpy array.
+
+        Returns:
+            str. The GeoPySpark ``cell_type`` equivalent of the ``dtype``.
+
+        Raises:
+            TypeError: If the given ``dtype`` is not a supported data type.
+        """
+
+        name = dtype.name
+
+        if name == 'int8':
+            return 'BYTE'
+        elif name == 'uint8':
+            return 'UBYTE'
+        elif name == 'int16':
+            return 'SHORT'
+        elif name == 'uint16':
+            return 'USHORT'
+        elif name == 'int32':
+            return 'INT'
+        elif name in ['uint32', 'float16', 'float32']:
+            return 'FLOAT'
+        elif name in ['int64', 'uint64', 'float64']:
+            return 'DOUBLE'
+        else:
+            raise TypeError(name, "Is not a supported data type.")
+
+    @classmethod
+    def from_numpy_array(cls, numpy_array, no_data_value=None):
+        """Creates an instance of ``Tile`` from a numpy array.
+
+        Args:
+            numpy_array (np.array): The numpy array to be used to represent the cell values
+                of the ``Tile``.
+
+                Note:
+                    GeoPySpark does not support arrays with the following data types: ``bool``,
+                    ``complex64``, ``complex128``, and ``complex256``.
+
+            no_data_value (optional): The value that represents no data value in the raster.
+                This can be represented by a variety of types depending on the value type of
+                the raster. If not given, then the value will be ``None``.
+
+        Returns:
+            :class:`~geopyspark.geotrellis.Tile`
+        """
+
+        return cls(numpy_array, cls.dtype_to_cell_type(numpy_array.dtype), no_data_value)
 
 
 class Log(object):

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -1130,7 +1130,7 @@ class TiledRasterLayer(CachableLayer):
             This can only be used on ``LayerType.SPATIAL`` ``TiledRasterLayer``\s.
 
         Returns:
-            :obj:`~geopyspark.geotrellis.Tile`
+            :class:`~geopyspark.geotrellis.Tile`
         """
 
         if self.layer_type != LayerType.SPATIAL:

--- a/geopyspark/geotrellis/protobufcodecs.py
+++ b/geopyspark/geotrellis/protobufcodecs.py
@@ -34,7 +34,7 @@ def from_pb_tile(tile, no_data_value=None, data_type=None):
         tile (ProtoTile): The ``ProtoTile`` instance to be converted.
 
     Returns:
-        :obj:`~geopyspark.geotrellis.Tile`
+        :class:`~geopyspark.geotrellis.Tile`
     """
 
     if not data_type:
@@ -66,7 +66,7 @@ def tile_decoder(proto_bytes):
         proto_bytes (bytes): The ProtoBuf encoded bytes of the ProtoBuf class.
 
     Returns:
-        :obj:`~geopyspark.geotrellis.Tile`
+        :class:`~geopyspark.geotrellis.Tile`
     """
 
     tile = ProtoTile.FromString(proto_bytes)
@@ -85,7 +85,7 @@ def from_pb_multibandtile(multibandtile):
         multibandtile (ProtoTile): The ``ProtoMultibandTile`` instance to be converted.
 
     Returns:
-        :obj:`~geopyspark.geotrellis.Tile`
+        :class:`~geopyspark.geotrellis.Tile`
     """
 
     cell_type = _mapped_data_types[multibandtile.tiles[0].cellType.dataType]
@@ -105,7 +105,7 @@ def multibandtile_decoder(proto_bytes):
         proto_bytes (bytes): The ProtoBuf encoded bytes of the ProtoBuf class.
 
     Returns:
-        :obj:`~geopyspark.geotrellis.Tile`
+        :class:`~geopyspark.geotrellis.Tile`
     """
 
     return from_pb_multibandtile(ProtoMultibandTile.FromString(proto_bytes))
@@ -253,7 +253,7 @@ def tuple_decoder(proto_bytes, key_decoder):
     """Deserializes ``ProtoTuple`` bytes into Python.
 
     Note:
-        The value of the tuple is always assumed to be a :ref:`Tile <raster>`,
+        The value of the tuple is always assumed to be a :class:`~geopyspark.geotrellis.Tile`
         thus, only the decoding method of the key is required.
 
     Args:
@@ -349,7 +349,7 @@ def to_pb_tile(obj):
     """Converts an instance of ``Tile`` to ``ProtoTile``.
 
     Args:
-        obj (:obj:`~geopyspark.geotrellis.Tile`): An instance of ``Tile``.
+        obj (:class:`~geopyspark.geotrellis.Tile`): An instance of ``Tile``.
 
     Returns:
         ProtoTile
@@ -408,7 +408,7 @@ def tile_encoder(obj):
     """Encodes a ``TILE`` into ``ProtoTile`` bytes.
 
     Args:
-        obj (:obj:`~geopyspark.geotrellis.Tile`): An instance of ``Tile``.
+        obj (:class:`~geopyspark.geotrellis.Tile`): An instance of ``Tile``.
 
     Returns:
         bytes
@@ -421,7 +421,7 @@ def to_pb_multibandtile(obj):
     """Converts an instance of ``Tile`` to ``ProtoMultibandTile``.
 
     Args:
-        obj (:obj:`~geopyspark.geotrellis.Tile`): An instance of ``Tile``.
+        obj (:class:`~geopyspark.geotrellis.Tile`): An instance of ``Tile``.
 
     Returns:
         ProtoMultibandTile
@@ -445,7 +445,7 @@ def multibandtile_encoder(obj):
     """Encodes a ``TILE`` into ``ProtoMultibandTile`` bytes.
 
     Args:
-        obj (:obj:`~geopyspark.geotrellis.Tile`): An instance of ``Tile``.
+        obj (:class:`~geopyspark.geotrellis.Tile`): An instance of ``Tile``.
 
     Returns:
         bytes
@@ -626,7 +626,7 @@ def tuple_encoder(obj, key_encoder):
     """Encodes a tuple into ``ProtoTuple`` bytes.
 
     Note:
-        The value of the tuple is always assumed to be a :ref:`Tile <raster>`,
+        The value of the tuple is always assumed to be a :class:`~geopyspark.geotrellis.Tile`,
         thus, only the encoding method of the key is required.
 
     Args:

--- a/geopyspark/tests/costdistance_test.py
+++ b/geopyspark/tests/costdistance_test.py
@@ -20,10 +20,12 @@ class CostDistanceTest(BaseTestClass):
         [1.0, 1.0, 1.0, 1.0, 1.0],
         [1.0, 1.0, 1.0, 1.0, 0.0]]])
 
-    layer = [(SpatialKey(0, 0), Tile(cells, 'FLOAT', -1.0)),
-             (SpatialKey(1, 0), Tile(cells, 'FLOAT', -1.0,)),
-             (SpatialKey(0, 1), Tile(cells, 'FLOAT', -1.0,)),
-             (SpatialKey(1, 1), Tile(cells, 'FLOAT', -1.0,))]
+    tile = Tile.from_numpy_array(cells, -1.0)
+
+    layer = [(SpatialKey(0, 0), tile),
+             (SpatialKey(1, 0), tile),
+             (SpatialKey(0, 1), tile),
+             (SpatialKey(1, 1), tile)]
 
     rdd = BaseTestClass.pysc.parallelize(layer)
 

--- a/geopyspark/tests/focal_test.py
+++ b/geopyspark/tests/focal_test.py
@@ -18,10 +18,12 @@ class FocalTest(BaseTestClass):
         [1.0, 1.0, 1.0, 1.0, 1.0],
         [1.0, 1.0, 1.0, 1.0, 0.0]]])
 
-    layer = [(SpatialKey(0, 0), Tile(cells, 'FLOAT', -1.0)),
-             (SpatialKey(1, 0), Tile(cells, 'FLOAT', -1.0,)),
-             (SpatialKey(0, 1), Tile(cells, 'FLOAT', -1.0,)),
-             (SpatialKey(1, 1), Tile(cells, 'FLOAT', -1.0,))]
+    tile = Tile.from_numpy_array(cells, -1.0)
+
+    layer = [(SpatialKey(0, 0), tile),
+             (SpatialKey(1, 0), tile),
+             (SpatialKey(0, 1), tile),
+             (SpatialKey(1, 1), tile)]
     rdd = BaseTestClass.pysc.parallelize(layer)
 
     extent = {'xmin': 0.0, 'ymin': 0.0, 'xmax': 33.0, 'ymax': 33.0}

--- a/geopyspark/tests/schema_tests/tile_schema_test.py
+++ b/geopyspark/tests/schema_tests/tile_schema_test.py
@@ -24,9 +24,9 @@ mapped_data_types = {
 
 class ShortTileSchemaTest(BaseTestClass):
     tiles = [
-        Tile(np.int16([0, 0, 1, 1]).reshape(2, 2), 'SHORT', -32768),
-        Tile(np.int16([1, 2, 3, 4]).reshape(2, 2), 'SHORT', -32768),
-        Tile(np.int16([5, 6, 7, 8]).reshape(2, 2), 'SHORT', -32768)
+        Tile.from_numpy_array(np.int16([0, 0, 1, 1]).reshape(2, 2), -32768),
+        Tile.from_numpy_array(np.int16([1, 2, 3, 4]).reshape(2, 2), -32768),
+        Tile.from_numpy_array(np.int16([5, 6, 7, 8]).reshape(2, 2), -32768)
     ]
 
     sc = BaseTestClass.pysc._jsc.sc()
@@ -59,9 +59,9 @@ class ShortTileSchemaTest(BaseTestClass):
 
 class UShortTileSchemaTest(BaseTestClass):
     tiles = [
-        Tile(np.uint16([0, 0, 1, 1]).reshape(2, 2), 'USHORT', 0),
-        Tile(np.uint16([1, 2, 3, 4]).reshape(2, 2), 'USHORT', 0),
-        Tile(np.uint16([5, 6, 7, 8]).reshape(2, 2), 'USHORT', 0)
+        Tile.from_numpy_array(np.uint16([0, 0, 1, 1]).reshape(2, 2), 0),
+        Tile.from_numpy_array(np.uint16([1, 2, 3, 4]).reshape(2, 2), 0),
+        Tile.from_numpy_array(np.uint16([5, 6, 7, 8]).reshape(2, 2), 0)
     ]
 
     sc = BaseTestClass.pysc._jsc.sc()
@@ -94,9 +94,9 @@ class UShortTileSchemaTest(BaseTestClass):
 
 class ByteTileSchemaTest(BaseTestClass):
     tiles = [
-        Tile(np.int8([0, 0, 1, 1]).reshape(2, 2), 'BYTE', -128),
-        Tile(np.int8([1, 2, 3, 4]).reshape(2, 2), 'BYTE', -128),
-        Tile(np.int8([5, 6, 7, 8]).reshape(2, 2), 'BYTE', -128)
+        Tile.from_numpy_array(np.int8([0, 0, 1, 1]).reshape(2, 2), -128),
+        Tile.from_numpy_array(np.int8([1, 2, 3, 4]).reshape(2, 2), -128),
+        Tile.from_numpy_array(np.int8([5, 6, 7, 8]).reshape(2, 2), -128)
     ]
 
     sc = BaseTestClass.pysc._jsc.sc()
@@ -129,9 +129,9 @@ class ByteTileSchemaTest(BaseTestClass):
 
 class UByteTileSchemaTest(BaseTestClass):
     tiles = [
-        Tile(np.uint8([0, 0, 1, 1]).reshape(2, 2), 'UBYTE', 0),
-        Tile(np.uint8([1, 2, 3, 4]).reshape(2, 2), 'UBYTE', 0),
-        Tile(np.uint8([5, 6, 7, 8]).reshape(2, 2), 'UBYTE', 0)
+        Tile.from_numpy_array(np.uint8([0, 0, 1, 1]).reshape(2, 2), 0),
+        Tile.from_numpy_array(np.uint8([1, 2, 3, 4]).reshape(2, 2), 0),
+        Tile.from_numpy_array(np.uint8([5, 6, 7, 8]).reshape(2, 2), 0)
     ]
 
     sc = BaseTestClass.pysc._jsc.sc()
@@ -164,9 +164,9 @@ class UByteTileSchemaTest(BaseTestClass):
 
 class IntTileSchemaTest(BaseTestClass):
     tiles = [
-        Tile(np.int32([0, 0, 1, 1]).reshape(2, 2), 'INT', -2147483648),
-        Tile(np.int32([1, 2, 3, 4]).reshape(2, 2), 'INT', -2147483648),
-        Tile(np.int32([5, 6, 7, 8]).reshape(2, 2), 'INT', -2147483648)
+        Tile.from_numpy_array(np.int32([0, 0, 1, 1]).reshape(2, 2), -2147483648),
+        Tile.from_numpy_array(np.int32([1, 2, 3, 4]).reshape(2, 2), -2147483648),
+        Tile.from_numpy_array(np.int32([5, 6, 7, 8]).reshape(2, 2), -2147483648)
     ]
 
     sc = BaseTestClass.pysc._jsc.sc()
@@ -199,9 +199,9 @@ class IntTileSchemaTest(BaseTestClass):
 
 class DoubleTileSchemaTest(BaseTestClass):
     tiles = [
-        Tile(np.double([0, 0, 1, 1]).reshape(2, 2), 'DOUBLE', True),
-        Tile(np.double([1, 2, 3, 4]).reshape(2, 2), 'DOUBLE', True),
-        Tile(np.double([5, 6, 7, 8]).reshape(2, 2), 'DOUBLE', True)
+        Tile.from_numpy_array(np.double([0, 0, 1, 1]).reshape(2, 2), True),
+        Tile.from_numpy_array(np.double([1, 2, 3, 4]).reshape(2, 2), True),
+        Tile.from_numpy_array(np.double([5, 6, 7, 8]).reshape(2, 2), True)
     ]
 
     sc = BaseTestClass.pysc._jsc.sc()
@@ -233,9 +233,9 @@ class DoubleTileSchemaTest(BaseTestClass):
 
 class FloatTileSchemaTest(BaseTestClass):
     tiles = [
-        Tile(np.float32([0, 0, 1, 1]).reshape(2, 2), 'FLOAT', True),
-        Tile(np.float32([1, 2, 3, 4]).reshape(2, 2), 'FLOAT', True),
-        Tile(np.float32([5, 6, 7, 8]).reshape(2, 2), 'FLOAT', True)
+        Tile.from_numpy_array(np.float32([0, 0, 1, 1]).reshape(2, 2), True),
+        Tile.from_numpy_array(np.float32([1, 2, 3, 4]).reshape(2, 2), True),
+        Tile.from_numpy_array(np.float32([5, 6, 7, 8]).reshape(2, 2), True)
     ]
 
     sc = BaseTestClass.pysc._jsc.sc()


### PR DESCRIPTION
This PR makes `Tile` a class and adds a `staticmethod` and `classmethod` to it, `dtype_to_cell_type` and `from_numpy_array`, respectively. By adding these methods, it will now be easier for users to create `Tile` instances without having to worry about choosing the correct `cell_type` for the `Tile`.

This PR resolves #356 #348 