### PR TITLE
Catalog Test Memory Leak Fix

### DIFF
--- a/geopyspark/tests/io_tests/catalog_test.py
+++ b/geopyspark/tests/io_tests/catalog_test.py
@@ -23,7 +23,7 @@ class CatalogTest(BaseTestClass):
     uri = "file://{}".format(dir_path)
     layer_name = "catalog-test"
 
-    @pytest.fixture(scope='class', autouse=True)
+    @pytest.fixture(autouse=True)
     def tearDown(self):
         yield
         BaseTestClass.pysc._gateway.close()


### PR DESCRIPTION
This PR resolves a memory leak issue that sometimes occured in the `catalog_test`. The cause of this leak appears to be not properly shutting down the `JavaGateway` object, leading to the following error.

```
Exception ignored in: <function JavaObject.__init__.<locals>.<lambda> at 0x7f2243c17ae8>
Traceback (most recent call last):
  File "/usr/local/spark/python/lib/py4j-0.10.4-src.zip/py4j/java_gateway.py", line 1169, in <lambda>
  File "/usr/local/spark/python/lib/py4j-0.10.4-src.zip/py4j/java_gateway.py", line 561, in _garbage_collect_object
  File "/usr/lib/python3.5/logging/__init__.py", line 1266, in debug
  File "/usr/lib/python3.5/logging/__init__.py", line 1519, in isEnabledFor
TypeError: unorderable types: int() >= NoneType()
Exception ignored in: <function GatewayConnection.__init__.<locals>.<lambda> at 0x7f2249c76840>
Traceback (most recent call last):
  File "/usr/local/spark/python/lib/py4j-0.10.4-src.zip/py4j/java_gateway.py", line 957, in <lambda>
  File "/usr/local/spark/python/lib/py4j-0.10.4-src.zip/py4j/java_gateway.py", line 573, in _garbage_collect_connection
  File "/usr/local/spark/python/lib/py4j-0.10.4-src.zip/py4j/java_gateway.py", line 443, in quiet_shutdown
  File "/usr/lib/python3.5/logging/__init__.py", line 1266, in debug
  File "/usr/lib/python3.5/logging/__init__.py", line 1519, in isEnabledFor
TypeError: unorderable types: int() >= NoneType()
(notebooks) geopyspark [master] % pytest geopyspark/tests/io_tests/catalog_test.py
```

With this issue being fixed, testing on Travis should be more stable and not fail as often.