### PR TITLE
Fixed Formatting Issue in Locallayout

### DIFF
--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -289,7 +289,7 @@ class LocalLayout(namedtuple("LocalLayout", 'tile_cols tile_rows')):
         tile_cols = tile_cols or tile_size or 256
         tile_rows = tile_rows or tile_size or 256
 
-        return super(LocalLayout, cls).__new__(cls, tile_cols, tile_rows)
+        return super(cls, LocalLayout).__new__(cls, tile_cols, tile_rows)
 
 
 TileLayout = namedtuple("TileLayout", 'layoutCols layoutRows tileCols tileRows')


### PR DESCRIPTION
When calling a parent class using `super`, this first argument should be the class that is making the call. For some reason, pylint could not determine whether the `LocalLayout` class or `namedtuple` was being passed in first, so it raised an error. This PR fixes this by swapping the places of `LocalLayout` and `cls` in the `super` call.