### PR TITLE
ResampleMethod Converter

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/GeoTrellisUtils.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/GeoTrellisUtils.scala
@@ -4,6 +4,7 @@ import geotrellis.proj4._
 import geotrellis.raster._
 import geotrellis.raster.mapalgebra.focal._
 import geotrellis.raster.render._
+import geotrellis.raster.resample.ResampleMethod
 import geotrellis.vector._
 import geotrellis.spark._
 import geotrellis.spark.reproject._
@@ -36,12 +37,10 @@ object GeoTrellisUtils {
     (stringMap, intMap)
   }
 
-  def getReprojectOptions(resampleMethod: String): Reproject.Options = {
+  def getReprojectOptions(resampleMethod: ResampleMethod): Reproject.Options = {
     import Reproject.Options
 
-    val method = TileRDD.getResampleMethod(resampleMethod)
-
-    Options(geotrellis.raster.reproject.Reproject.Options(method=method))
+    Options(geotrellis.raster.reproject.Reproject.Options(method=resampleMethod))
   }
 
   def getNeighborhood(

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ProjectedRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ProjectedRasterRDD.scala
@@ -31,16 +31,14 @@ class ProjectedRasterRDD(val rdd: RDD[(ProjectedExtent, MultibandTile)]) extends
     }
   }.toJson.compactPrint
 
-  def cutTiles(layerMetadata: String, resampleMethod: String): TiledRasterRDD[SpatialKey] = {
+  def cutTiles(layerMetadata: String, resampleMethod: ResampleMethod): TiledRasterRDD[SpatialKey] = {
     val md = layerMetadata.parseJson.convertTo[TileLayerMetadata[SpatialKey]]
-    val rm = TileRDD.getResampleMethod(resampleMethod)
-    new SpatialTiledRasterRDD(None, MultibandTileLayerRDD(rdd.cutTiles(md, rm), md))
+    new SpatialTiledRasterRDD(None, MultibandTileLayerRDD(rdd.cutTiles(md, resampleMethod), md))
   }
 
-  def tileToLayout(tileLayerMetadata: String, resampleMethod: String): TiledRasterRDD[SpatialKey] = {
+  def tileToLayout(tileLayerMetadata: String, resampleMethod: ResampleMethod): TiledRasterRDD[SpatialKey] = {
     val md = tileLayerMetadata.parseJson.convertTo[TileLayerMetadata[SpatialKey]]
-    val rm = TileRDD.getResampleMethod(resampleMethod)
-    new SpatialTiledRasterRDD(None, MultibandTileLayerRDD(rdd.tileToLayout(md, rm), md))
+    new SpatialTiledRasterRDD(None, MultibandTileLayerRDD(rdd.tileToLayout(md, resampleMethod), md))
   }
 
   def tileToLayout(
@@ -57,10 +55,9 @@ class ProjectedRasterRDD(val rdd: RDD[(ProjectedExtent, MultibandTile)]) extends
     new SpatialTiledRasterRDD(None, MultibandTileLayerRDD(tiled, md))
   }
 
-  def reproject(targetCRS: String, resampleMethod: String): ProjectedRasterRDD = {
+  def reproject(targetCRS: String, resampleMethod: ResampleMethod): ProjectedRasterRDD = {
     val crs = TileRDD.getCRS(targetCRS).get
-    val resample = TileRDD.getResampleMethod(resampleMethod)
-    new ProjectedRasterRDD(rdd.reproject(crs, resample))
+    new ProjectedRasterRDD(rdd.reproject(crs, resampleMethod))
   }
 
   def reclassify(reclassifiedRDD: RDD[(ProjectedExtent, MultibandTile)]): RasterRDD[ProjectedExtent] =

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
@@ -98,8 +98,8 @@ abstract class RasterRDD[K](implicit ev0: ClassTag[K], ev1: Component[K, Project
     withRDD(rdd.map { x => (x._1, x._2.convert(CellType.fromName(newType))) })
 
   protected def collectMetadata(layout: Either[LayoutScheme, LayoutDefinition], crs: Option[CRS]): String
-  protected def cutTiles(layerMetadata: String, resampleMethod: String): TiledRasterRDD[_]
-  protected def tileToLayout(tileLayerMetadata: String, resampleMethod: String): TiledRasterRDD[_]
-  protected def reproject(target_crs: String, resampleMethod: String): RasterRDD[_]
+  protected def cutTiles(layerMetadata: String, resampleMethod: ResampleMethod): TiledRasterRDD[_]
+  protected def tileToLayout(tileLayerMetadata: String, resampleMethod: ResampleMethod): TiledRasterRDD[_]
+  protected def reproject(target_crs: String, resampleMethod: ResampleMethod): RasterRDD[_]
   protected def withRDD(result: RDD[(K, MultibandTile)]): RasterRDD[K]
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalRasterRDD.scala
@@ -30,17 +30,15 @@ class TemporalRasterRDD(val rdd: RDD[(TemporalProjectedExtent, MultibandTile)]) 
     }
   }.toJson.compactPrint
 
-  def cutTiles(layerMetadata: String, resampleMethod: String): TiledRasterRDD[SpaceTimeKey] = {
+  def cutTiles(layerMetadata: String, resampleMethod: ResampleMethod): TiledRasterRDD[SpaceTimeKey] = {
     val md = layerMetadata.parseJson.convertTo[TileLayerMetadata[SpaceTimeKey]]
-    val rm = TileRDD.getResampleMethod(resampleMethod)
-    val tiles = rdd.cutTiles[SpaceTimeKey](md, rm)
+    val tiles = rdd.cutTiles[SpaceTimeKey](md, resampleMethod)
     new TemporalTiledRasterRDD(None, MultibandTileLayerRDD(tiles, md))
   }
 
-  def tileToLayout(layerMetadata: String, resampleMethod: String): TiledRasterRDD[SpaceTimeKey] = {
+  def tileToLayout(layerMetadata: String, resampleMethod: ResampleMethod): TiledRasterRDD[SpaceTimeKey] = {
     val md = layerMetadata.parseJson.convertTo[TileLayerMetadata[SpaceTimeKey]]
-    val rm = TileRDD.getResampleMethod(resampleMethod)
-    new TemporalTiledRasterRDD(None, MultibandTileLayerRDD(rdd.tileToLayout(md, rm), md))
+    new TemporalTiledRasterRDD(None, MultibandTileLayerRDD(rdd.tileToLayout(md, resampleMethod), md))
   }
 
   def tileToLayout(
@@ -49,10 +47,10 @@ class TemporalRasterRDD(val rdd: RDD[(TemporalProjectedExtent, MultibandTile)]) 
     force_crs: String,
     force_cellType: String
   ): TiledRasterRDD[_] = ???
-  def reproject(targetCRS: String, resampleMethod: String): TemporalRasterRDD = {
+
+  def reproject(targetCRS: String, resampleMethod: ResampleMethod): TemporalRasterRDD = {
     val crs = TileRDD.getCRS(targetCRS).get
-    val resample = TileRDD.getResampleMethod(resampleMethod)
-    new TemporalRasterRDD(rdd.reproject(crs, resample))
+    new TemporalRasterRDD(rdd.reproject(crs, resampleMethod))
   }
 
   def reclassify(reclassifiedRDD: RDD[(TemporalProjectedExtent, MultibandTile)]): RasterRDD[TemporalProjectedExtent] =

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
@@ -76,7 +76,7 @@ abstract class TiledRasterRDD[K: SpatialComponent: JsonFormat: ClassTag] extends
   def resample_to_power_of_two(
     col_power: Int,
     row_power: Int,
-    resampleMethod: String
+    resampleMethod: ResampleMethod
   ): TiledRasterRDD[K]
 
   def layerMetadata: String = rdd.metadata.toJson.prettyPrint
@@ -98,7 +98,7 @@ abstract class TiledRasterRDD[K: SpatialComponent: JsonFormat: ClassTag] extends
     extent: java.util.Map[String, Double],
     layout: java.util.Map[String, Int],
     crs: String,
-    resampleMethod: String
+    resampleMethod: ResampleMethod
   ): TiledRasterRDD[K] = {
     val layoutDefinition = Right(LayoutDefinition(extent.toExtent, layout.toTileLayout))
 
@@ -110,7 +110,7 @@ abstract class TiledRasterRDD[K: SpatialComponent: JsonFormat: ClassTag] extends
     tileSize: Int,
     resolutionThreshold: Double,
     crs: String,
-    resampleMethod: String
+    resampleMethod: ResampleMethod
   ): TiledRasterRDD[K] = {
     val _crs = TileRDD.getCRS(crs).get
 
@@ -132,7 +132,7 @@ abstract class TiledRasterRDD[K: SpatialComponent: JsonFormat: ClassTag] extends
   def tileToLayout(
     extent: java.util.Map[String, Double],
     tileLayout: java.util.Map[String, Int],
-    resampleMethod: String
+    resampleMethod: ResampleMethod
   ): TiledRasterRDD[K] =
     tileToLayout(
       LayoutDefinition(extent.toExtent, tileLayout.toTileLayout),
@@ -140,13 +140,13 @@ abstract class TiledRasterRDD[K: SpatialComponent: JsonFormat: ClassTag] extends
 
   protected def tileToLayout(
     layoutDefinition: LayoutDefinition,
-    resampleMethod: String
+    resampleMethod: ResampleMethod
   ): TiledRasterRDD[K]
 
   def pyramid(
     startZoom: Int,
     endZoom: Int,
-    resampleMethod: String
+    resampleMethod: ResampleMethod
   ): Array[_] // Array[TiledRasterRDD[K]]
 
   def focal(

--- a/geopyspark/geotrellis/converters.py
+++ b/geopyspark/geotrellis/converters.py
@@ -3,6 +3,7 @@ from py4j.java_gateway import JavaClass
 from py4j.protocol import register_input_converter
 
 from geopyspark.geotrellis import RasterizerOptions, GlobalLayout, LocalLayout
+from geopyspark.geotrellis.constants import ResampleMethod
 
 
 class RasterizerOptionsConverter(object):
@@ -34,5 +35,40 @@ class LayoutTypeConverter(object):
         else:
             raise TypeError("Could not convert {} to geotrellis.raster.LayoutType".format(obj.sampleType))
 
+
+class ResampleMethodConverter(object):
+    def can_convert(self, object):
+        return isinstance(object, ResampleMethod)
+
+    def convert(self, obj, gateway_client):
+        name = obj.value
+
+        if name == 'NearestNeighbor':
+            sample = JavaClass("geotrellis.raster.resample.NearestNeighbor$", gateway_client)
+        elif name == 'Bilinear':
+            sample = JavaClass("geotrellis.raster.resample.Bilinear$", gateway_client)
+        elif name == 'CubicConvolution':
+            sample = JavaClass("geotrellis.raster.resample.CubicConvolution$", gateway_client)
+        elif name == 'CubicSpline':
+            sample = JavaClass("geotrellis.raster.resample.CubicSpline$", gateway_client)
+        elif name == 'Lanczos':
+            sample = JavaClass("geotrellis.raster.resample.Lanczos$", gateway_client)
+        elif name == 'Average':
+            sample = JavaClass("geotrellis.raster.resample.Average$", gateway_client)
+        elif name == 'Mode':
+            sample = JavaClass("geotrellis.raster.resample.Mode$", gateway_client)
+        elif name == 'Median':
+            sample = JavaClass("geotrellis.raster.resample.Median$", gateway_client)
+        elif name == 'Max':
+            sample = JavaClass("geotrellis.raster.resample.Max$", gateway_client)
+        elif name == 'Min':
+            sample = JavaClass("geotrellis.raster.resample.Min$", gateway_client)
+        else:
+            raise TypeError(name, "Could not be converted to a GeoTrellis ResampleMethod.")
+
+        return sample.__getattr__("MODULE$")
+
+
 register_input_converter(RasterizerOptionsConverter(), prepend=True)
 register_input_converter(LayoutTypeConverter(), prepend=True)
+register_input_converter(ResampleMethodConverter(), prepend=True)

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -519,7 +519,7 @@ class RasterLayer(CachableLayer):
             target_crs = str(target_crs)
 
         return RasterLayer(self.pysc, self.layer_type,
-                           self.srdd.reproject(target_crs, ResampleMethod(resample_method).value))
+                           self.srdd.reproject(target_crs, ResampleMethod(resample_method)))
 
     def cut_tiles(self, layer_metadata, resample_method=ResampleMethod.NEAREST_NEIGHBOR):
         """Cut tiles to layout. May result in duplicate keys.
@@ -538,7 +538,7 @@ class RasterLayer(CachableLayer):
         if isinstance(layer_metadata, Metadata):
             layer_metadata = layer_metadata.to_dict()
 
-        srdd = self.srdd.cutTiles(json.dumps(layer_metadata), ResampleMethod(resample_method).value)
+        srdd = self.srdd.cutTiles(json.dumps(layer_metadata), ResampleMethod(resample_method))
         return TiledRasterLayer(self.pysc, self.layer_type, srdd)
 
     def tile_to_layout(self, layer_metadata, resample_method=ResampleMethod.NEAREST_NEIGHBOR):
@@ -559,7 +559,7 @@ class RasterLayer(CachableLayer):
             layer_metadata = layer_metadata.to_dict()
 
         srdd = self.srdd.tileToLayout(json.dumps(layer_metadata),
-                                      ResampleMethod(resample_method).value)
+                                      ResampleMethod(resample_method))
         return TiledRasterLayer(self.pysc, self.layer_type, srdd)
 
     def reclassify(self, value_map, data_type,
@@ -934,10 +934,10 @@ class TiledRasterLayer(CachableLayer):
 
         if extent and layout:
             srdd = self.srdd.reproject(extent, layout, target_crs,
-                                       ResampleMethod(resample_method).value)
+                                       ResampleMethod(resample_method))
         elif not extent and not layout:
             srdd = self.srdd.reproject(LayoutScheme(scheme).value, tile_size, resolution_threshold,
-                                       target_crs, ResampleMethod(resample_method).value)
+                                       target_crs, ResampleMethod(resample_method))
         else:
             raise TypeError("Could not collect reproject Layer with {} and {}".format(extent, layout))
 
@@ -994,7 +994,7 @@ class TiledRasterLayer(CachableLayer):
 
         srdd = self.srdd.tileToLayout(layout_definition.extent._asdict(),
                                       layout_definition.tileLayout._asdict(),
-                                      ResampleMethod(resample_method).value)
+                                      ResampleMethod(resample_method))
 
         return TiledRasterLayer(self.pysc, self.layer_type, srdd)
 
@@ -1035,7 +1035,7 @@ class TiledRasterLayer(CachableLayer):
         else:
             raise ValueError("No start_zoom given.")
 
-        result = self.srdd.pyramid(start_zoom, end_zoom, ResampleMethod(resample_method).value)
+        result = self.srdd.pyramid(start_zoom, end_zoom, ResampleMethod(resample_method))
 
         return Pyramid([TiledRasterLayer(self.pysc, self.layer_type, srdd) for srdd in result])
 
@@ -1062,7 +1062,7 @@ class TiledRasterLayer(CachableLayer):
             ValueError: If the given ``resample_method`` is not known.
         """
 
-        resample_method = ResampleMethod(resample_method).value
+        resample_method = ResampleMethod(resample_method)
         new_srdd = self.srdd.resample_to_power_of_two(col_power, row_power, resample_method)
         new_layer = TiledRasterLayer(self.pysc, self.layer_type, new_srdd)
 


### PR DESCRIPTION
This PR adds a `ResampleMethodConverter` to `converters` making it easier to send parameters over to scala.