### PR TITLE
Re-Implemented TiledRasterLayer.tile_to_layout

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterRDD.scala
@@ -126,18 +126,21 @@ abstract class TiledRasterRDD[K: SpatialComponent: JsonFormat: ClassTag] extends
   ): TiledRasterRDD[K]
 
   def tileToLayout(
-    extent: java.util.Map[String, Double],
-    tileLayout: java.util.Map[String, Int],
+    layOutDefinition: LayoutDefinition,
+    resampleMethod: ResampleMethod
+  ): TiledRasterRDD[K]
+
+  def tileToLayout(
+    layoutType: LayoutType,
     resampleMethod: ResampleMethod
   ): TiledRasterRDD[K] =
     tileToLayout(
-      LayoutDefinition(extent.toExtent, tileLayout.toTileLayout),
-      resampleMethod)
-
-  protected def tileToLayout(
-    layoutDefinition: LayoutDefinition,
-    resampleMethod: ResampleMethod
-  ): TiledRasterRDD[K]
+      layoutType.layoutDefinition(
+        rdd.metadata.crs,
+        rdd.metadata.extent,
+        rdd.metadata.cellSize),
+      resampleMethod
+    )
 
   def pyramid(
     startZoom: Int,

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -1000,8 +1000,13 @@ class TiledRasterLayer(CachableLayer):
         """Cut tiles to a given layout and merge overlapping tiles. This will produce unique keys.
 
         Args:
-            layout_definition (:obj:`~geopyspark.geotrellis.LayoutDefinition`): Specify the
-                ``LayoutDefinition`` to cut to.
+            layout (
+                :obj:`~geopyspark.geotrellis.LayoutDefinition` or
+                :class:`~geopyspark.geotrellis.Metadata` or
+                :class:`~geopyspark.geotrellis.TiledRasterLayer` or
+                :obj:`~geopyspark.geotrellis.GlobalLayout` or
+                :obj:`~geopyspark.geotrellis.LocalLayout`
+            ): Target raster layout for the tiling operation.
             resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
                 The resample method to use for the reprojection. If none is specified, then
                 ``ResampleMethods.NEAREST_NEIGHBOR`` is used.

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -1021,9 +1021,15 @@ class TiledRasterLayer(CachableLayer):
             srdd = self.srdd.tileToLayout(layout, resample_method)
 
         elif isinstance(layout, Metadata):
+            if self.layer_metadata.crs != layout.crs:
+                raise ValueError("The layout needs to have the same crs as the TiledRasterLayer")
+
             srdd = self.srdd.tileToLayout(layout.layout_definition, resample_method)
 
         elif isinstance(layout, TiledRasterLayer):
+            if self.layer_metadata.crs != layout.crs:
+                raise ValueError("The layout needs to have the same crs as the TiledRasterLayer")
+
             metadata = layout.layer_metadata
             srdd = self.srdd.tileToLayout(metadata.layout_definition, resample_method)
 
@@ -1031,7 +1037,7 @@ class TiledRasterLayer(CachableLayer):
             srdd = self.srdd.tileToLayout(layout, resample_method)
 
         else:
-            raise ValueError("Could not retile from the given layout", layout)
+            raise TypeError("Could not retile from the given layout", layout)
 
         return TiledRasterLayer(self.pysc, self.layer_type, srdd)
 

--- a/geopyspark/tests/tiled_raster_layer_test.py
+++ b/geopyspark/tests/tiled_raster_layer_test.py
@@ -3,7 +3,7 @@ import pytest
 
 from geopyspark.geotrellis.constants import LayerType
 from geopyspark.tests.python_test_utils import geotiff_test_path
-from geopyspark.geotrellis import Extent, LayoutDefinition
+from geopyspark.geotrellis import Extent, LayoutDefinition, GlobalLayout
 from geopyspark.geotrellis.geotiff import get
 from geopyspark.tests.base_test_class import BaseTestClass
 
@@ -18,7 +18,7 @@ class TiledRasterLayerTest(BaseTestClass):
         yield
         BaseTestClass.pysc._gateway.close()
 
-    def test_tile_to_layout(self):
+    def test_tile_to_layout_layout_definition(self):
         layout_definition = self.tiled_layer.layer_metadata.layout_definition
         new_extent = Extent(layout_definition.extent.xmin,
                             layout_definition.extent.ymin,
@@ -30,6 +30,12 @@ class TiledRasterLayerTest(BaseTestClass):
         actual = self.tiled_layer.tile_to_layout(new_layout_definition).layer_metadata.layout_definition.extent
 
         self.assertEqual(actual, new_extent)
+
+    def test_tile_to_layout_tiled_layer(self):
+        actual = self.tiled_layer.tile_to_layout(self.tiled_layer).layer_metadata
+        expected = self.tiled_layer.layer_metadata
+
+        self.assertDictEqual(actual.to_dict(), expected.to_dict())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR updates the `TiledRasterLayer.tile_to_layout` method by having it pass over either a `LayoutType` or a `LayoutDefinition`

This PR is based on another, open PR #388 