### PR TITLE
to_spatial_layer Method

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalRasterLayer.scala
@@ -129,6 +129,9 @@ class TemporalRasterLayer(val rdd: RDD[(TemporalProjectedExtent, MultibandTile)]
 
     PythonTranslator.toPython[(TemporalProjectedExtent, Array[Byte]), ProtoTuple](geotiffRDD)
   }
+
+  def toSpatialLayer(): ProjectedRasterLayer =
+    ProjectedRasterLayer(rdd.map { x => (x._1.projectedExtent, x._2) })
 }
 
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
@@ -281,6 +281,15 @@ class TemporalTiledRasterLayer(
 
     PythonTranslator.toPython[(SpaceTimeKey, Array[Byte]), ProtoTuple](geotiffRDD)
   }
+
+  def toSpatialLayer(): SpatialTiledRasterLayer = {
+    val spatialRDD = rdd.map { x => (x._1.spatialKey, x._2) }
+    val bounds = rdd.metadata.bounds.get
+    val spatialMetadata =
+      rdd.metadata.copy(bounds = Bounds(bounds.minKey.spatialKey, bounds.maxKey.spatialKey))
+
+    SpatialTiledRasterLayer(zoomLevel, ContextRDD(spatialRDD, spatialMetadata))
+  }
 }
 
 

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -118,6 +118,13 @@ def _reproject(target_crs, layout, resample_method, layer):
         raise TypeError("%s can not be used as target layout." % layout)
 
 
+def _to_spatial_layer(layer):
+    if layer.layer_type == LayerType.SPATIAL:
+        raise ValueError("The given already has a layer_type of LayerType.SPATIAL")
+
+    return layer.srdd.toSpatialLayer()
+
+
 class CachableLayer(object):
     """
     Base class for class that wraps a Scala RDD instance through a py4j reference.
@@ -343,6 +350,19 @@ class RasterLayer(CachableLayer):
         ser = ProtoBufSerializer.create_image_rdd_serializer(key_type=key)
 
         return create_python_rdd(result, ser)
+
+    def to_spatial_layer(self):
+        """Converts a ``RasterLayer`` with a ``layout_type`` of ``LayoutType.SPACETIME`` to a
+        ``RasterLayer`` with a ``layout_type`` of ``LayoutType.SPATIAL``.
+
+        Returns:
+            :class:`~geopyspark.geotrellis.layer.RasterLayer`
+
+        Raises:
+            ValueError: If the layer already has a ``layout_type`` of ``LayoutType.SPATIAL``.
+        """
+
+        return RasterLayer(LayerType.SPATIAL, _to_spatial_layer(self))
 
     def bands(self, band):
         """Select a subsection of bands from the ``Tile``\s within the layer.
@@ -713,6 +733,19 @@ class TiledRasterLayer(CachableLayer):
         ser = ProtoBufSerializer.create_image_rdd_serializer(key_type=key)
 
         return create_python_rdd(result, ser)
+
+    def to_spatial_layer(self):
+        """Converts a ``TiledRasterLayer`` with a ``layout_type`` of ``LayoutType.SPACETIME`` to a
+        ``TiledRasterLayer`` with a ``layout_type`` of ``LayoutType.SPATIAL``.
+
+        Returns:
+            :class:`~geopyspark.geotrellis.layer.TiledRasterLayer`
+
+        Raises:
+            ValueError: If the layer already has a ``layout_type`` of ``LayoutType.SPATIAL``.
+        """
+
+        return TiledRasterLayer(LayerType.SPATIAL, _to_spatial_layer(self))
 
     def bands(self, band):
         """Select a subsection of bands from the ``Tile``\s within the layer.

--- a/geopyspark/geotrellis/protobufcodecs.py
+++ b/geopyspark/geotrellis/protobufcodecs.py
@@ -657,7 +657,7 @@ def tuple_encoder(obj, key_encoder):
     elif key_encoder == "SpatialKey":
         tup.spatialKey.CopyFrom(to_pb_spatial_key(obj[0]))
     else:
-        tup.spaceTimeKey = to_pb_space_time_key(obj[0])
+        tup.spaceTimeKey.CopyFrom(to_pb_space_time_key(obj[0]))
 
     return tup.SerializeToString()
 

--- a/geopyspark/tests/to_spatial_test.py
+++ b/geopyspark/tests/to_spatial_test.py
@@ -1,0 +1,94 @@
+import os
+import datetime
+import unittest
+import numpy as np
+
+import pytest
+
+from geopyspark.geotrellis import SpatialKey, Tile
+from geopyspark.tests.base_test_class import BaseTestClass
+from geopyspark.geotrellis import Extent, ProjectedExtent, SpaceTimeKey, SpatialKey, TemporalProjectedExtent
+from geopyspark.geotrellis.layer import RasterLayer, TiledRasterLayer
+from geopyspark.geotrellis.constants import LayerType
+
+
+class ToSpatialLayerTest(BaseTestClass):
+    band_1 = np.array([
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0, 1.0]])
+
+    band_2 = np.array([
+        [2.0, 2.0, 2.0, 2.0, 2.0],
+        [2.0, 2.0, 2.0, 2.0, 2.0],
+        [2.0, 2.0, 2.0, 2.0, 2.0],
+        [2.0, 2.0, 2.0, 2.0, 2.0],
+        [2.0, 2.0, 2.0, 2.0, 2.0]])
+
+    bands = np.array([band_1, band_2])
+    time = datetime.datetime.strptime("2016-08-24T09:00:00Z", '%Y-%m-%dT%H:%M:%SZ')
+
+    layer = [(SpaceTimeKey(0, 0, time), Tile(bands, 'FLOAT', -1.0)),
+             (SpaceTimeKey(1, 0, time), Tile(bands, 'FLOAT', -1.0,)),
+             (SpaceTimeKey(0, 1, time), Tile(bands, 'FLOAT', -1.0,)),
+             (SpaceTimeKey(1, 1, time), Tile(bands, 'FLOAT', -1.0,))]
+
+    rdd = BaseTestClass.pysc.parallelize(layer)
+
+    extent = {'xmin': 0.0, 'ymin': 0.0, 'xmax': 33.0, 'ymax': 33.0}
+    layout = {'layoutCols': 2, 'layoutRows': 2, 'tileCols': 5, 'tileRows': 5}
+    metadata = {'cellType': 'float32ud-1.0',
+                'extent': extent,
+                'crs': '+proj=longlat +datum=WGS84 +no_defs ',
+                'bounds': {
+                    'minKey': {'col': 0, 'row': 0, 'instant': 1},
+                    'maxKey': {'col': 1, 'row': 1, 'instant': 1}},
+                'layoutDefinition': {
+                    'extent': extent,
+                    'tileLayout': {'tileCols': 5, 'tileRows': 5, 'layoutCols': 2, 'layoutRows': 2}}}
+
+    tiled_raster_rdd = TiledRasterLayer.from_numpy_rdd(LayerType.SPACETIME, rdd, metadata)
+
+    layer2 = [(TemporalProjectedExtent(Extent(0, 0, 1, 1), epsg=3857, instant=time), Tile(bands, 'FLOAT', -1.0)),
+              (TemporalProjectedExtent(Extent(1, 0, 2, 1), epsg=3857, instant=time), Tile(bands, 'FLOAT', -1.0)),
+              (TemporalProjectedExtent(Extent(0, 1, 1, 2), epsg=3857, instant=time), Tile(bands, 'FLOAT', -1.0)),
+              (TemporalProjectedExtent(Extent(1, 1, 2, 2), epsg=3857, instant=time), Tile(bands, 'FLOAT', -1.0))]
+    rdd2 = BaseTestClass.pysc.parallelize(layer2)
+    raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPACETIME, rdd2)
+
+    @pytest.fixture(autouse=True)
+    def tearDown(self):
+        yield
+        BaseTestClass.pysc._gateway.close()
+
+    def test_to_spatial_raster_layer(self):
+        actual = [k for k, v in self.raster_rdd.to_spatial_layer().to_numpy_rdd().collect()]
+
+        expected = [
+            ProjectedExtent(Extent(0, 0, 1, 1), 3857),
+            ProjectedExtent(Extent(1, 0, 2, 1), 3857),
+            ProjectedExtent(Extent(0, 1, 1, 2), 3857),
+            ProjectedExtent(Extent(1, 1, 2, 2), 3857)
+        ]
+
+        for a, e in zip(actual, expected):
+            self.assertEqual(a, e)
+
+    def test_to_spatial_tiled_layer(self):
+        actual = [k for k, v in self.tiled_raster_rdd.to_spatial_layer().to_numpy_rdd().collect()]
+
+        expected = [
+            SpatialKey(0, 0),
+            SpatialKey(1, 0),
+            SpatialKey(0, 1),
+            SpatialKey(1, 1)
+        ]
+
+        for a, e in zip(actual, expected):
+            self.assertEqual(a, e)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds the `to_spatial_layer` method to `RasterLayer` and `TiledRasterLayer`. With this method, one can switch from a layer with a `layer_type` of `SPACETIME` to a `layer_type` of `SPATIAL`