### PR TITLE
Reimplement the collect_metadata Method

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterLayer.scala
@@ -49,27 +49,11 @@ abstract class RasterLayer[K](implicit ev0: ClassTag[K], ev1: Component[K, Proje
   def bands(bands: java.util.ArrayList[Int]): RasterLayer[K] =
     withRDD(rdd.mapValues { multibandTile => multibandTile.subsetBands(bands.asScala) })
 
-  def collectMetadata(
-    layoutDefinition: LayoutDefinition,
-    crs: String
-  ): String = {
-    collectMetadata(Right(layoutDefinition), TileLayer.getCRS(crs))
-  }
-
-  def collectMetadata(tileSize: String, crs: String): String = {
-    val layoutScheme =
-      if (tileSize != "")
-        Left(FloatingLayoutScheme(tileSize.toInt))
-      else
-        Left(FloatingLayoutScheme())
-
-    collectMetadata(layoutScheme, TileLayer.getCRS(crs))
-  }
+  def collectMetadata(layoutType: LayoutType): String
+  def collectMetadata(layoutDefinition: LayoutDefinition): String
 
   def convertDataType(newType: String): RasterLayer[_] =
     withRDD(rdd.map { x => (x._1, x._2.convert(CellType.fromName(newType))) })
-
-  protected def collectMetadata(layout: Either[LayoutScheme, LayoutDefinition], crs: Option[CRS]): String
 
   protected def tileToLayout(tileLayerMetadata: String, resampleMethod: ResampleMethod): TiledRasterLayer[_]
   def tileToLayout(layoutType: LayoutType, resampleMethod: ResampleMethod): TiledRasterLayer[_]

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -482,38 +482,22 @@ class RasterLayer(CachableLayer):
             return RasterLayer(self.pysc, self.layer_type,
                                self.srdd.convertDataType(new_type))
 
-    def collect_metadata(self, layout=None, crs=None, tile_size=256):
+    def collect_metadata(self, layout=LocalLayout()):
         """Iterate over the RDD records and generates layer metadata desribing the contained
         rasters.
 
         Args:
-            extent (:class:`~geopyspark.geotrellis.Extent`, optional): Specify layout extent, must
-                also specify ``layout``.
-            layout (:obj:`~geopyspark.geotrellis.TileLayout`, optional): Specify tile layout, must
-                also specify ``extent``.
-            crs (str or int, optional): Ignore CRS from records and use given one instead.
-            tile_size (int, optional): Pixel dimensions of each tile, if not using ``layout``.
-
-        Note:
-            ``extent`` and ``layout`` must both be defined if they are to be used.
+            layout (
+                :obj:`~geopyspark.geotrellis.LayoutDefinition` or
+                :obj:`~geopyspark.geotrellis.GlobalLayout` or
+                :obj:`~geopyspark.geotrellis.LocalLayout`, optional
+            ): Target raster layout for the tiling operation.
 
         Returns:
             :class:`~geopyspark.geotrellis.Metadata`
-
-        Raises:
-            TypeError: If either ``extent`` and ``layout`` is not defined but the other is.
         """
 
-        if not crs:
-            crs = ""
-
-        if isinstance(crs, int):
-            crs = str(crs)
-
-        if layout:
-            json_metadata = self.srdd.collectMetadata(layout, crs)
-        else:
-            json_metadata = self.srdd.collectMetadata(str(tile_size), crs)
+        json_metadata = self.srdd.collectMetadata(layout)
 
         return Metadata.from_dict(json.loads(json_metadata))
 

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -346,33 +346,6 @@ class RasterLayer(CachableLayer):
 
         return create_python_rdd(self.pysc, result, ser)
 
-    def to_tiled_layer(self, layout=None, crs=None, tile_size=256,
-                       resample_method=ResampleMethod.NEAREST_NEIGHBOR):
-        """Converts this ``RasterLayer`` to a ``TiledRasterLayer``.
-
-        This method combines :meth:`~geopyspark.geotrellis.rdd.RasterLayer.collect_metadata` and
-        :meth:`~geopyspark.geotrellis.rdd.RasterLayer.tile_to_layout` into one step.
-
-        Args:
-            extent (:class:`~geopyspark.geotrellis.Extent`, optional): Specify layout extent,
-                must also specify layout.
-            layout (:obj:`~geopyspark.geotrellis.TileLayout`, optional): Specify tile layout, must
-                also specify ``extent``.
-            crs (str or int, optional): Ignore CRS from records and use given one instead.
-            tile_size (int, optional): Pixel dimensions of each tile, if not using layout.
-            resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
-                The resample method to use for the reprojection. If none is specified, then
-                ``ResampleMethods.NEAREST_NEIGHBOR`` is used.
-
-        Note:
-            ``extent`` and ``layout`` must both be defined if they are to be used.
-
-        Returns:
-            :class:`~geopyspark.geotrellis.rdd.RasterLayer`
-        """
-
-        return self.tile_to_layout(self.collect_metadata(layout, crs, tile_size), resample_method)
-
     def bands(self, band):
         """Select a subsection of bands from the ``Tile``\s within the layer.
 

--- a/geopyspark/tests/geotiff_raster_rdd_test.py
+++ b/geopyspark/tests/geotiff_raster_rdd_test.py
@@ -61,22 +61,11 @@ class Multiband(GeoTiffIOTest, BaseTestClass):
         self.assertTrue('+proj=longlat' in md.crs)
         self.assertTrue('+datum=WGS84' in md.crs)
 
-    def test_collect_metadata_crs_override(self, options=None):
-        md = self.result.collect_metadata(crs='EPSG:3857')
-        self.assertTrue('+proj=merc' in md.crs)
-
     def test_reproject(self, options=None):
         tiles = self.result.reproject("EPSG:3857")
         md = tiles.collect_metadata()
         self.assertTrue('+proj=merc' in md.crs)
 
-    def test_to_tiled_raster(self):
-        md = self.result.collect_metadata()
-        tiled = self.result.tile_to_layout(md)
-        converted = self.result.to_tiled_layer()
-
-        self.assertDictEqual(tiled.layer_metadata.to_dict(),
-                             converted.layer_metadata.to_dict())
     '''
 
     def test_to_int(self):

--- a/geopyspark/tests/tile_layer_metadata_test.py
+++ b/geopyspark/tests/tile_layer_metadata_test.py
@@ -3,7 +3,7 @@ import unittest
 import rasterio
 import pytest
 
-from geopyspark.geotrellis import Tile, LayoutDefinition
+from geopyspark.geotrellis import Tile, LayoutDefinition, LocalLayout
 from geopyspark.geotrellis.constants import LayerType
 from geopyspark.geotrellis.layer import RasterLayer
 from geopyspark.tests.base_test_class import BaseTestClass
@@ -45,7 +45,7 @@ class TileLayerMetadataTest(BaseTestClass):
         self.assertEqual(result.layout_definition.tileLayout, self.layout)
 
     def test_collection_floating(self):
-        result = self.rdd.collect_metadata(tile_size=self.cols)
+        result = self.rdd.collect_metadata(LocalLayout(self.cols))
 
         self.assertEqual(result.extent, self.extent)
         self.assertEqual(result.layout_definition.extent, self.extent)

--- a/geopyspark/tests/tiled_raster_layer_test.py
+++ b/geopyspark/tests/tiled_raster_layer_test.py
@@ -11,7 +11,7 @@ from geopyspark.tests.base_test_class import BaseTestClass
 class TiledRasterLayerTest(BaseTestClass):
     dir_path = geotiff_test_path("all-ones.tif")
     result = get(BaseTestClass.pysc, LayerType.SPATIAL, dir_path)
-    tiled_layer = result.to_tiled_layer()
+    tiled_layer = result.tile_to_layout()
 
     @pytest.fixture(autouse=True)
     def tearDown(self):

--- a/geopyspark/tests/to_geotiff_rdd_test.py
+++ b/geopyspark/tests/to_geotiff_rdd_test.py
@@ -55,7 +55,7 @@ class ToGeoTiffTest(BaseTestClass):
                 self.assertEqual(src.compression, rasterio.enums.Compression.deflate)
 
     def test_to_geotiff_rdd_tiledrasterlayer(self):
-        tiled_rdd = self.rdd.to_tiled_layer()
+        tiled_rdd = self.rdd.tile_to_layout()
         tiled_collected = tiled_rdd.to_numpy_rdd().first()[1]
 
         geotiff_rdd = tiled_rdd.to_geotiff_rdd()


### PR DESCRIPTION
This PR re-implements the `collect_metadata` method by having it just accept a `layout`. It also removes the `to_tiled_layer` method.