### PR TITLE
SparkContext Checking

### DIFF
--- a/geopyspark/__init__.py
+++ b/geopyspark/__init__.py
@@ -11,6 +11,13 @@ from pyspark import RDD, SparkConf, SparkContext
 from pyspark.serializers import AutoBatchedSerializer
 
 
+def get_spark_context():
+    if SparkContext._active_spark_context:
+        return SparkContext._active_spark_context
+    else:
+        raise RuntimeError("SparkContext must be initialized")
+
+
 def map_key_input(key_type, is_boundable):
     """Gets the mapped GeoTrellis type from the ``key_type``.
 
@@ -37,7 +44,7 @@ def map_key_input(key_type, is_boundable):
         else:
             raise Exception("Could not find key type that matches", key_type)
 
-def create_python_rdd(pysc, jrdd, serializer):
+def create_python_rdd(jrdd, serializer):
     """Creates a Python RDD from a RDD from Scala.
 
     Args:
@@ -48,6 +55,8 @@ def create_python_rdd(pysc, jrdd, serializer):
     Returns:
         RDD
     """
+
+    pysc = get_spark_context()
 
     if isinstance(serializer, AutoBatchedSerializer):
         return RDD(jrdd, pysc, serializer)

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -4,6 +4,7 @@ import warnings
 import functools
 from shapely.geometry import box
 
+from geopyspark import get_spark_context
 from geopyspark.geotrellis.constants import CellType, NO_DATA_INT
 
 
@@ -23,11 +24,10 @@ def deprecated(func):
     return new_func
 
 
-def crs_to_proj4(pysc, crs):
+def crs_to_proj4(crs):
     """Converts a given CRS to a Proj4 string.
 
     Args:
-        pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
         crs (str or int): Target CRS of reprojection. Either EPSG code, well-known name, or a
             PROJ.4 string. If ``None``, no reproject will be perfomed.
 
@@ -38,6 +38,7 @@ def crs_to_proj4(pysc, crs):
     if not isinstance(crs, str):
         crs = str(crs)
 
+    pysc = get_spark_context()
     scala_crs = pysc._gateway.jvm.geopyspark.geotrellis.TileLayer.getCRS(crs).get()
 
     return scala_crs.toProj4String()

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -149,7 +149,6 @@ def read_layer_metadata(layer_type,
     """Reads the metadata from a saved layer without reading in the whole layer.
 
     Args:
-        pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
         layer_type (str or :class:`geopyspark.geotrellis.constants.LayerType`): What the spatial type
             of the geotiffs are. This is represented by either constants within ``LayerType`` or by
             a string.
@@ -186,7 +185,6 @@ def get_layer_ids(uri,
     name and zoom of a given layer.
 
     Args:
-        pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
         uri (str): The Uniform Resource Identifier used to point towards the desired GeoTrellis
             catalog to be read from. The shape of this string varies depending on backend.
         options (dict, optional): Additional parameters for reading the layer for specific backends.
@@ -240,7 +238,6 @@ def read_value(layer_type,
         When requesting a tile that does not exist, ``None`` will be returned.
 
     Args:
-        pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
         layer_type (str or :class:`geopyspark.geotrellis.constants.LayerType`): What the spatial type
             of the geotiffs are. This is represented by either constants within ``LayerType`` or by
             a string.
@@ -304,7 +301,6 @@ def query(layer_type,
         been set, or if the querried region contains the entire layer.
 
     Args:
-        pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
         layer_type (str or :class:`geopyspark.geotrellis.constants.LayerType`): What the spatial type
             of the geotiffs are. This is represented by either constants within ``LayerType`` or by
             a string.

--- a/geopyspark/geotrellis/color.py
+++ b/geopyspark/geotrellis/color.py
@@ -118,7 +118,7 @@ class ColorMap(object):
         pysc = get_spark_context()
 
         if isinstance(breaks, dict):
-            return ColorMap.from_break_map(pysc, breaks, no_data_color, fallback, classification_strategy)
+            return ColorMap.from_break_map(breaks, no_data_color, fallback, classification_strategy)
 
         if isinstance(colors, str):
             color_list = get_colors_from_matplotlib(colors)
@@ -131,9 +131,9 @@ class ColorMap(object):
             raise ValueError("Could not construct ColorMap from the given colors", colors)
 
         if isinstance(breaks, list):
-            return ColorMap.from_colors(pysc, breaks, color_list, no_data_color, fallback, classification_strategy)
+            return ColorMap.from_colors(breaks, color_list, no_data_color, fallback, classification_strategy)
         elif isinstance(breaks, Histogram):
-            return ColorMap.from_histogram(pysc, breaks, color_list, no_data_color, fallback, classification_strategy)
+            return ColorMap.from_histogram(breaks, color_list, no_data_color, fallback, classification_strategy)
         else:
             raise ValueError("Could not construct ColorMap from the given breaks", breaks)
 

--- a/geopyspark/geotrellis/color.py
+++ b/geopyspark/geotrellis/color.py
@@ -94,7 +94,6 @@ class ColorMap(object):
         """Given breaks and colors, build a ``ColorMap`` object.
 
         Args:
-            pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
             breaks (dict or list or :class:`~geopyspark.geotrellis.Histogram`): If a ``dict`` then a
                 mapping from tile values to colors, the latter represented as integers
                 e.g., 0xff000080 is red at half opacity. If a ``list`` then tile values that
@@ -145,7 +144,6 @@ class ColorMap(object):
         """Converts a dictionary mapping from tile values to colors to a ColorMap.
 
         Args:
-            pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
             break_map (dict): A mapping from tile values to colors, the latter
                 represented as integers e.g., 0xff000080 is red at half opacity.
             no_data_color(int, optional): A color to replace NODATA values with
@@ -181,7 +179,6 @@ class ColorMap(object):
         """Converts lists of values and colors to a ``ColorMap``.
 
         Args:
-            pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
             breaks (list): The tile values that specify breaks in the color
                 mapping.
             color_list ([int]): The colors corresponding to the values in the
@@ -219,7 +216,6 @@ class ColorMap(object):
         """Converts a wrapped GeoTrellis histogram into a ``ColorMap``.
 
         Args:
-            pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
             histogram (:class:`~geopyspark.geotrellis.Histogram`): A ``Histogram`` instance;
                 specifies breaks
             color_list ([int]): The colors corresponding to the values in the
@@ -247,9 +243,6 @@ class ColorMap(object):
     @staticmethod
     def nlcd_colormap():
         """Returns a color map for NLCD tiles.
-
-        Args:
-            pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
 
         Returns:
             :class:`~geopyspark.geotrellis.color.ColorMap`

--- a/geopyspark/geotrellis/cost_distance.py
+++ b/geopyspark/geotrellis/cost_distance.py
@@ -30,4 +30,4 @@ def cost_distance(friction_layer, geometries, max_distance):
         wkbs,
         float(max_distance))
 
-    return TiledRasterLayer(friction_layer.pysc, friction_layer.layer_type, srdd)
+    return TiledRasterLayer(friction_layer.layer_type, srdd)

--- a/geopyspark/geotrellis/euclidean_distance.py
+++ b/geopyspark/geotrellis/euclidean_distance.py
@@ -1,4 +1,5 @@
 import shapely.wkb
+from geopyspark import get_spark_context
 from geopyspark.geotrellis.constants import LayerType, CellType
 from geopyspark.geotrellis.layer import TiledRasterLayer
 
@@ -6,7 +7,7 @@ from geopyspark.geotrellis.layer import TiledRasterLayer
 __all__ = ['euclidean_distance']
 
 
-def euclidean_distance(pysc, geometry, source_crs, zoom, cell_type=CellType.FLOAT64):
+def euclidean_distance(geometry, source_crs, zoom, cell_type=CellType.FLOAT64):
     """Calculates the Euclidean distance of a Shapely geometry.
 
     Args:
@@ -29,9 +30,11 @@ def euclidean_distance(pysc, geometry, source_crs, zoom, cell_type=CellType.FLOA
     if isinstance(source_crs, int):
         source_crs = str(source_crs)
 
+    pysc = get_spark_context()
+
     srdd = pysc._gateway.jvm.geopyspark.geotrellis.SpatialTiledRasterLayer.euclideanDistance(pysc._jsc.sc(),
                                                                                              shapely.wkb.dumps(geometry),
                                                                                              source_crs,
                                                                                              CellType(cell_type).value,
                                                                                              zoom)
-    return TiledRasterLayer(pysc, LayerType.SPATIAL, srdd)
+    return TiledRasterLayer(LayerType.SPATIAL, srdd)

--- a/geopyspark/geotrellis/euclidean_distance.py
+++ b/geopyspark/geotrellis/euclidean_distance.py
@@ -11,7 +11,6 @@ def euclidean_distance(geometry, source_crs, zoom, cell_type=CellType.FLOAT64):
     """Calculates the Euclidean distance of a Shapely geometry.
 
     Args:
-        pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
         geometry (shapely.geometry): The input geometry to compute the Euclidean distance
             for.
         source_crs (str or int): The CRS of the input geometry.

--- a/geopyspark/geotrellis/geotiff.py
+++ b/geopyspark/geotrellis/geotiff.py
@@ -1,7 +1,7 @@
 """This module contains functions that create ``RasterLayer`` from files."""
 
 from functools import reduce
-from geopyspark import map_key_input
+from geopyspark import map_key_input, get_spark_context
 from geopyspark.geotrellis.constants import LayerType
 from geopyspark.geotrellis.layer import RasterLayer
 
@@ -9,8 +9,7 @@ from geopyspark.geotrellis.layer import RasterLayer
 __all__ = ['get']
 
 
-def get(pysc,
-        layer_type,
+def get(layer_type,
         uri,
         crs=None,
         max_tile_size=None,
@@ -63,20 +62,21 @@ def get(pysc,
     """
 
     inputs = {k:v for k, v in locals().items() if v is not None}
+    pysc = get_spark_context()
 
     geotiff_rdd = pysc._gateway.jvm.geopyspark.geotrellis.io.geotiff.GeoTiffRDD
 
     key = map_key_input(LayerType(inputs.pop('layer_type')).value, False)
 
     if isinstance(uri, list):
-        srdd = geotiff_rdd.get(inputs.pop('pysc')._jsc.sc(),
+        srdd = geotiff_rdd.get(pysc._jsc.sc(),
                                key,
                                inputs.pop('uri'),
                                inputs)
     else:
-        srdd = geotiff_rdd.get(inputs.pop('pysc')._jsc.sc(),
+        srdd = geotiff_rdd.get(pysc._jsc.sc(),
                                key,
                                [inputs.pop('uri')],
                                inputs)
 
-    return RasterLayer(pysc, layer_type, srdd)
+    return RasterLayer(layer_type, srdd)

--- a/geopyspark/geotrellis/geotiff.py
+++ b/geopyspark/geotrellis/geotiff.py
@@ -22,7 +22,6 @@ def get(layer_type,
     or ``S3``.
 
     Args:
-        pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
         layer_type (str or :class:`geopyspark.geotrellis.constants.LayerType`): What the spatial type
             of the geotiffs are. This is represented by either constants within ``LayerType`` or by
             a string.

--- a/geopyspark/geotrellis/hillshade.py
+++ b/geopyspark/geotrellis/hillshade.py
@@ -3,6 +3,7 @@ from geopyspark.geotrellis.layer import TiledRasterLayer
 
 __all__ = ['hillshade']
 
+
 def hillshade(tiled_raster_layer, band=0, azimuth=315.0, altitude=45.0, z_factor=1.0):
     """Computes Hillshade (shaded relief) from a raster.
 
@@ -29,4 +30,4 @@ def hillshade(tiled_raster_layer, band=0, azimuth=315.0, altitude=45.0, z_factor
     srdd = tiled_raster_layer.srdd.hillshade(tiled_raster_layer.pysc._jsc.sc(), azimuth,
                                              altitude, z_factor, band)
 
-    return TiledRasterLayer(tiled_raster_layer.pysc, tiled_raster_layer.layer_type, srdd)
+    return TiledRasterLayer(tiled_raster_layer.layer_type, srdd)

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -13,7 +13,7 @@ ensure_pyspark()
 
 from pyspark.storagelevel import StorageLevel
 
-from geopyspark import map_key_input, create_python_rdd
+from geopyspark import get_spark_context, map_key_input, create_python_rdd
 from geopyspark.geotrellis import Metadata, Tile, LocalLayout, GlobalLayout, LayoutDefinition, crs_to_proj4
 from geopyspark.geotrellis.histogram import Histogram
 from geopyspark.geotrellis.constants import (Operation,
@@ -64,6 +64,7 @@ def _reclassify(srdd, value_map, data_type, classification_strategy, replace_nod
 
 def _to_geotiff_rdd(pysc, srdd, storage_method, rows_per_strip, tile_dimensions, compression,
                     color_space, color_map, head_tags, band_tags):
+
     storage_method = StorageMethod(storage_method).value
     compression = Compression(compression).value
     color_space = ColorSpace(color_space).value
@@ -221,14 +222,14 @@ class RasterLayer(CachableLayer):
 
     __slots__ = ['pysc', 'layer_type', 'srdd']
 
-    def __init__(self, pysc, layer_type, srdd):
+    def __init__(self, layer_type, srdd):
         CachableLayer.__init__(self)
-        self.pysc = pysc
+        self.pysc = get_spark_context()
         self.layer_type = layer_type
         self.srdd = srdd
 
     @classmethod
-    def from_numpy_rdd(cls, pysc, layer_type, numpy_rdd):
+    def from_numpy_rdd(cls, layer_type, numpy_rdd):
         """Create a ``RasterLayer`` from a numpy RDD.
 
         Args:
@@ -245,6 +246,7 @@ class RasterLayer(CachableLayer):
             :class:`~geopyspark.geotrellis.rdd.RasterLayer`
         """
 
+        pysc = get_spark_context()
         key = map_key_input(LayerType(layer_type).value, False)
         ser = ProtoBufSerializer.create_tuple_serializer(key_type=key)
         reserialized_rdd = numpy_rdd._reserialize(ser)
@@ -258,7 +260,7 @@ class RasterLayer(CachableLayer):
                     pysc._gateway.jvm.geopyspark.geotrellis.TemporalRasterLayer.fromProtoEncodedRDD(
                         reserialized_rdd._jrdd)
 
-        return cls(pysc, layer_type, srdd)
+        return cls(layer_type, srdd)
 
     def to_numpy_rdd(self):
         """Converts a ``RasterLayer`` to a numpy RDD.
@@ -275,7 +277,7 @@ class RasterLayer(CachableLayer):
         key = map_key_input(LayerType(self.layer_type).value, False)
         ser = ProtoBufSerializer.create_tuple_serializer(key_type=key)
 
-        return create_python_rdd(self.pysc, result, ser)
+        return create_python_rdd(result, ser)
 
     def to_png_rdd(self, color_map):
         """Converts the rasters within this layer to PNGs which are then converted to bytes.
@@ -293,7 +295,7 @@ class RasterLayer(CachableLayer):
         key = map_key_input(LayerType(self.layer_type).value, False)
         ser = ProtoBufSerializer.create_image_rdd_serializer(key_type=key)
 
-        return create_python_rdd(self.pysc, result, ser)
+        return create_python_rdd(result, ser)
 
     def to_geotiff_rdd(self,
                        storage_method=StorageMethod.STRIPED,
@@ -342,7 +344,7 @@ class RasterLayer(CachableLayer):
         key = map_key_input(LayerType(self.layer_type).value, False)
         ser = ProtoBufSerializer.create_image_rdd_serializer(key_type=key)
 
-        return create_python_rdd(self.pysc, result, ser)
+        return create_python_rdd(result, ser)
 
     def bands(self, band):
         """Select a subsection of bands from the ``Tile``\s within the layer.
@@ -372,7 +374,7 @@ class RasterLayer(CachableLayer):
         else:
             raise TypeError("band must be an int, tuple, or list. Recieved", type(band), "instead.")
 
-        return RasterLayer(self.pysc, self.layer_type, result)
+        return RasterLayer(self.layer_type, result)
 
     def map_tiles(self, func):
         """Maps over each ``Tile`` within the layer with a given function.
@@ -392,7 +394,7 @@ class RasterLayer(CachableLayer):
 
         python_rdd = self.to_numpy_rdd()
 
-        return RasterLayer.from_numpy_rdd(self.pysc, self.layer_type,
+        return RasterLayer.from_numpy_rdd(self.layer_type,
                                           python_rdd.mapValues(lambda tile: func(tile.cells)))
 
     def map_cells(self, func):
@@ -418,7 +420,7 @@ class RasterLayer(CachableLayer):
         def tile_func(cells, cell_type, no_data_value):
             return Tile(func(cells, no_data_value), cell_type, no_data_value)
 
-        return RasterLayer.from_numpy_rdd(self.pysc, self.layer_type,
+        return RasterLayer.from_numpy_rdd(self.layer_type,
                                           python_rdd.mapValues(lambda tile: tile_func(*tile)))
 
     def convert_data_type(self, new_type, no_data_value=None):
@@ -447,11 +449,9 @@ class RasterLayer(CachableLayer):
 
             no_data_constant = new_type + "ud" + str(no_data_value)
 
-            return RasterLayer(self.pysc, self.layer_type,
-                               self.srdd.convertDataType(no_data_constant))
+            return RasterLayer(self.layer_type, self.srdd.convertDataType(no_data_constant))
         else:
-            return RasterLayer(self.pysc, self.layer_type,
-                               self.srdd.convertDataType(new_type))
+            return RasterLayer(self.layer_type, self.srdd.convertDataType(new_type))
 
     def collect_metadata(self, layout=LocalLayout()):
         """Iterate over the RDD records and generates layer metadata desribing the contained
@@ -494,7 +494,7 @@ class RasterLayer(CachableLayer):
 
         srdd = self.srdd.reproject(target_crs, resample_method)
 
-        return RasterLayer(self.pysc, self.layer_type, srdd)
+        return RasterLayer(self.layer_type, srdd)
 
     def tile_to_layout(self, layout=LocalLayout(), target_crs=None, resample_method=ResampleMethod.NEAREST_NEIGHBOR):
         """Cut tiles to layout and merge overlapping tiles. This will produce unique keys.
@@ -536,7 +536,7 @@ class RasterLayer(CachableLayer):
         else:
             raise TypeError("%s can not be converted to raster layout." % layout)
 
-        return TiledRasterLayer(self.pysc, self.layer_type, srdd)
+        return TiledRasterLayer(self.layer_type, srdd)
 
     def reclassify(self, value_map, data_type,
                    classification_strategy=ClassificationStrategy.LESS_THAN_OR_EQUAL_TO,
@@ -568,7 +568,7 @@ class RasterLayer(CachableLayer):
 
         srdd = _reclassify(self.srdd, value_map, data_type, classification_strategy, replace_nodata_with)
 
-        return RasterLayer(self.pysc, self.layer_type, srdd)
+        return RasterLayer(self.layer_type, srdd)
 
     def get_min_max(self):
         """Returns the maximum and minimum values of all of the rasters in the layer.
@@ -621,9 +621,9 @@ class TiledRasterLayer(CachableLayer):
 
     __slots__ = ['pysc', 'layer_type', 'srdd']
 
-    def __init__(self, pysc, layer_type, srdd):
+    def __init__(self, layer_type, srdd):
         CachableLayer.__init__(self)
-        self.pysc = pysc
+        self.pysc = get_spark_context()
         self.layer_type = layer_type
         self.srdd = srdd
 
@@ -632,7 +632,7 @@ class TiledRasterLayer(CachableLayer):
         self.zoom_level = self.srdd.getZoom()
 
     @classmethod
-    def from_numpy_rdd(cls, pysc, layer_type, numpy_rdd, metadata):
+    def from_numpy_rdd(cls, layer_type, numpy_rdd, metadata):
         """Create a ``TiledRasterLayer`` from a numpy RDD.
 
         Args:
@@ -651,6 +651,7 @@ class TiledRasterLayer(CachableLayer):
             :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
         """
 
+        pysc = get_spark_context()
         key = map_key_input(LayerType(layer_type).value, True)
         ser = ProtoBufSerializer.create_tuple_serializer(key_type=key)
         reserialized_rdd = numpy_rdd._reserialize(ser)
@@ -667,7 +668,7 @@ class TiledRasterLayer(CachableLayer):
                     pysc._gateway.jvm.geopyspark.geotrellis.TemporalTiledRasterLayer.fromProtoEncodedRDD(
                         reserialized_rdd._jrdd, json.dumps(metadata))
 
-        return cls(pysc, layer_type, srdd)
+        return cls(layer_type, srdd)
 
     def to_numpy_rdd(self):
         """Converts a ``TiledRasterLayer`` to a numpy RDD.
@@ -684,7 +685,7 @@ class TiledRasterLayer(CachableLayer):
         key = map_key_input(LayerType(self.layer_type).value, True)
         ser = ProtoBufSerializer.create_tuple_serializer(key_type=key)
 
-        return create_python_rdd(self.pysc, result, ser)
+        return create_python_rdd(result, ser)
 
     def to_png_rdd(self, color_map):
         """Converts the rasters within this layer to PNGs which are then converted to bytes.
@@ -702,7 +703,7 @@ class TiledRasterLayer(CachableLayer):
         key = map_key_input(LayerType(self.layer_type).value, True)
         ser = ProtoBufSerializer.create_image_rdd_serializer(key_type=key)
 
-        return create_python_rdd(self.pysc, result, ser)
+        return create_python_rdd(result, ser)
 
     def bands(self, band):
         """Select a subsection of bands from the ``Tile``\s within the layer.
@@ -732,7 +733,7 @@ class TiledRasterLayer(CachableLayer):
         else:
             raise TypeError("band must be an int, tuple, or list. Recieved", type(band), "instead.")
 
-        return TiledRasterLayer(self.pysc, self.layer_type, result)
+        return TiledRasterLayer(self.layer_type, result)
 
     def map_tiles(self, func):
         """Maps over each ``Tile`` within the layer with a given function.
@@ -752,7 +753,7 @@ class TiledRasterLayer(CachableLayer):
 
         python_rdd = self.to_numpy_rdd()
 
-        return TiledRasterLayer.from_numpy_rdd(self.pysc, self.layer_type,
+        return TiledRasterLayer.from_numpy_rdd(self.layer_type,
                                                python_rdd.mapValues(lambda tile: func(tile)),
                                                self.layer_metadata)
 
@@ -779,7 +780,7 @@ class TiledRasterLayer(CachableLayer):
         def tile_func(cells, cell_type, no_data_value):
             return Tile(func(cells, no_data_value), cell_type, no_data_value)
 
-        return TiledRasterLayer.from_numpy_rdd(self.pysc, self.layer_type,
+        return TiledRasterLayer.from_numpy_rdd(self.layer_type,
                                                python_rdd.mapValues(lambda tile: tile_func(*tile)),
                                                self.layer_metadata)
 
@@ -830,7 +831,7 @@ class TiledRasterLayer(CachableLayer):
         key = map_key_input(LayerType(self.layer_type).value, True)
         ser = ProtoBufSerializer.create_image_rdd_serializer(key_type=key)
 
-        return create_python_rdd(self.pysc, result, ser)
+        return create_python_rdd(result, ser)
 
     def convert_data_type(self, new_type, no_data_value=None):
         """Converts the underlying, raster values to a new ``CellType``.
@@ -856,10 +857,10 @@ class TiledRasterLayer(CachableLayer):
 
             no_data_constant = CellType(new_type).value + "ud" + str(no_data_value)
 
-            return TiledRasterLayer(self.pysc, self.layer_type,
+            return TiledRasterLayer(self.layer_type,
                                     self.srdd.convertDataType(no_data_constant))
         else:
-            return TiledRasterLayer(self.pysc, self.layer_type,
+            return TiledRasterLayer(self.layer_type,
                                     self.srdd.convertDataType(CellType(new_type).value))
 
     def reproject(self, target_crs, resample_method=ResampleMethod.NEAREST_NEIGHBOR):
@@ -880,10 +881,11 @@ class TiledRasterLayer(CachableLayer):
         resample_method = ResampleMethod(resample_method)
 
         srdd = self.srdd.reproject(target_crs, resample_method)
-        return TiledRasterLayer(self.pysc, self.layer_type, srdd)
+
+        return TiledRasterLayer(self.layer_type, srdd)
 
     def repartition(self, num_partitions):
-        return TiledRasterLayer(self.pysc, self.layer_type, self.srdd.repartition(num_partitions))
+        return TiledRasterLayer(self.layer_type, self.srdd.repartition(num_partitions))
 
     def lookup(self, col, row):
         """Return the value(s) in the image of a particular ``SpatialKey`` (given by col and row).
@@ -966,7 +968,7 @@ class TiledRasterLayer(CachableLayer):
         else:
             raise TypeError("Could not retile from the given layout", layout)
 
-        return TiledRasterLayer(self.pysc, self.layer_type, srdd)
+        return TiledRasterLayer(self.layer_type, srdd)
 
     def pyramid(self, resample_method=ResampleMethod.NEAREST_NEIGHBOR):
         """Creates a layer ``Pyramid`` where the resolution is halved per level.
@@ -985,7 +987,7 @@ class TiledRasterLayer(CachableLayer):
 
         resample_method = ResampleMethod(resample_method)
         result = self.srdd.pyramid(resample_method)
-        return Pyramid([TiledRasterLayer(self.pysc, self.layer_type, srdd) for srdd in result])
+        return Pyramid([TiledRasterLayer(self.layer_type, srdd) for srdd in result])
 
     def focal(self, operation, neighborhood=None, param_1=None, param_2=None, param_3=None):
         """Performs the given focal operation on the layers contained in the Layer.
@@ -1040,7 +1042,7 @@ class TiledRasterLayer(CachableLayer):
         else:
             raise ValueError("neighborhood must be set or the operation must be SLOPE or ASPECT")
 
-        return TiledRasterLayer(self.pysc, self.layer_type, srdd)
+        return TiledRasterLayer(self.layer_type, srdd)
 
     def stitch(self):
         """Stitch all of the rasters within the Layer into one raster.
@@ -1104,7 +1106,7 @@ class TiledRasterLayer(CachableLayer):
         wkbs = [shapely.wkb.dumps(g) for g in geometries]
         srdd = self.srdd.mask(wkbs)
 
-        return TiledRasterLayer(self.pysc, self.layer_type, srdd)
+        return TiledRasterLayer(self.layer_type, srdd)
 
     def reclassify(self, value_map, data_type,
                    classification_strategy=ClassificationStrategy.LESS_THAN_OR_EQUAL_TO,
@@ -1137,7 +1139,7 @@ class TiledRasterLayer(CachableLayer):
         srdd = _reclassify(self.srdd, value_map, data_type,
                            ClassificationStrategy(classification_strategy).value, replace_nodata_with)
 
-        return TiledRasterLayer(self.pysc, self.layer_type, srdd)
+        return TiledRasterLayer(self.layer_type, srdd)
 
     def get_min_max(self):
         """Returns the maximum and minimum values of all of the rasters in the Layer.
@@ -1164,7 +1166,7 @@ class TiledRasterLayer(CachableLayer):
 
         srdd = self.srdd.normalize(old_min, old_max, new_min, new_max)
 
-        return TiledRasterLayer(self.pysc, self.layer_type, srdd)
+        return TiledRasterLayer(self.layer_type, srdd)
 
     @staticmethod
     def _process_polygonal_summary(geometry, operation):
@@ -1315,7 +1317,7 @@ class TiledRasterLayer(CachableLayer):
         else:
             raise TypeError("Local operation cannot be performed with", value)
 
-        return TiledRasterLayer(self.pysc, self.layer_type, srdd)
+        return TiledRasterLayer(self.layer_type, srdd)
 
     def __add__(self, value):
         return self._process_operation(value, self.srdd.localAdd)

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -98,14 +98,14 @@ def _reproject(target_crs, layout, resample_method, layer):
 
     if isinstance(layout, (LocalLayout, GlobalLayout, LayoutDefinition)):
         srdd = layer.srdd.reproject(target_crs, layout, resample_method)
-        return TiledRasterLayer(layer.pysc, layer.layer_type, srdd)
+        return TiledRasterLayer(layer.layer_type, srdd)
 
     elif isinstance(layout, Metadata):
         if layout.crs != target_crs:
             raise ValueError("The layout needs to be in the same CRS as the target_crs")
 
         srdd = layer.srdd.reproject(target_crs, json.dumps(layout.to_dict()), resample_method)
-        return TiledRasterLayer(layer.pysc, layer.layer_type, srdd)
+        return TiledRasterLayer(layer.layer_type, srdd)
 
     elif isinstance(layout, TiledRasterLayer):
         if layout.layer_metadata.crs != target_crs:
@@ -113,7 +113,7 @@ def _reproject(target_crs, layout, resample_method, layer):
 
         metadata = layout.layer_metadata
         srdd = layer.srdd.reproject(target_crs, json.dumps(metadata.to_dict()), resample_method)
-        return TiledRasterLayer(layer.pysc, layer.layer_type, srdd)
+        return TiledRasterLayer(layer.layer_type, srdd)
     else:
         raise TypeError("%s can not be used as target layout." % layout)
 
@@ -518,7 +518,7 @@ class RasterLayer(CachableLayer):
         resample_method = ResampleMethod(resample_method)
 
         if target_crs:
-            target_crs = crs_to_proj4(self.pysc, target_crs)
+            target_crs = crs_to_proj4(target_crs)
             return _reproject(target_crs, layout, resample_method, self)
 
         if isinstance(layout, Metadata):
@@ -939,7 +939,7 @@ class TiledRasterLayer(CachableLayer):
         resample_method = ResampleMethod(resample_method)
 
         if target_crs:
-            target_crs = crs_to_proj4(self.pysc, target_crs)
+            target_crs = crs_to_proj4(target_crs)
             return _reproject(target_crs, layout, resample_method, self)
 
         if isinstance(layout, LayoutDefinition):

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -204,7 +204,6 @@ class RasterLayer(CachableLayer):
     modified to fit a certain layout. See :ref:`raster_rdd` for more information.
 
     Args:
-        pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
         layer_type (str or :class:`geopyspark.geotrellis.constants.LayerType`): What the spatial type
             of the geotiffs are. This is represented by either constants within ``LayerType`` or by
             a string.
@@ -233,7 +232,6 @@ class RasterLayer(CachableLayer):
         """Create a ``RasterLayer`` from a numpy RDD.
 
         Args:
-            pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
             layer_type (str or :class:`geopyspark.geotrellis.constants.LayerType`): What the spatial type
                 of the geotiffs are. This is represented by either constants within ``LayerType`` or by
                 a string.
@@ -598,7 +596,6 @@ class TiledRasterLayer(CachableLayer):
     a larger layout. For more information, see :ref:`tiled-raster-rdd`.
 
     Args:
-        pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
         layer_type (str or :class:`geopyspark.geotrellis.constants.LayerType`): What the spatial type
             of the geotiffs are. This is represented by either constants within ``LayerType`` or by
             a string.
@@ -636,7 +633,6 @@ class TiledRasterLayer(CachableLayer):
         """Create a ``TiledRasterLayer`` from a numpy RDD.
 
         Args:
-            pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
             layer_type (str or :class:`geopyspark.geotrellis.constants.LayerType`): What the spatial type
                 of the geotiffs are. This is represented by either constants within ``LayerType`` or by
                 a string.

--- a/geopyspark/geotrellis/rasterize.py
+++ b/geopyspark/geotrellis/rasterize.py
@@ -11,7 +11,6 @@ def rasterize(geoms, crs, zoom, fill_value, cell_type=CellType.FLOAT64, options=
     """Rasterizes a Shapely geometries.
 
     Args:
-        pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
         geoms ([shapely.geometry]): List of shapely geometries to rasterize.
         crs (str or int): The CRS of the input geometry.
         zoom (int): The zoom level of the output raster.

--- a/geopyspark/geotrellis/rasterize.py
+++ b/geopyspark/geotrellis/rasterize.py
@@ -1,4 +1,5 @@
 import shapely.wkb
+from geopyspark import get_spark_context
 from geopyspark.geotrellis.constants import LayerType, CellType
 from geopyspark.geotrellis.layer import TiledRasterLayer
 
@@ -6,7 +7,7 @@ from geopyspark.geotrellis.layer import TiledRasterLayer
 __all__ = ['rasterize']
 
 
-def rasterize(pysc, geoms, crs, zoom, fill_value, cell_type=CellType.FLOAT64, options=None, num_partitions=None):
+def rasterize(geoms, crs, zoom, fill_value, cell_type=CellType.FLOAT64, options=None, num_partitions=None):
     """Rasterizes a Shapely geometries.
 
     Args:
@@ -26,6 +27,7 @@ def rasterize(pysc, geoms, crs, zoom, fill_value, cell_type=CellType.FLOAT64, op
     if isinstance(crs, int):
         crs = str(crs)
 
+    pysc = get_spark_context()
     wkb_geoms = [shapely.wkb.dumps(g) for g in geoms]
     srdd = pysc._gateway.jvm.geopyspark.geotrellis.SpatialTiledRasterLayer.rasterizeGeometry(pysc._jsc.sc(),
                                                                                              wkb_geoms,
@@ -35,4 +37,4 @@ def rasterize(pysc, geoms, crs, zoom, fill_value, cell_type=CellType.FLOAT64, op
                                                                                              CellType(cell_type).value,
                                                                                              options,
                                                                                              num_partitions)
-    return TiledRasterLayer(pysc, LayerType.SPATIAL, srdd)
+    return TiledRasterLayer(LayerType.SPATIAL, srdd)

--- a/geopyspark/geotrellis/render.py
+++ b/geopyspark/geotrellis/render.py
@@ -17,13 +17,13 @@ def get_breaks_from_matplot(ramp_name, num_colors):
     return color.get_breaks_from_matplot(ramp_name, num_colors)
 
 @deprecated
-def get_breaks(pysc, ramp_name, num_colors=None):
+def get_breaks(ramp_name, num_colors=None):
     """Deprecated in favor of geopyspark.geotrellis.color.get_breaks
     """
-    return color.get_breaks(pysc, ramp_name, num_colors=None)
+    return color.get_breaks(ramp_name, num_colors=None)
 
 @deprecated
 def get_hex(pysc, ramp_name, num_colors=None):
     """Deprecated in favor of geopyspark.geotrellis.color.get_hex
     """
-    return color.get_hex(pysc, ramp_name, num_colors=None)
+    return color.get_hex(ramp_name, num_colors=None)

--- a/geopyspark/geotrellis/tms.py
+++ b/geopyspark/geotrellis/tms.py
@@ -110,26 +110,25 @@ class TMS(object):
     the TMS class.
 
     Args:
-        pysc (SparkContext)
         server (JavaObject): The Java TMSServer instance
 
     Attributes:
-        pysc (SparkContext)
+        pysc (pyspark.SparkContext): The ``SparkContext`` being used this session.
         server (JavaObject): The Java TMSServer instance
     """
 
-    def __init__(self, pysc, server):
-        self.pysc = pysc
+    def __init__(self, server):
+        self.pysc = get_spark_context()
         self.server = server
         self.handshake = ''
-        pysc._gateway.start_callback_server()
+        self.pysc._gateway.start_callback_server()
 
     def set_handshake(self, handshake):
         self.server.set_handshake(handshake)
         self.handshake = handshake
 
     @classmethod
-    def build(cls, pysc, source, display):
+    def build(cls, source, display):
         """Builds a TMS server from one or more layers.
 
         This function takes a SparkContext, a source or list of sources, and a
@@ -141,7 +140,6 @@ class TMS(object):
         that tile.
 
         Args:
-            pysc (SparkContext): The Spark context
             source (tuple, Pyramid, list): The tile sources to render.  Tuple
                 inputs are (string, string) pairs where the first component is
                 the URI of a catalog and the second is the layer name.  A list
@@ -154,6 +152,8 @@ class TMS(object):
                 different tile sizes.  Returns bytes representing the resulting
                 image.
         """
+
+        pysc = get_spark_context()
 
         def makeReader(arg):
             if isinstance(arg, Pyramid):
@@ -188,4 +188,4 @@ class TMS(object):
             raise ValueError("Display method must be callable or a ColorMap")
 
         server = pysc._jvm.geopyspark.geotrellis.tms.TMSServer.createServer(route)
-        return cls(pysc, server)
+        return cls(server)

--- a/geopyspark/geotrellis/tms.py
+++ b/geopyspark/geotrellis/tms.py
@@ -1,9 +1,11 @@
 import io
 import numpy as np
 
+from geopyspark import get_spark_context
 from geopyspark.geotrellis.color import ColorMap
 from geopyspark.geotrellis.layer import Pyramid
 from geopyspark.geotrellis.protobufcodecs import multibandtile_decoder
+
 
 __all__ = ['TileRender', 'TMS']
 
@@ -52,6 +54,7 @@ class TileRender(object):
     class Java:
         implements = ["geopyspark.geotrellis.tms.TileRender"]
 
+
 class TileCompositer(object):
     """A Python implementation of the Scala geopyspark.geotrellis.tms.TileCompositer
     interface.  Permits a callback from Scala to Python to allow for custom
@@ -84,6 +87,7 @@ class TileCompositer(object):
         Returns:
             [bytes] representing an image
         """
+
         try:
             cells = [multibandtile_decoder(scala_array).cells for scala_array in all_scala_arrays]
             image = self.composite_function(cells)
@@ -96,6 +100,7 @@ class TileCompositer(object):
 
     class Java:
         implements = ["geopyspark.geotrellis.tms.TileCompositer"]
+
 
 class TMS(object):
     """Provides a TMS server for raster data.
@@ -112,6 +117,7 @@ class TMS(object):
         pysc (SparkContext)
         server (JavaObject): The Java TMSServer instance
     """
+
     def __init__(self, pysc, server):
         self.pysc = pysc
         self.server = server
@@ -148,6 +154,7 @@ class TMS(object):
                 different tile sizes.  Returns bytes representing the resulting
                 image.
         """
+
         def makeReader(arg):
             if isinstance(arg, Pyramid):
                 reader = pysc._gateway.jvm.geopyspark.geotrellis.tms.TileReaders.createSpatialRddReader(

--- a/geopyspark/tests/band_selection_test.py
+++ b/geopyspark/tests/band_selection_test.py
@@ -55,14 +55,14 @@ class BandSelectionTest(BaseTestClass):
                     'extent': extent,
                     'tileLayout': {'tileCols': 5, 'tileRows': 5, 'layoutCols': 2, 'layoutRows': 2}}}
 
-    tiled_raster_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, metadata)
+    tiled_raster_rdd = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, metadata)
 
     layer2 = [(ProjectedExtent(Extent(0, 0, 1, 1), 3857), Tile(bands, 'FLOAT', -1.0)),
               (ProjectedExtent(Extent(1, 0, 2, 1), 3857), Tile(bands, 'FLOAT', -1.0)),
               (ProjectedExtent(Extent(0, 1, 1, 2), 3857), Tile(bands, 'FLOAT', -1.0)),
               (ProjectedExtent(Extent(1, 1, 2, 2), 3857), Tile(bands, 'FLOAT', -1.0))]
     rdd2 = BaseTestClass.pysc.parallelize(layer2)
-    raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd2)
+    raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd2)
 
     @pytest.fixture(autouse=True)
     def tearDown(self):

--- a/geopyspark/tests/base_test_class.py
+++ b/geopyspark/tests/base_test_class.py
@@ -31,7 +31,7 @@ class BaseTestClass(unittest.TestCase):
 
     dir_path = geotiff_test_path("all-ones.tif")
 
-    rdd = get(pysc, LayerType.SPATIAL, dir_path)
+    rdd = get(LayerType.SPATIAL, dir_path)
     value = rdd.to_numpy_rdd().collect()[0]
 
     projected_extent = value[0]

--- a/geopyspark/tests/catalog_test.py
+++ b/geopyspark/tests/catalog_test.py
@@ -13,7 +13,7 @@ from geopyspark.tests.python_test_utils import geotiff_test_path
 
 
 class CatalogTest(BaseTestClass):
-    rdd = get(BaseTestClass.pysc, LayerType.SPATIAL, geotiff_test_path("srtm_52_11.tif"))
+    rdd = get(LayerType.SPATIAL, geotiff_test_path("srtm_52_11.tif"))
 
     metadata = rdd.collect_metadata()
     reprojected = rdd.tile_to_layout(layout=GlobalLayout(zoom=11), target_crs="EPSG:3857")
@@ -30,15 +30,14 @@ class CatalogTest(BaseTestClass):
 
     def test_read(self):
         for x in range(11, 0, -1):
-            actual_layer = read(BaseTestClass.pysc, LayerType.SPATIAL, self.uri, self.layer_name, x)
+            actual_layer = query(LayerType.SPATIAL, self.uri, self.layer_name, x)
             expected_layer = self.result.levels[x]
 
             self.assertDictEqual(actual_layer.layer_metadata.to_dict(),
                                  expected_layer.layer_metadata.to_dict())
 
     def test_read_value1(self):
-        tiled = read_value(BaseTestClass.pysc,
-                           LayerType.SPATIAL,
+        tiled = read_value(LayerType.SPATIAL,
                            self.uri,
                            self.layer_name,
                            11,
@@ -48,8 +47,7 @@ class CatalogTest(BaseTestClass):
         self.assertEqual(tiled.cells.shape, (1, 256, 256))
 
     def test_read_value2(self):
-        tiled = read_value(BaseTestClass.pysc,
-                           LayerType.SPATIAL,
+        tiled = read_value(LayerType.SPATIAL,
                            self.uri,
                            self.layer_name,
                            11,
@@ -60,8 +58,7 @@ class CatalogTest(BaseTestClass):
         self.assertEqual(tiled.cells.shape, (1, 256, 256))
 
     def test_read_value3(self):
-        tiled = read_value(BaseTestClass.pysc,
-                           LayerType.SPATIAL,
+        tiled = read_value(LayerType.SPATIAL,
                            self.uri,
                            self.layer_name,
                            11,
@@ -72,8 +69,7 @@ class CatalogTest(BaseTestClass):
         self.assertEqual(tiled.cells.shape, (1, 256, 256))
 
     def test_bad_read_value(self):
-        tiled = read_value(BaseTestClass.pysc,
-                           LayerType.SPATIAL,
+        tiled = read_value(LayerType.SPATIAL,
                            self.uri,
                            self.layer_name,
                            11,
@@ -84,7 +80,7 @@ class CatalogTest(BaseTestClass):
 
     def test_query1(self):
         intersection = box(8348915.46680623, 543988.943201519, 8348915.4669, 543988.943201520)
-        queried = query(BaseTestClass.pysc, LayerType.SPATIAL, self.uri, self.layer_name,
+        queried = query(LayerType.SPATIAL, self.uri, self.layer_name,
                         11, intersection,
                         options={'a': 0})
 
@@ -92,7 +88,7 @@ class CatalogTest(BaseTestClass):
 
     def test_query2(self):
         intersection = Extent(8348915.46680623, 543988.943201519, 8348915.4669, 543988.943201520)
-        queried = query(BaseTestClass.pysc, LayerType.SPATIAL, self.uri, self.layer_name,
+        queried = query(LayerType.SPATIAL, self.uri, self.layer_name,
                         11, intersection,
                         query_proj=3857, kwargs={'a': 0})
 
@@ -100,7 +96,7 @@ class CatalogTest(BaseTestClass):
 
     def test_query3(self):
         intersection = box(8348915.46680623, 543988.943201519, 8348915.4669, 543988.943201520).wkb
-        queried = query(BaseTestClass.pysc, LayerType.SPATIAL, self.uri, self.layer_name,
+        queried = query(LayerType.SPATIAL, self.uri, self.layer_name,
                         11, intersection)
 
         self.assertEqual(queried.to_numpy_rdd().first()[0], SpatialKey(1450, 996))
@@ -108,20 +104,20 @@ class CatalogTest(BaseTestClass):
     def test_query4(self):
         intersection = 42
         with pytest.raises(TypeError):
-            queried = query(BaseTestClass.pysc, LayerType.SPATIAL, self.uri, self.layer_name,
+            queried = query(LayerType.SPATIAL, self.uri, self.layer_name,
                             11, query_geom=intersection, numPartitions=2)
             result = queried.to_numpy_rdd().first()[0]
 
     def test_query_partitions(self):
         intersection = box(8348915.46680623, 543988.943201519, 8348915.4669, 543988.943201520)
-        queried = query(BaseTestClass.pysc, LayerType.SPATIAL, self.uri, self.layer_name,
+        queried = query(LayerType.SPATIAL, self.uri, self.layer_name,
                         11, intersection, numPartitions=2)
 
         self.assertEqual(queried.to_numpy_rdd().first()[0], SpatialKey(1450, 996))
 
     def test_query_crs(self):
         intersection = box(8348915.46680623, 543988.943201519, 8348915.4669, 543988.943201520)
-        queried = query(BaseTestClass.pysc, LayerType.SPATIAL, self.uri, self.layer_name, 11, intersection,
+        queried = query(LayerType.SPATIAL, self.uri, self.layer_name, 11, intersection,
                         proj_query=3857)
 
         self.assertEqual(queried.to_numpy_rdd().first()[0], SpatialKey(1450, 996))
@@ -130,36 +126,36 @@ class CatalogTest(BaseTestClass):
         uri = "abcxyz://123"
         options = {'a': 0, 'b': 1}
         with pytest.raises(ValueError):
-            layer = read_layer_metadata(BaseTestClass.pysc, LayerType.SPATIAL, uri,
+            layer = read_layer_metadata(LayerType.SPATIAL, uri,
                                         self.layer_name, 5, options=options)
 
     def test_read_metadata1(self):
-        layer = read(BaseTestClass.pysc, LayerType.SPATIAL, self.uri, self.layer_name, 5)
+        layer = read(LayerType.SPATIAL, self.uri, self.layer_name, 5)
         actual_metadata = layer.layer_metadata
 
-        expected_metadata = read_layer_metadata(BaseTestClass.pysc, LayerType.SPATIAL, self.uri,
+        expected_metadata = read_layer_metadata(LayerType.SPATIAL, self.uri,
                                                 self.layer_name, 5, kwargs={'a': 0})
     def test_read_metadata2(self):
-        layer = read(BaseTestClass.pysc, LayerType.SPATIAL, self.uri, self.layer_name, 5)
+        layer = read(LayerType.SPATIAL, self.uri, self.layer_name, 5)
         actual_metadata = layer.layer_metadata
 
-        expected_metadata = read_layer_metadata(BaseTestClass.pysc, LayerType.SPATIAL, self.uri,
+        expected_metadata = read_layer_metadata(LayerType.SPATIAL, self.uri,
                                                 self.layer_name, 5)
 
         self.assertEqual(actual_metadata.to_dict(), expected_metadata.to_dict())
 
     def test_layer_ids1(self):
-        ids = get_layer_ids(BaseTestClass.pysc, self.uri)
+        ids = get_layer_ids(self.uri)
 
         self.assertTrue(len(ids) == 11)
 
     def test_layer_ids2(self):
-        ids = get_layer_ids(BaseTestClass.pysc, self.uri, options={'a': 0})
+        ids = get_layer_ids(self.uri, options={'a': 0})
 
         self.assertTrue(len(ids) == 11)
 
     def test_layer_ids3(self):
-        ids = get_layer_ids(BaseTestClass.pysc, self.uri, kwargs={'a': 0})
+        ids = get_layer_ids(self.uri, kwargs={'a': 0})
 
         self.assertTrue(len(ids) == 11)
 

--- a/geopyspark/tests/colormap_test.py
+++ b/geopyspark/tests/colormap_test.py
@@ -29,7 +29,7 @@ class ColormapTest(BaseTestClass):
         self.assertEqual(result[0], 0x440154ff)
 
     def test_nlcd(self):
-        result = ColorMap.nlcd_colormap(BaseTestClass.pysc)
+        result = ColorMap.nlcd_colormap()
         self.assertEqual(result.cmap.map(0), 0x00000000)
         self.assertEqual((0x0ffffffff + 1 + result.cmap.map(51)), 0xbaa65cff)
         self.assertEqual((0x0ffffffff + 1 + result.cmap.map(92)), 0xb6d8f5ff)
@@ -39,7 +39,7 @@ class ColormapTest(BaseTestClass):
         break_map = {}
         for i in range(len(color_list)):
             break_map[i] = color_list[i]
-        result = ColorMap.from_break_map(BaseTestClass.pysc, break_map)
+        result = ColorMap.from_break_map(break_map)
         self.assertTrue(isinstance(result, ColorMap))
         self.assertEqual(result.cmap.map(3), color_list[3])
 
@@ -48,7 +48,7 @@ class ColormapTest(BaseTestClass):
         break_map = {}
         for i in range(len(color_list)):
             break_map[float(i)] = color_list[i]
-        result = ColorMap.from_break_map(BaseTestClass.pysc, break_map)
+        result = ColorMap.from_break_map(break_map)
         self.assertTrue(isinstance(result, ColorMap))
         self.assertEqual(result.cmap.map(3), color_list[3])
 
@@ -58,19 +58,19 @@ class ColormapTest(BaseTestClass):
         for i in range(len(color_list)):
             break_map[str(i)] = color_list[i]
         with pytest.raises(TypeError):
-            result = ColorMap.from_break_map(BaseTestClass.pysc, break_map)
+            result = ColorMap.from_break_map(break_map)
 
     def test_from_colors_int(self):
         color_list = self.color_list
         breaks = range(len(color_list))
-        result = ColorMap.from_colors(BaseTestClass.pysc, breaks, color_list)
+        result = ColorMap.from_colors(breaks, color_list)
         self.assertTrue(isinstance(result, ColorMap))
         self.assertEqual(result.cmap.map(3), color_list[3])
 
     def test_from_colors_float(self):
         color_list = self.color_list
         breaks = map(float, range(len(color_list)))
-        result = ColorMap.from_colors(BaseTestClass.pysc, breaks, color_list)
+        result = ColorMap.from_colors(breaks, color_list)
         self.assertTrue(isinstance(result, ColorMap))
         self.assertEqual(result.cmap.mapDouble(3.0), color_list[2]) # XXX
 
@@ -91,11 +91,11 @@ class ColormapTest(BaseTestClass):
                          [4.0, 6.0, 7.0, 0.0]]], dtype=float)
         tile = Tile(arr, 'FLOAT', -500)
         rdd = BaseTestClass.pysc.parallelize([(spatial_key, tile)])
-        tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, metadata)
+        tiled = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, metadata)
         hist = tiled.get_histogram()
 
         color_list = self.color_list
-        result = ColorMap.from_histogram(BaseTestClass.pysc, hist, color_list)
+        result = ColorMap.from_histogram(hist, color_list)
         self.assertTrue(isinstance(result, ColorMap))
 
     def test_build_map(self):
@@ -103,21 +103,21 @@ class ColormapTest(BaseTestClass):
         break_map = {}
         for i in range(len(color_list)):
             break_map[i] = color_list[i]
-        result = ColorMap.build(BaseTestClass.pysc, breaks=break_map)
+        result = ColorMap.build(breaks=break_map)
         self.assertTrue(isinstance(result, ColorMap))
         self.assertEqual(result.cmap.map(3), color_list[3])
 
     def test_build_int_list(self):
         color_list = self.color_list
         breaks = list(range(len(color_list)))
-        result = ColorMap.build(BaseTestClass.pysc, breaks=breaks, colors=color_list)
+        result = ColorMap.build(breaks=breaks, colors=color_list)
         self.assertTrue(isinstance(result, ColorMap))
         self.assertEqual(result.cmap.map(3), color_list[3])
 
     def test_build_color_list(self):
         color_list = [Color('red'), Color('green'), Color('blue')] # XXX
         breaks = list(range(len(color_list)))
-        result = ColorMap.build(BaseTestClass.pysc, breaks=breaks, colors=color_list)
+        result = ColorMap.build(breaks=breaks, colors=color_list)
         self.assertTrue(isinstance(result, ColorMap))
         self.assertEqual(result.cmap.map(2), struct.unpack(">L", bytes(color_list[2].rgba))[0])
 
@@ -125,7 +125,7 @@ class ColormapTest(BaseTestClass):
                         reason="Python 3.4 or greater needed for matplotlib")
     def test_build_color_string(self):
         breaks = list(range(42))
-        result = ColorMap.build(BaseTestClass.pysc, breaks=breaks, colors='viridis')
+        result = ColorMap.build(breaks=breaks, colors='viridis')
         self.assertTrue(isinstance(result, ColorMap))
         self.assertEqual(result.cmap.map(0), 0x440154ff)
 
@@ -146,11 +146,11 @@ class ColormapTest(BaseTestClass):
                          [4.0, 6.0, 7.0, 0.0]]], dtype=float)
         tile = Tile(arr, 'FLOAT', -500)
         rdd = BaseTestClass.pysc.parallelize([(spatial_key, tile)])
-        tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, metadata)
+        tiled = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, metadata)
         hist = tiled.get_histogram()
 
         color_list = self.color_list
-        result = ColorMap.build(BaseTestClass.pysc, breaks=hist, colors=color_list)
+        result = ColorMap.build(breaks=hist, colors=color_list)
         self.assertTrue(isinstance(result, ColorMap))
 
 if __name__ == "__main__":

--- a/geopyspark/tests/costdistance_test.py
+++ b/geopyspark/tests/costdistance_test.py
@@ -41,7 +41,7 @@ class CostDistanceTest(BaseTestClass):
                     'extent': extent,
                     'tileLayout': {'tileCols': 5, 'tileRows': 5, 'layoutCols': 2, 'layoutRows': 2}}}
 
-    raster_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, metadata)
+    raster_rdd = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, metadata)
 
     @pytest.fixture(autouse=True)
     def tearDown(self):

--- a/geopyspark/tests/euclidean_distance_test.py
+++ b/geopyspark/tests/euclidean_distance_test.py
@@ -48,7 +48,7 @@ class EuclideanDistanceTest(BaseTestClass):
             x, y = gridToMap(layoutDefinition, spatialKey, px, py)
             return geom.distance(Point(x, y))
 
-        tiled = euclidean_distance(BaseTestClass.pysc, self.pts_wm, 3857, 7)
+        tiled = euclidean_distance(self.pts_wm, 3857, 7)
         result = tiled.stitch().cells[0]
 
         arr = np.zeros((256,256), dtype=float)

--- a/geopyspark/tests/focal_test.py
+++ b/geopyspark/tests/focal_test.py
@@ -38,7 +38,7 @@ class FocalTest(BaseTestClass):
                     'extent': extent,
                     'tileLayout': {'tileCols': 5, 'tileRows': 5, 'layoutCols': 2, 'layoutRows': 2}}}
 
-    raster_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, metadata)
+    raster_rdd = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, metadata)
 
     @pytest.fixture(autouse=True)
     def tearDown(self):

--- a/geopyspark/tests/geotiff_raster_rdd_test.py
+++ b/geopyspark/tests/geotiff_raster_rdd_test.py
@@ -44,7 +44,7 @@ class GeoTiffIOTest(object):
 
 class Multiband(GeoTiffIOTest, BaseTestClass):
     dir_path = geotiff_test_path("one-month-tiles-multiband/")
-    result = get(BaseTestClass.pysc, LayerType.SPATIAL, dir_path)
+    result = get(LayerType.SPATIAL, dir_path)
 
     @pytest.fixture(autouse=True)
     def tearDown(self):
@@ -78,7 +78,7 @@ class Multiband(GeoTiffIOTest, BaseTestClass):
 
         tile = {'data': arr, 'no_data_value': float('nan')}
         rdd = BaseTestClass.pysc.parallelize([(projected_extent, tile)])
-        raster_rdd = RasterRDD.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterRDD.from_numpy_rdd(LayerType.SPATIAL, rdd)
 
         converted = raster_rdd.convert_data_type(INT32)
         arr = converted.to_numpy_rdd().first()[1]['data']
@@ -102,7 +102,7 @@ class Multiband(GeoTiffIOTest, BaseTestClass):
 
         tile = Tile(arr, 'FLOAT',float('nan'))
         rdd = BaseTestClass.pysc.parallelize([(projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
 
         converted = raster_rdd.convert_data_type(CellType.UINT8, no_data_value=-1)
         tile = converted.to_numpy_rdd().first()
@@ -122,7 +122,7 @@ class Multiband(GeoTiffIOTest, BaseTestClass):
 
         tile = Tile(arr, 'SHORT', -32768)
         rdd = BaseTestClass.pysc.parallelize([(projected_extent, tile)])
-        raster_layer = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_layer = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
 
         actual_tile = raster_layer.to_numpy_rdd().first()[1]
 

--- a/geopyspark/tests/hadoop_geotiff_rdd_test.py
+++ b/geopyspark/tests/hadoop_geotiff_rdd_test.py
@@ -50,12 +50,10 @@ class Singleband(GeoTiffIOTest, BaseTestClass):
 
     def read_singleband_geotrellis(self, options=None):
         if options is None:
-            result = get(BaseTestClass.pysc,
-                         LayerType.SPATIAL,
+            result = get(LayerType.SPATIAL,
                          self.dir_path)
         else:
-            result = get(BaseTestClass.pysc,
-                         LayerType.SPATIAL,
+            result = get(LayerType.SPATIAL,
                          self.dir_path,
                          max_tile_size=256)
 
@@ -85,6 +83,7 @@ class Singleband(GeoTiffIOTest, BaseTestClass):
         for x, y in zip(geotrellis_tiles, rasterio_tiles):
             self.assertTrue((x.cells == y['cells']).all())
             self.assertEqual(x.no_data_value, y['no_data_value'])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/geopyspark/tests/hillshade_test.py
+++ b/geopyspark/tests/hillshade_test.py
@@ -37,7 +37,7 @@ class HillshadeTest(BaseTestClass):
                     'extent': extent,
                     'tileLayout': {'tileCols': 6, 'tileRows': 6, 'layoutCols': 1, 'layoutRows': 1}}}
 
-    raster_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, metadata)
+    raster_rdd = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, metadata)
 
     @pytest.fixture(autouse=True)
     def tearDown(self):

--- a/geopyspark/tests/histogram_test.py
+++ b/geopyspark/tests/histogram_test.py
@@ -30,7 +30,7 @@ class HistogramTest(BaseTestClass):
 
     tile = Tile(arr, 'FLOAT', -500)
     rdd = BaseTestClass.pysc.parallelize([(spatial_key, tile)])
-    tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, metadata)
+    tiled = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, metadata)
     hist = tiled.get_histogram()
 
     def test_min(self):
@@ -53,7 +53,7 @@ class HistogramTest(BaseTestClass):
 
         tile2 = Tile(arr2, 'FLOAT', -500)
         rdd2 = BaseTestClass.pysc.parallelize([(self.spatial_key, tile2)])
-        tiled2 = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd2, self.metadata)
+        tiled2 = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd2, self.metadata)
         hist2 = tiled2.get_histogram()
 
         self.assertEqual(hist2.mode(), 1.0)
@@ -97,7 +97,7 @@ class HistogramTest(BaseTestClass):
 
         tile2 = Tile(arr2, 'INT', -500)
         rdd2 = BaseTestClass.pysc.parallelize([(self.spatial_key, tile2)])
-        tiled2 = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd2,
+        tiled2 = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd2,
                                                  metadata2)
 
         hist2 = tiled2.get_histogram()
@@ -113,7 +113,7 @@ class HistogramTest(BaseTestClass):
 
         tile2 = Tile(arr2, 'FLOAT', -500)
         rdd2 = BaseTestClass.pysc.parallelize([(self.spatial_key, tile2)])
-        tiled2 = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd2,
+        tiled2 = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd2,
                                                  self.metadata)
 
         hist2 = tiled2.get_histogram()

--- a/geopyspark/tests/local_ops_test.py
+++ b/geopyspark/tests/local_ops_test.py
@@ -33,7 +33,7 @@ class LocalOpertaionsTest(BaseTestClass):
 
         tile = Tile(arr, 'FLOAT', -500)
         rdd = BaseTestClass.pysc.parallelize([(self.spatial_key, tile)])
-        tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, self.metadata)
+        tiled = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, self.metadata)
 
         result = tiled + 1
         actual = result.to_numpy_rdd().first()[1].cells
@@ -48,7 +48,7 @@ class LocalOpertaionsTest(BaseTestClass):
 
         tile = Tile(arr, 'FLOAT', -500)
         rdd = BaseTestClass.pysc.parallelize([(self.spatial_key, tile)])
-        tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, self.metadata)
+        tiled = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, self.metadata)
 
         result = 5.0 - tiled
         actual = result.to_numpy_rdd().first()[1].cells
@@ -68,7 +68,7 @@ class LocalOpertaionsTest(BaseTestClass):
 
         tile = Tile(arr, 'FLOAT', float('nan'))
         rdd = BaseTestClass.pysc.parallelize([(self.spatial_key, tile)])
-        tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, self.metadata)
+        tiled = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, self.metadata)
 
         result = 5.0 * tiled
         actual = result.to_numpy_rdd().first()[1].cells
@@ -97,8 +97,8 @@ class LocalOpertaionsTest(BaseTestClass):
         rdd = BaseTestClass.pysc.parallelize([(self.spatial_key, tile)])
         rdd2 = BaseTestClass.pysc.parallelize([(self.spatial_key, tile2)])
 
-        tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, self.metadata)
-        tiled2 = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd2, self.metadata)
+        tiled = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, self.metadata)
+        tiled2 = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd2, self.metadata)
 
         result = tiled / tiled2
         actual = result.to_numpy_rdd().first()[1].cells
@@ -114,7 +114,7 @@ class LocalOpertaionsTest(BaseTestClass):
         tile = Tile(arr, 'INT', -500)
         rdd = BaseTestClass.pysc.parallelize([(self.spatial_key, tile)])
 
-        tiled = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, self.metadata)
+        tiled = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, self.metadata)
 
         result = (tiled + tiled) / 2
         actual = result.to_numpy_rdd().first()[1].cells

--- a/geopyspark/tests/lookup_test.py
+++ b/geopyspark/tests/lookup_test.py
@@ -37,7 +37,7 @@ class LookupTest(BaseTestClass):
                     'extent': extent,
                     'tileLayout': {'tileCols': 5, 'tileRows': 5, 'layoutCols': 2, 'layoutRows': 2}}}
 
-    raster_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, metadata)
+    raster_rdd = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, metadata)
 
     @pytest.fixture(autouse=True)
     def tearDown(self):

--- a/geopyspark/tests/mask_test.py
+++ b/geopyspark/tests/mask_test.py
@@ -41,7 +41,7 @@ class MaskTest(BaseTestClass):
                     'tileLayout': layout}}
 
     geometries = Polygon([(17, 17), (42, 17), (42, 42), (17, 42)])
-    raster_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, metadata)
+    raster_rdd = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, metadata)
 
     @pytest.fixture(autouse=True)
     def tearDown(self):

--- a/geopyspark/tests/min_max_test.py
+++ b/geopyspark/tests/min_max_test.py
@@ -25,7 +25,7 @@ class MinMaxTest(BaseTestClass):
         tile = Tile(arr, 'INT', -500)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
         min_max = raster_rdd.get_min_max()
 
         self.assertEqual((0.0, 0.0), min_max)
@@ -38,7 +38,7 @@ class MinMaxTest(BaseTestClass):
         tile = Tile(arr, 'INT', -500)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
         min_max = raster_rdd.get_min_max()
 
         self.assertEqual((1.0, 4.0), min_max)
@@ -51,10 +51,11 @@ class MinMaxTest(BaseTestClass):
 
         tile = Tile(arr, 'FLOAT', float('nan'))
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
         min_max = raster_rdd.get_min_max()
 
         self.assertEqual((0.0, 2.0), min_max)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/geopyspark/tests/polygonal_summaries_test.py
+++ b/geopyspark/tests/polygonal_summaries_test.py
@@ -38,7 +38,7 @@ class CostDistanceTest(BaseTestClass):
                     'extent': extent,
                     'tileLayout': {'tileCols': 5, 'tileRows': 5, 'layoutCols': 2, 'layoutRows': 2}}}
 
-    tiled_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, metadata)
+    tiled_rdd = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, metadata)
 
     @pytest.fixture(autouse=True)
     def tearDown(self):

--- a/geopyspark/tests/pyramiding_test.py
+++ b/geopyspark/tests/pyramiding_test.py
@@ -26,7 +26,7 @@ class PyramidingTest(BaseTestClass):
         projected_extent = ProjectedExtent(extent, epsg_code)
 
         rdd = BaseTestClass.pysc.parallelize([(projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
         tile_layout = TileLayout(32, 32, 16, 16)
         new_extent = Extent(-20037508.342789244, -20037508.342789244, 20037508.342789244,
                             20037508.342789244)
@@ -47,7 +47,7 @@ class PyramidingTest(BaseTestClass):
         projected_extent = ProjectedExtent(extent, epsg_code)
 
         rdd = BaseTestClass.pysc.parallelize([(projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
         tile_layout = TileLayout(32, 32, 16, 16)
         new_extent = Extent(-20037508.342789244, -20037508.342789244, 20037508.342789244,
                             20037508.342789244)
@@ -72,7 +72,7 @@ class PyramidingTest(BaseTestClass):
 
         rdd = BaseTestClass.pysc.parallelize([(projected_extent, tile)])
 
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
         laid_out = raster_rdd.tile_to_layout(LocalLayout(250))
 
         # Single tile is at level 0
@@ -98,7 +98,7 @@ class PyramidingTest(BaseTestClass):
         projected_extent = ProjectedExtent(extent, epsg_code)
 
         rdd = BaseTestClass.pysc.parallelize([(projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
         tile_layout = TileLayout(1, 1, 16, 16)
         reprojected = raster_rdd.tile_to_layout(layout=GlobalLayout(tile_size=16), target_crs=3857)
 

--- a/geopyspark/tests/raster_layer_test.py
+++ b/geopyspark/tests/raster_layer_test.py
@@ -27,7 +27,7 @@ class RasterLayerTest(BaseTestClass):
     ]
 
     numpy_rdd = BaseTestClass.pysc.parallelize(layer)
-    layer = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, numpy_rdd)
+    layer = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, numpy_rdd)
     metadata = layer.collect_metadata(GlobalLayout(5))
 
     def test_tile_to_local_layout(self):

--- a/geopyspark/tests/rasterize_test.py
+++ b/geopyspark/tests/rasterize_test.py
@@ -22,8 +22,7 @@ class RasterizeTest(BaseTestClass):
     def test_whole_area(self):
         polygon = Polygon([(0, 11), (11, 11), (11, 0), (0, 0)])
 
-        raster_rdd = rasterize(BaseTestClass.pysc,
-                               [polygon],
+        raster_rdd = rasterize([polygon],
                                "EPSG:3857",
                                11,
                                1)
@@ -36,8 +35,7 @@ class RasterizeTest(BaseTestClass):
     def test_whole_area_integer_crs(self):
         polygon = Polygon([(0, 11), (11, 11), (11, 0), (0, 0)])
 
-        raster_rdd = rasterize(BaseTestClass.pysc,
-                               [polygon],
+        raster_rdd = rasterize([polygon],
                                3857,
                                11,
                                1)

--- a/geopyspark/tests/rddwrapper_test.py
+++ b/geopyspark/tests/rddwrapper_test.py
@@ -24,7 +24,7 @@ class LayerWrapperTest(BaseTestClass):
         tile = Tile(arr, 'INT', -500)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
 
         self.assertEqual(raster_rdd.is_cached, False)
 
@@ -42,7 +42,7 @@ class LayerWrapperTest(BaseTestClass):
         tile = Tile(arr, 'INT', -500)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
 
         self.assertEqual(raster_rdd.is_cached, False)
 
@@ -57,7 +57,7 @@ class LayerWrapperTest(BaseTestClass):
         tile = Tile(arr, 'INT', -500)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
 
         self.assertEqual(raster_rdd.count(), 1)
         self.assertTrue(raster_rdd.getNumPartitions() >= 1)

--- a/geopyspark/tests/reclassify_test.py
+++ b/geopyspark/tests/reclassify_test.py
@@ -26,7 +26,7 @@ class ReclassifyTest(BaseTestClass):
         tile = Tile(arr, 'FLOAT', -500)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
 
         value_map = {(0, 1): 1}
 
@@ -39,7 +39,7 @@ class ReclassifyTest(BaseTestClass):
         tile = Tile(arr, 'FLOAT', -500)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
 
         value_map = {'apple, orange, banana': 1}
 
@@ -52,7 +52,7 @@ class ReclassifyTest(BaseTestClass):
         tile = Tile(arr, 'FLOAT', -500)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
 
         value_map = {0: 1}
 
@@ -68,7 +68,7 @@ class ReclassifyTest(BaseTestClass):
         tile = Tile(arr, 'INT', -500)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
 
         value_map = {1: 10, 3: 17}
 
@@ -89,7 +89,7 @@ class ReclassifyTest(BaseTestClass):
         tile = Tile(arr, 'INT', -500)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
 
         value_map = {2: 20}
 
@@ -111,7 +111,7 @@ class ReclassifyTest(BaseTestClass):
         tile = Tile(arr, 'INT', -500)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
 
         value_map = {3: 10, 4: 20}
 
@@ -132,7 +132,7 @@ class ReclassifyTest(BaseTestClass):
 
         tile = Tile(arr, 'FLOAT', float('nan'))
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
 
         value_map = {2.0: 5.0}
 
@@ -152,7 +152,7 @@ class ReclassifyTest(BaseTestClass):
         tile = Tile(arr, 'INT', NO_DATA_INT)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
 
         value_map = {0: NO_DATA_INT}
 
@@ -168,7 +168,7 @@ class ReclassifyTest(BaseTestClass):
         tile = Tile(arr, 'FLOAT', float('nan'))
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
 
         value_map = {0.0: float('nan')}
 
@@ -185,7 +185,7 @@ class ReclassifyTest(BaseTestClass):
         tile = Tile(arr, 'INT', NO_DATA_INT)
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
 
         value_map = {1: 0}
 
@@ -201,7 +201,7 @@ class ReclassifyTest(BaseTestClass):
         tile = Tile(arr, 'FLOAT', float('nan'))
 
         rdd = BaseTestClass.pysc.parallelize([(self.projected_extent, tile)])
-        raster_rdd = RasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
 
         value_map = {1.0: 0.0}
 

--- a/geopyspark/tests/s3_geotiff_rdd_test.py
+++ b/geopyspark/tests/s3_geotiff_rdd_test.py
@@ -62,8 +62,7 @@ class Multiband(S3GeoTiffIOTest, BaseTestClass):
 
     def read_multiband_geotrellis(self, opt=options):
         self.client.putObject(self.bucket, self.key, self.cells)
-        result = get(BaseTestClass.pysc,
-                     LayerType.SPATIAL,
+        result = get(LayerType.SPATIAL,
                      self.uri,
                      s3_client=opt['s3Client'],
                      max_tile_size=opt.get('maxTileSize'))

--- a/geopyspark/tests/stitch_test.py
+++ b/geopyspark/tests/stitch_test.py
@@ -36,7 +36,7 @@ class StitchTest(BaseTestClass):
                     'extent': extent,
                     'tileLayout': {'tileCols': 5, 'tileRows': 5, 'layoutCols': 2, 'layoutRows': 2}}}
 
-    raster_rdd = TiledRasterLayer.from_numpy_rdd(BaseTestClass.pysc, LayerType.SPATIAL, rdd, metadata)
+    raster_rdd = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, metadata)
 
     @pytest.fixture(scope='class', autouse=True)
     def tearDown(self):

--- a/geopyspark/tests/tile_layer_metadata_test.py
+++ b/geopyspark/tests/tile_layer_metadata_test.py
@@ -36,7 +36,7 @@ class TileLayerMetadataTest(BaseTestClass):
         tile_dict = Tile(data.read(), 'FLOAT', data.nodata)
 
         rasterio_rdd = self.pysc.parallelize([(self.projected_extent, tile_dict)])
-        raster_rdd = RasterLayer.from_numpy_rdd(self.pysc, LayerType.SPATIAL, rasterio_rdd)
+        raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rasterio_rdd)
 
         result = raster_rdd.collect_metadata(layout=self.layout_def)
 

--- a/geopyspark/tests/tiled_raster_layer_test.py
+++ b/geopyspark/tests/tiled_raster_layer_test.py
@@ -38,7 +38,7 @@ class TiledRasterLayerTest(BaseTestClass):
         self.assertDictEqual(actual.to_dict(), expected.to_dict())
 
     def test_tile_to_layout_with_reproject(self):
-        proj4 = crs_to_proj4(BaseTestClass.pysc, 3857)
+        proj4 = crs_to_proj4(3857)
         actual = self.result.tile_to_layout(layout=GlobalLayout(), target_crs=proj4).layer_metadata.crs
 
         self.assertEqual(proj4, actual)

--- a/geopyspark/tests/tiled_raster_layer_test.py
+++ b/geopyspark/tests/tiled_raster_layer_test.py
@@ -10,7 +10,7 @@ from geopyspark.tests.base_test_class import BaseTestClass
 
 class TiledRasterLayerTest(BaseTestClass):
     dir_path = geotiff_test_path("all-ones.tif")
-    result = get(BaseTestClass.pysc, LayerType.SPATIAL, dir_path)
+    result = get(LayerType.SPATIAL, dir_path)
     tiled_layer = result.tile_to_layout()
 
     @pytest.fixture(autouse=True)

--- a/geopyspark/tests/to_geotiff_rdd_test.py
+++ b/geopyspark/tests/to_geotiff_rdd_test.py
@@ -13,7 +13,7 @@ from geopyspark.tests.base_test_class import BaseTestClass
 
 class ToGeoTiffTest(BaseTestClass):
     dir_path = geotiff_test_path("all-ones.tif")
-    rdd = get(BaseTestClass.pysc, LayerType.SPATIAL, dir_path)
+    rdd = get(LayerType.SPATIAL, dir_path)
     metadata = rdd.collect_metadata()
 
     mapped_types = {


### PR DESCRIPTION
This PR makes it so that `pysc` no longer needs to be passed around as a parameter for classes and functions in GeoPySpark. Rather, it just checks to see if one has been set and uses that.

This PR resolves #368 