### PR TITLE
No More Duplicate Jars in Path

### DIFF
--- a/geopyspark/__init__.py
+++ b/geopyspark/__init__.py
@@ -116,9 +116,10 @@ def geopyspark_conf(master=None, appName=None, additional_jar_dirs=[]):
     possible_jars = [os.path.join(prefix, '*.jar') for prefix in local_prefixes + additional_jar_dirs]
     configuration = os.path.join(current_location, 'command', 'geopyspark.conf')
 
-    if os.path.isfile(configuration):
-        with open(os.path.join(configuration)) as config_file:
-            possible_jars.append(os.path.relpath(config_file.read(), cwd))
+    if not possible_jars:
+        if os.path.isfile(configuration):
+            with open(os.path.join(configuration)) as config_file:
+                possible_jars.append(os.path.relpath(config_file.read(), cwd))
 
     jar = os.path.abspath(resource_filename('geopyspark.jars', JAR))
     jar_dir = os.path.dirname(jar)


### PR DESCRIPTION
This PR makes it so that there is no duplicate jars in path when GeoPySpark is installed via pip.