### PR TITLE
LocalLayout is Now Constructed From tile_cols and tile_rows

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/LayoutType.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/LayoutType.scala
@@ -7,8 +7,6 @@ import geotrellis.vector.Extent
 
 /** Strategy for selecting LayoutScheme before metadata is collected */
 sealed trait LayoutType {
-  def tileSize: Int
-
   /** Produce the [[LayoutDefinition]] and zoom level, if applicable, for given raster */
   def layoutDefinitionWithZoom(crs: CRS, extent: Extent, cellSize: CellSize): (LayoutDefinition, Option[Int])
 
@@ -32,9 +30,15 @@ case class GlobalLayout(tileSize: Int, zoom: Integer, threshold: Double)  extend
 }
 
 /** @see [[geotrellis.spark.tiling.FloatingLayoutScheme]] */
-case class LocalLayout(tileSize: Int) extends LayoutType {
+case class LocalLayout(tileCols: Int, tileRows: Int) extends LayoutType {
   def layoutDefinitionWithZoom(crs: CRS, extent: Extent, cellSize: CellSize) = {
-    val scheme = new FloatingLayoutScheme(tileSize, tileSize)
+    val scheme = new FloatingLayoutScheme(tileCols, tileRows)
     scheme.levelFor(extent, cellSize).layout -> None
   }
+}
+
+
+object LocalLayout {
+  def apply(tileSize: Int): LocalLayout =
+    LocalLayout(tileSize, tileSize)
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ProjectedRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ProjectedRasterLayer.scala
@@ -90,8 +90,8 @@ class ProjectedRasterLayer(val rdd: RDD[(ProjectedExtent, MultibandTile)]) exten
         val (_, reprojected) = tiled.reproject(crs, scheme.levelForZoom(zoom).layout, resampleMethod)
         new SpatialTiledRasterLayer(Some(zoom), reprojected)
 
-      case LocalLayout(tileSize) =>
-        val (_, reprojected) = tiled.reproject(crs, FloatingLayoutScheme(tileSize), resampleMethod)
+      case LocalLayout(tileCols, tileRows) =>
+        val (_, reprojected) = tiled.reproject(crs, FloatingLayoutScheme(tileCols, tileRows), resampleMethod)
         new SpatialTiledRasterLayer(None, reprojected)
     }
   }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialTiledRasterLayer.scala
@@ -79,8 +79,8 @@ class SpatialTiledRasterLayer(
         val (_, reprojected) = tiled.reproject(crs, scheme.levelForZoom(zoom).layout, resampleMethod)
         SpatialTiledRasterLayer(Some(zoom), reprojected)
 
-      case LocalLayout(tileSize) =>
-        val (_, reprojected) = tiled.reproject(crs, FloatingLayoutScheme(tileSize), resampleMethod)
+      case LocalLayout(tileCols, tileRows) =>
+        val (_, reprojected) = tiled.reproject(crs, FloatingLayoutScheme(tileCols, tileRows), resampleMethod)
         SpatialTiledRasterLayer(None, reprojected)
     }
   }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalRasterLayer.scala
@@ -88,8 +88,8 @@ class TemporalRasterLayer(val rdd: RDD[(TemporalProjectedExtent, MultibandTile)]
         val (_, reprojected) = tiled.reproject(crs, scheme.levelForZoom(zoom).layout, resampleMethod)
         new TemporalTiledRasterLayer(Some(zoom), reprojected)
 
-      case LocalLayout(tileSize) =>
-        val (_, reprojected) = tiled.reproject(crs, FloatingLayoutScheme(tileSize), resampleMethod)
+      case LocalLayout(tileCols, tileRows) =>
+        val (_, reprojected) = tiled.reproject(crs, FloatingLayoutScheme(tileCols, tileRows), resampleMethod)
         new TemporalTiledRasterLayer(None, reprojected)
     }
   }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
@@ -110,8 +110,8 @@ class TemporalTiledRasterLayer(
         val (_, reprojected) = tiled.reproject(crs, scheme.levelForZoom(zoom).layout, resampleMethod)
         TemporalTiledRasterLayer(Some(zoom), reprojected)
 
-      case LocalLayout(tileSize) =>
-        val (_, reprojected) = tiled.reproject(crs, FloatingLayoutScheme(tileSize), resampleMethod)
+      case LocalLayout(tileCols, tileRows) =>
+        val (_, reprojected) = tiled.reproject(crs, FloatingLayoutScheme(tileCols, tileRows), resampleMethod)
         TemporalTiledRasterLayer(None, reprojected)
     }
   }

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -258,20 +258,38 @@ Returns:
 GlobalLayout.__new__.__defaults__ = (256, None, 0.1)
 
 
-LocalLayout = namedtuple("LayoutDefinition", 'tile_size')
-"""TileLayout type that snaps the layer extent.
+class LocalLayout(namedtuple("LocalLayout", 'tile_cols tile_rows')):
+    """TileLayout type that snaps the layer extent.
 
-When passed in place of LayoutDefinition it signifies that a LayoutDefinition instances should be
-constructed over the envelope of the layer pixels with given tile size. Resulting TileLayout will
-match the cell resolution of the source rasters.
+    When passed in place of LayoutDefinition it signifies that a LayoutDefinition instances should
+    be constructed over the envelope of the layer pixels with given tile size. Resulting TileLayout
+    will match the cell resolution of the source rasters.
 
-Args:
-    tile_size (int): The number of columns and row pixels in each tile.
+    Args:
+        tile_size (int, optional): The number of columns and row pixels in each tile. If this
+            is ``None``, then the sizes of each tile will be set using ``tile_cols`` and
+            ``tile_rows``.
+        tile_cols (int, optional): The number of column pixels in each tile. This supersedes
+            ``tile_size``. Meaning if this and ``tile_size`` are set, then this will be used for
+            the number of colunn pixles. If ``None``, then the number of column pixels will
+            default to 256.
+        tile_rows (int, optional): The number of rows pixels in each tile. This supersedes
+            ``tile_size``. Meaning if this and ``tile_size`` are set, then this will be used for
+            the number of row pixles. If ``None``, then the number of row pixels will
+            default to 256.
 
-Returns:
-    :obj:`~geopyspark.geotrellis.LocalLayout`
-"""
-LocalLayout.__new__.__defaults__ = (256,)
+    Attributes:
+        tile_cols (int): The number of column pixels in each tile
+        tile_rows (int): The number of rows pixels in each tile. This supersedes
+    """
+
+    __slots__ = []
+
+    def __new__(cls, tile_size=None, tile_cols=None, tile_rows=None):
+        tile_cols = tile_cols or tile_size or 256
+        tile_rows = tile_rows or tile_size or 256
+
+        return super(LocalLayout, cls).__new__(cls, tile_cols, tile_rows)
 
 
 TileLayout = namedtuple("TileLayout", 'layoutCols layoutRows tileCols tileRows')

--- a/geopyspark/geotrellis/converters.py
+++ b/geopyspark/geotrellis/converters.py
@@ -42,7 +42,7 @@ class LayoutTypeConverter(object):
             return JavaGlobalLayout(obj.tile_size, obj.zoom, float(obj.threshold))
         elif isinstance(obj, LocalLayout):
             JavaLocalLayout = JavaClass("geopyspark.geotrellis.LocalLayout", gateway_client)
-            return JavaLocalLayout(obj.tile_size)
+            return JavaLocalLayout(obj.tile_cols, obj.tile_rows)
         else:
             raise TypeError("Could not convert {} to geotrellis.raster.LayoutType".format(obj.sampleType))
 

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -463,7 +463,7 @@ class RasterLayer(CachableLayer):
             layout (
                 :obj:`~geopyspark.geotrellis.LayoutDefinition` or
                 :obj:`~geopyspark.geotrellis.GlobalLayout` or
-                :obj:`~geopyspark.geotrellis.LocalLayout`, optional
+                :class:`~geopyspark.geotrellis.LocalLayout`, optional
             ): Target raster layout for the tiling operation.
 
         Returns:
@@ -484,7 +484,7 @@ class RasterLayer(CachableLayer):
                 Either EPSG code, well-known name, or a PROJ.4 string.
             layout (
                 :obj:`~geopyspark.geotrellis.GlobalLayout` or
-                :obj:`~geopyspark.geotrellis.LocalLayout`, optional
+                :class:`~geopyspark.geotrellis.LocalLayout`, optional
             ): Target raster layout when reprojecting.
             resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
                 The resample method to use for the reprojection. If none is specified, then
@@ -514,7 +514,7 @@ class RasterLayer(CachableLayer):
                 :class:`~geopyspark.geotrellis.Metadata` or
                 :class:`~geopyspark.geotrellis.TiledRasterLayer` or
                 :obj:`~geopyspark.geotrellis.GlobalLayout` or
-                :obj:`~geopyspark.geotrellis.LocalLayout`, optional
+                :class:`~geopyspark.geotrellis.LocalLayout`, optional
             ): Target raster layout for the tiling operation.
             resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
                 The cell resample method to used during the tiling operation.
@@ -882,7 +882,7 @@ class TiledRasterLayer(CachableLayer):
                 :class:`~geopyspark.geotrellis.Metadata` or
                 :class:`~geopyspark.geotrellis.TiledRasterLayer` or
                 :obj:`~geopyspark.geotrellis.GlobalLayout` or
-                :obj:`~geopyspark.geotrellis.LocalLayout`, optional
+                :class:`~geopyspark.geotrellis.LocalLayout`, optional
             ): Target raster layout for the tiling operation.
             resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
                 The resample method to use for the reprojection. If none is specified, then
@@ -947,7 +947,7 @@ class TiledRasterLayer(CachableLayer):
                 :class:`~geopyspark.geotrellis.Metadata` or
                 :class:`~geopyspark.geotrellis.TiledRasterLayer` or
                 :obj:`~geopyspark.geotrellis.GlobalLayout` or
-                :obj:`~geopyspark.geotrellis.LocalLayout`
+                :class:`~geopyspark.geotrellis.LocalLayout`
             ): Target raster layout for the tiling operation.
             resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
                 The resample method to use for the reprojection. If none is specified, then


### PR DESCRIPTION
This PR makes `LocalLayout` except either a `tile_size`, `tile_cols`, or `tile_rows` as constructors. This'll give the user more control over how the `LocalLayout` is defined.