### PR TITLE
Build Docs With Latest Scala Backend

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,10 +28,12 @@ if 'SPARK_HOME' not in os.environ.keys():
     subprocess.call(['tar', '-xvf', 'spark-2.1.1-bin-hadoop2.7.tgz'])
     os.environ['SPARK_HOME'] = './spark-2.1.1-bin-hadoop2.7/'
 
+os.chdir('..')
 jar = 'geotrellis-backend-assembly-0.2.0.jar'
-url = 'https://github.com/locationtech-labs/geopyspark/releases/download/v0.2.0-RC3/'
-subprocess.call(['curl', '-L', url+jar, '-o', '../geopyspark/jars/' + jar])
-sys.path.insert(0, path.abspath('../'))
+
+if not path.isfile(path.join('geopyspark/jars', jar)):
+    subprocess.call(['make', 'build'])
+sys.path.insert(0, path.abspath(os.curdir))
 
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
This PR makes it so that the documentation for GeoPySpark's ReadTheDocs page is built using the latest Scala backend instead of the older jar from GitHub.