### PR TITLE
LayoutDefinition Converter

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterRDD.scala
@@ -50,13 +50,10 @@ abstract class RasterRDD[K](implicit ev0: ClassTag[K], ev1: Component[K, Project
     withRDD(rdd.mapValues { multibandTile => multibandTile.subsetBands(bands.asScala) })
 
   def collectMetadata(
-    extent: java.util.Map[String, Double],
-    layout: java.util.Map[String, Int],
+    layoutDefinition: LayoutDefinition,
     crs: String
   ): String = {
-    val layoutDefinition = Right(LayoutDefinition(extent.toExtent, layout.toTileLayout))
-
-    collectMetadata(layoutDefinition, TileRDD.getCRS(crs))
+    collectMetadata(Right(layoutDefinition), TileRDD.getCRS(crs))
   }
 
   def collectMetadata(tileSize: String, crs: String): String = {

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
@@ -95,15 +95,11 @@ abstract class TiledRasterRDD[K: SpatialComponent: JsonFormat: ClassTag] extends
   protected def mask(geometries: Seq[MultiPolygon]): TiledRasterRDD[K]
 
   def reproject(
-    extent: java.util.Map[String, Double],
-    layout: java.util.Map[String, Int],
+    layoutDefinition: LayoutDefinition,
     crs: String,
     resampleMethod: ResampleMethod
-  ): TiledRasterRDD[K] = {
-    val layoutDefinition = Right(LayoutDefinition(extent.toExtent, layout.toTileLayout))
-
-    reproject(layoutDefinition, TileRDD.getCRS(crs).get, getReprojectOptions(resampleMethod))
-  }
+  ): TiledRasterRDD[K] =
+    reproject(Right(layoutDefinition), TileRDD.getCRS(crs).get, getReprojectOptions(resampleMethod))
 
   def reproject(
     scheme: String,

--- a/geopyspark/tests/pyramiding_test.py
+++ b/geopyspark/tests/pyramiding_test.py
@@ -4,7 +4,7 @@ import rasterio
 import numpy as np
 import pytest
 
-from geopyspark.geotrellis import Extent, ProjectedExtent, TileLayout, Tile
+from geopyspark.geotrellis import Extent, ProjectedExtent, TileLayout, Tile, LayoutDefinition
 from geopyspark.geotrellis.constants import LayerType, LayoutScheme
 from geopyspark.geotrellis.layer import Pyramid, RasterLayer
 from geopyspark.tests.base_test_class import BaseTestClass
@@ -54,7 +54,8 @@ class PyramidingTest(BaseTestClass):
         new_extent = Extent(-20037508.342789244, -20037508.342789244, 20037508.342789244,
                             20037508.342789244)
 
-        metadata = raster_rdd.collect_metadata(extent=new_extent, layout=tile_layout)
+        layout_def = LayoutDefinition(new_extent, tile_layout)
+        metadata = raster_rdd.collect_metadata(layout=layout_def)
         laid_out = raster_rdd.tile_to_layout(metadata)
 
         result = laid_out.pyramid(start_zoom=5, end_zoom=1)
@@ -75,7 +76,8 @@ class PyramidingTest(BaseTestClass):
         new_extent = Extent(-20037508.342789244, -20037508.342789244, 20037508.342789244,
                             20037508.342789244)
 
-        metadata = raster_rdd.collect_metadata(extent=new_extent, layout=tile_layout)
+        layout_def = LayoutDefinition(new_extent, tile_layout)
+        metadata = raster_rdd.collect_metadata(layout=layout_def)
         laid_out = raster_rdd.tile_to_layout(metadata)
         reprojected = laid_out.reproject(3857, scheme=LayoutScheme.ZOOM)
 

--- a/geopyspark/tests/reproject_test.py
+++ b/geopyspark/tests/reproject_test.py
@@ -8,8 +8,8 @@ from geopyspark.tests.base_test_class import BaseTestClass
 
 
 class ReprojectTest(BaseTestClass):
-    metadata = BaseTestClass.rdd.collect_metadata(extent=BaseTestClass.extent,
-                                                  layout=BaseTestClass.layout)
+    layout_def = LayoutDefinition(BaseTestClass.extent, BaseTestClass.layout)
+    metadata = BaseTestClass.rdd.collect_metadata(layout=layout_def)
 
     crs = metadata.crs
     expected_crs = "+proj=longlat +ellps=WGS72 +towgs84=0,0,1.9,0,0,0.814,-0.38 +no_defs "
@@ -21,16 +21,12 @@ class ReprojectTest(BaseTestClass):
         yield
         BaseTestClass.pysc._gateway.close()
 
-    def test_invalid(self):
-        with pytest.raises(TypeError):
-            self.laid_out_rdd.reproject(4326, extent=self.extent)
-
     def test_repartition(self):
         result = self.laid_out_rdd.repartition(2)
         self.assertEqual(result.getNumPartitions(), 2)
 
     def test_same_crs_layout(self):
-        result = self.laid_out_rdd.reproject("EPSG:4326", extent =self.extent, layout=self.layout)
+        result = self.laid_out_rdd.reproject("EPSG:4326", layout=self.layout_def)
         new_metadata = result.layer_metadata
 
         layout_definition = LayoutDefinition(BaseTestClass.extent, BaseTestClass.layout)
@@ -38,7 +34,7 @@ class ReprojectTest(BaseTestClass):
         self.assertEqual(layout_definition, new_metadata.layout_definition)
 
     def test_integer_crs(self):
-        result = self.laid_out_rdd.reproject(4326, extent =self.extent, layout=self.layout)
+        result = self.laid_out_rdd.reproject(4326, layout=self.layout_def)
         new_metadata = result.layer_metadata
 
         layout_definition = LayoutDefinition(BaseTestClass.extent, BaseTestClass.layout)
@@ -54,7 +50,7 @@ class ReprojectTest(BaseTestClass):
         self.assertTrue("+datum=WGS84" in new_metadata.crs)
 
     def test_different_crs_layout(self):
-        result = self.laid_out_rdd.reproject("EPSG:4324", extent=self.extent, layout=self.layout)
+        result = self.laid_out_rdd.reproject("EPSG:4324", layout=self.layout_def)
         new_metadata = result.layer_metadata
 
         self.assertEqual(self.expected_crs, new_metadata.crs)

--- a/geopyspark/tests/tile_layer_metadata_test.py
+++ b/geopyspark/tests/tile_layer_metadata_test.py
@@ -3,7 +3,7 @@ import unittest
 import rasterio
 import pytest
 
-from geopyspark.geotrellis import Tile
+from geopyspark.geotrellis import Tile, LayoutDefinition
 from geopyspark.geotrellis.constants import LayerType
 from geopyspark.geotrellis.layer import RasterLayer
 from geopyspark.tests.base_test_class import BaseTestClass
@@ -12,6 +12,7 @@ from geopyspark.tests.base_test_class import BaseTestClass
 class TileLayerMetadataTest(BaseTestClass):
     extent = BaseTestClass.extent
     layout = BaseTestClass.layout
+    layout_def = LayoutDefinition(extent, layout)
     rdd = BaseTestClass.rdd
     projected_extent = BaseTestClass.projected_extent
     cols = BaseTestClass.cols
@@ -21,12 +22,8 @@ class TileLayerMetadataTest(BaseTestClass):
         yield
         BaseTestClass.pysc._gateway.close()
 
-    def test_collection_invalid(self):
-        with pytest.raises(TypeError):
-            self.rdd.collect_metadata(self.extent)
-
     def test_collection_avro_rdd(self):
-        result = self.rdd.collect_metadata(self.extent, self.layout)
+        result = self.rdd.collect_metadata(layout=self.layout_def)
 
         self.assertEqual(result.extent, self.extent)
         self.assertEqual(result.layout_definition.extent, self.extent)
@@ -41,7 +38,7 @@ class TileLayerMetadataTest(BaseTestClass):
         rasterio_rdd = self.pysc.parallelize([(self.projected_extent, tile_dict)])
         raster_rdd = RasterLayer.from_numpy_rdd(self.pysc, LayerType.SPATIAL, rasterio_rdd)
 
-        result = raster_rdd.collect_metadata(extent=self.extent, layout=self.layout)
+        result = raster_rdd.collect_metadata(layout=self.layout_def)
 
         self.assertEqual(result.extent, self.extent)
         self.assertEqual(result.layout_definition.extent, self.extent)


### PR DESCRIPTION
This PR adds a `LayoutDefinitionConverter` to `converters` that will make it easier to send the layout over to Scala.