### PR TITLE
datetime for Temporal Parameters

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerWriterFactory.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerWriterFactory.scala
@@ -45,7 +45,8 @@ abstract class LayerWriterWrapper {
 
   private def getTemporalIndexMethod(
     timeString: String,
-    indexStrategy: String) =
+    indexStrategy: String
+  ) =
     (indexStrategy, timeString) match {
       case ("zorder", "millis") => ZCurveKeyIndexMethod.byMilliseconds(1)
       case ("zorder", "seconds") => ZCurveKeyIndexMethod.bySecond

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tests/schemas/SpaceTimeKeyWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tests/schemas/SpaceTimeKeyWrapper.scala
@@ -9,6 +9,9 @@ import org.apache.spark._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.api.java.JavaRDD
 
+import java.time.Instant
+
+
 object SpaceTimeKeyWrapper extends Wrapper2[SpaceTimeKey, ProtoSpaceTimeKey] {
   def testOut(sc: SparkContext): JavaRDD[Array[Byte]] =
     PythonTranslator.toPython[SpaceTimeKey, ProtoSpaceTimeKey](testRdd(sc))
@@ -17,9 +20,9 @@ object SpaceTimeKeyWrapper extends Wrapper2[SpaceTimeKey, ProtoSpaceTimeKey] {
 
   def testRdd(sc: SparkContext): RDD[SpaceTimeKey] = {
     val arr = Array(
-      SpaceTimeKey(7, 3, 5.toLong),
-      SpaceTimeKey(9, 4, 10.toLong),
-      SpaceTimeKey(11, 5, 15.toLong))
+      SpaceTimeKey(7, 3,Instant.parse("2016-08-24T09:00:00Z").toEpochMilli),
+      SpaceTimeKey(9, 4,Instant.parse("2016-08-24T09:00:00Z").toEpochMilli),
+      SpaceTimeKey(11, 5, Instant.parse("2016-08-24T09:00:00Z").toEpochMilli))
     sc.parallelize(arr)
   }
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tests/schemas/TemporalProjectedExtentWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tests/schemas/TemporalProjectedExtentWrapper.scala
@@ -13,6 +13,9 @@ import org.apache.spark._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.api.java.JavaRDD
 
+import java.time.Instant
+
+
 object TemporalProjectedExtentWrapper extends Wrapper2[TemporalProjectedExtent, ProtoTemporalProjectedExtent]{
   def testOut(sc: SparkContext): JavaRDD[Array[Byte]] =
     PythonTranslator.toPython[TemporalProjectedExtent, ProtoTemporalProjectedExtent](testRdd(sc))
@@ -21,9 +24,9 @@ object TemporalProjectedExtentWrapper extends Wrapper2[TemporalProjectedExtent, 
 
   def testRdd(sc: SparkContext): RDD[TemporalProjectedExtent] = {
     val arr = Array(
-      TemporalProjectedExtent(Extent(0, 0, 1, 1), CRS.fromEpsgCode(2004), 0.toLong),
-      TemporalProjectedExtent(Extent(1, 2, 3, 4), CRS.fromEpsgCode(2004), 1.toLong),
-      TemporalProjectedExtent(Extent(5, 6, 7, 8), CRS.fromEpsgCode(2004), 2.toLong))
+      TemporalProjectedExtent(Extent(0, 0, 1, 1), CRS.fromEpsgCode(2004), Instant.parse("2016-08-24T09:00:00Z").toEpochMilli),
+      TemporalProjectedExtent(Extent(1, 2, 3, 4), CRS.fromEpsgCode(2004), Instant.parse("2016-08-24T09:00:00Z").toEpochMilli),
+      TemporalProjectedExtent(Extent(5, 6, 7, 8), CRS.fromEpsgCode(2004), Instant.parse("2016-08-24T09:00:00Z").toEpochMilli))
     sc.parallelize(arr)
   }
 }

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -9,13 +9,6 @@ from geopyspark import get_spark_context
 from geopyspark.geotrellis.constants import CellType, NO_DATA_INT
 
 
-_EPOCH = datetime.datetime.utcfromtimestamp(0)
-
-
-def _convert_to_unix_time(date_time):
-    return int((date_time - _EPOCH).total_seconds() * 1000)
-
-
 def deprecated(func):
     """This is a decorator which can be used to mark functions
     as deprecated. It will result in a warning being emmitted
@@ -235,21 +228,15 @@ class TemporalProjectedExtent(namedtuple("TemporalProjectedExtent", 'extent inst
 
     Args:
         extent (:class:`~geopyspark.geotrellis.Extent`): The area the raster represents.
-        instant (``datetime.datetime``): The time stamp of the raster. This is
-            an instance of ``datetime.datetime`` that references the correct date and time.
+        instant (``datetime.datetime``): The time stamp of the raster.
         epsg (int, optional): The EPSG code of the CRS.
         proj4 (str, optional): The Proj.4 string representation of the CRS.
 
     Attributes:
         extent (:class:`~geopyspark.geotrellis.Extent`): The area the raster represents.
-        instant (int): The time stamp of the raster. This is an ``int`` which represents the
-            timestamp in miliseconds.
+        instant (``datetime.datetime``): The time stamp of the raster.
         epsg (int, optional): The EPSG code of the CRS.
         proj4 (str, optional): The Proj.4 string representation of the CRS.
-
-    Note:
-        The ``instant`` attribute is in milliseconds since the 1970 epoch. Thus, it may be
-        different than the timestamp given by the ``datetime.datetime`` instance.
 
     Note:
         Either ``epsg`` or ``proj4`` must be defined.
@@ -258,9 +245,6 @@ class TemporalProjectedExtent(namedtuple("TemporalProjectedExtent", 'extent inst
     __slots__ = []
 
     def __new__(cls, extent, instant, epsg=None, proj4=None):
-        if isinstance(instant, datetime.datetime):
-            instant = _convert_to_unix_time(instant)
-
         return super(TemporalProjectedExtent, cls).__new__(cls, extent, instant, epsg, proj4)
 
     def _asdict(self):
@@ -373,40 +357,20 @@ Returns:
 """
 
 
-class SpaceTimeKey(namedtuple("SpaceTimeKey", 'col row instant')):
-    """
-    Represents the position of a raster within a grid.
-    This grid is a 3D plane where raster positions are represented by a pair of coordinates as well
-    as a z value that represents time.
+SpaceTimeKey = namedtuple("SpaceTimeKey", 'col row instant')
+"""
+Represents the position of a raster within a grid.
+This grid is a 3D plane where raster positions are represented by a pair of coordinates as well
+as a z value that represents time.
 
-    Args:
-        col (int): The column of the grid, the numbers run east to west.
-        row (int): The row of the grid, the numbers run north to south.
-        instant (``datetime.datetime``): The time stamp of the raster. This is
-            an instance of ``datetime.datetime`` that references the correct date and time.
+Args:
+    col (int): The column of the grid, the numbers run east to west.
+    row (int): The row of the grid, the numbers run north to south.
+    instant (``datetime.datetime``): The time stamp of the raster.
 
-    Args:
-        col (int): The column of the grid, the numbers run east to west.
-        row (int): The row of the grid, the numbers run north to south.
-        instant (int): The time stamp of the raster. This is an ``int`` which represents the
-            timestamp in miliseconds.
-
-    Note:
-        The ``instant`` attribute is in milliseconds since the 1970 epoch. Thus, it may be
-        different than the timestamp given by the ``datetime.datetime`` instance.
-
-    Returns:
-        :class:`~geopyspark.geotrellis.SpaceTimeKey`
-    """
-
-    __slots__ = []
-
-    def __new__(cls, col, row, instant):
-        if isinstance(instant, datetime.datetime):
-            instant = _convert_to_unix_time(instant)
-
-        return super(SpaceTimeKey, cls).__new__(cls, col, row, instant)
-
+Returns:
+    :obj:`~geopyspark.geotrellis.SpaceTimeKey`
+"""
 
 RasterizerOptions = namedtuple("RasterizeOption", 'includePartial sampleType')
 """Represents options available to geometry rasterizer

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -329,10 +329,9 @@ def query(layer_type,
                 All other types are restricted to ``Polygon`` and ``MulitPolygon``.
 
             If not specified, then the entire layer will be read.
-        time_intervals (list, optional): A list of ``datetime.datetime`` instanaces that represent
-            the time intervals to query.  This parameter is only used when querying spatial-temporal
-            data. The default value is, ``None``. If ``None``, then only the spatial area will be
-            querried.
+        time_intervals (``[datetime.datetime]``, optional): A list of the time intervals to query.
+            This parameter is only used when querying spatial-temporal data. The default value is,
+            ``None``. If ``None``, then only the spatial area will be querried.
         options (dict, optional): Additional parameters for querying the tile for specific backends.
             The dictioanry is only used for ``Cassandra`` and ``HBase``, no other backend requires
             this to be set.
@@ -424,8 +423,9 @@ def write(uri,
             only certain methods are available. Can either be a string or a ``IndexingMethod``
             attribute.  The default method used is, ``IndexingMethod.ZORDER``.
         time_unit (str or :class:`~geopyspark.geotrellis.constants.TimeUnit`, optional): Which time
-            unit should be used when saving spatial-temporal data.  While this is set to ``None``
-            as default, it must be set if saving spatial-temporal data.
+            unit should be used when saving spatial-temporal data. This controls the resolution of
+            each index. Meaning, what time intervals are used to seperate each record. While this is
+            set to ``None`` as default, it must be set if saving spatial-temporal data.
             Depending on the indexing method chosen, different time units are used.
         options (dict, optional): Additional parameters for writing the layer for specific
             backends. The dictioanry is only used for ``Cassandra`` and ``HBase``, no other backend

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -10,7 +10,7 @@ from shapely.wkt import dumps
 import shapely.wkb
 
 from geopyspark import map_key_input, get_spark_context
-from geopyspark.geotrellis.constants import LayerType, IndexingMethod
+from geopyspark.geotrellis.constants import LayerType, IndexingMethod, TimeUnit
 from geopyspark.geotrellis.protobufcodecs import multibandtile_decoder
 from geopyspark.geotrellis import Metadata, Extent, deprecated, Log
 from geopyspark.geotrellis.layer import TiledRasterLayer
@@ -247,9 +247,9 @@ def read_value(layer_type,
         layer_zoom (int): The zoom level of the layer that is to be read.
         col (int): The col number of the tile within the layout. Cols run east to west.
         row (int): The row number of the tile within the layout. Row run north to south.
-        zdt (str): The Zone-Date-Time string of the tile. The string must be in a valid date-time
-            format. This parameter is only used when querying spatial-temporal data. The default
-            value is, None. If None, then only the spatial area will be queried.
+        zdt (``datetime.datetime``): The time stamp of the tile if the data is spatial-temporal.
+            This is represented as a ``datetime.datetime.`` instance.  The default value is,
+            ``None``. If ``None``, then only the spatial area will be queried.
         options (dict, optional): Additional parameters for reading the tile for specific backends.
             The dictionary is only used for ``Cassandra`` and ``HBase``, no other backend requires
             this to be set.
@@ -264,7 +264,11 @@ def read_value(layer_type,
         return None
     else:
         options = options or kwargs or {}
-        zdt = zdt or ""
+
+        if zdt:
+            zdt = zdt.isoformat()
+        else:
+            zdt = ""
 
         if uri not in _mapped_cached:
             _construct_catalog(get_spark_context(), uri, options)
@@ -325,10 +329,10 @@ def query(layer_type,
                 All other types are restricted to ``Polygon`` and ``MulitPolygon``.
 
             If not specified, then the entire layer will be read.
-        time_intervals (list, optional): A list of strings that time intervals to query.
-            The strings must be in a valid date-time format. This parameter is only used when
-            querying spatial-temporal data. The default value is, None. If None, then only the
-            spatial area will be querried.
+        time_intervals (list, optional): A list of ``datetime.datetime`` instanaces that represent
+            the time intervals to query.  This parameter is only used when querying spatial-temporal
+            data. The default value is, ``None``. If ``None``, then only the spatial area will be
+            querried.
         options (dict, optional): Additional parameters for querying the tile for specific backends.
             The dictioanry is only used for ``Cassandra`` and ``HBase``, no other backend requires
             this to be set.
@@ -358,7 +362,11 @@ def query(layer_type,
         return TiledRasterLayer(layer_type, srdd)
 
     else:
-        time_intervals = time_intervals or []
+        if time_intervals:
+            time_intervals = [time.isoformat() for time in time_intervals]
+        else:
+            time_intervals = []
+
         query_proj = query_proj or ""
 
         if isinstance(query_proj, int):
@@ -415,8 +423,9 @@ def write(uri,
             method used to orginize the saved data. Depending on the type of data within the layer,
             only certain methods are available. Can either be a string or a ``IndexingMethod``
             attribute.  The default method used is, ``IndexingMethod.ZORDER``.
-        time_unit (str, optional): Which time unit should be used when saving spatial-temporal data.
-            While this is set to None as default, it must be set if saving spatial-temporal data.
+        time_unit (str or :class:`~geopyspark.geotrellis.constants.TimeUnit`, optional): Which time
+            unit should be used when saving spatial-temporal data.  While this is set to ``None``
+            as default, it must be set if saving spatial-temporal data.
             Depending on the indexing method chosen, different time units are used.
         options (dict, optional): Additional parameters for writing the layer for specific
             backends. The dictioanry is only used for ``Cassandra`` and ``HBase``, no other backend
@@ -442,5 +451,5 @@ def write(uri,
     else:
         cached.writer.writeTemporal(layer_name,
                                     tiled_raster_layer.srdd,
-                                    time_unit,
+                                    TimeUnit(time_unit).value,
                                     IndexingMethod(index_strategy).value)

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -589,7 +589,7 @@ class TiledRasterLayer(CachableLayer):
     """Wraps a RDD of tiled, GeoTrellis rasters.
 
     Represents a RDD that contains ``(K, V)``. Where ``K`` is either
-    :class:`~geopyspark.geotrellis.SpatialKey` or :class:`~geopyspark.geotrellis.SpaceTimeKey`
+    :class:`~geopyspark.geotrellis.SpatialKey` or :obj:`~geopyspark.geotrellis.SpaceTimeKey`
     depending on the ``layer_type`` of the RDD, and ``V`` being a :ref:`raster`.
 
     The data held within the layer is tiled. This means that the rasters have been modified to fit
@@ -638,7 +638,7 @@ class TiledRasterLayer(CachableLayer):
                 a string.
             numpy_rdd (pyspark.RDD): A PySpark RDD that contains tuples of either
                 :class:`~geopyspark.geotrellis.SpatialKey` or
-                :class:`~geopyspark.geotrellis.SpaceTimeKey` and rasters that are represented by a
+                :obj:`~geopyspark.geotrellis.SpaceTimeKey` and rasters that are represented by a
                 numpy array.
             metadata (:class:`~geopyspark.geotrellis.Metadata`): The ``Metadata`` of
                 the ``TiledRasterLayer`` instance.

--- a/geopyspark/geotrellis/protobufcodecs.py
+++ b/geopyspark/geotrellis/protobufcodecs.py
@@ -1,5 +1,6 @@
 """Contains the various encoding/decoding methods to bring values to/from Python from Scala."""
 from functools import partial
+import datetime
 import numpy as np
 from geopyspark.geopyspark_utils import ensure_pyspark
 ensure_pyspark()
@@ -23,6 +24,13 @@ _mapped_data_types = {
     6: 'FLOAT',
     7: 'DOUBLE'
 }
+
+_EPOCH = datetime.datetime.utcfromtimestamp(0)
+
+
+def _convert_to_unix_time(date_time):
+    return int((date_time - _EPOCH).total_seconds() * 1000)
+
 
 # DECODERS
 
@@ -176,14 +184,16 @@ def from_pb_temporal_projected_extent(pb_temporal_projected_extent):
         :class:`~geopyspark.geotrellis.TemporalProjectedExtent`
     """
 
+    instant = datetime.datetime.utcfromtimestamp(pb_temporal_projected_extent.instant / 1000)
+
     if pb_temporal_projected_extent.crs.epsg is not 0:
         return TemporalProjectedExtent(extent=from_pb_extent(pb_temporal_projected_extent.extent),
                                        epsg=pb_temporal_projected_extent.crs.epsg,
-                                       instant=pb_temporal_projected_extent.instant)
+                                       instant=instant)
     else:
         return TemporalProjectedExtent(extent=from_pb_extent(pb_temporal_projected_extent.extent),
                                        proj4=pb_temporal_projected_extent.crs.proj4,
-                                       instant=pb_temporal_projected_extent.instant)
+                                       instant=instant)
 
 def temporal_projected_extent_decoder(proto_bytes):
     """Deserializes ``ProtoTemporalProjectedExtent`` bytes into Python.
@@ -230,11 +240,11 @@ def from_pb_space_time_key(pb_space_time_key):
         pb_space_time_key (ProtoSpaceTimeKey): An instance of ``ProtoSpaceTimeKey``.
 
     Returns:
-        :class:`~geopyspark.geotrellis.SpaceTimeKey`
+        :obj:`~geopyspark.geotrellis.SpaceTimeKey`
     """
 
     return SpaceTimeKey(col=pb_space_time_key.col, row=pb_space_time_key.row,
-                        instant=pb_space_time_key.instant)
+                        instant=datetime.datetime.utcfromtimestamp(pb_space_time_key.instant / 1000))
 
 def space_time_key_decoder(proto_bytes):
     """Deserializes ``ProtoSpaceTime`` bytes into Python.
@@ -243,7 +253,7 @@ def space_time_key_decoder(proto_bytes):
         proto_bytes (bytes): The ProtoBuf encoded bytes of the ProtoBuf class.
 
     Returns:
-        :class:`~geopyspark.geotrellis.SpaceTimeKey`
+        :obj:`~geopyspark.geotrellis.SpaceTimeKey`
     """
 
     pb_space_time_key = keyMessages_pb2.ProtoSpaceTimeKey.FromString(proto_bytes)
@@ -546,7 +556,7 @@ def to_pb_temporal_projected_extent(obj):
 
     tpex.extent.CopyFrom(ex)
     tpex.crs.CopyFrom(crs)
-    tpex.instant = obj.instant
+    tpex.instant = _convert_to_unix_time(obj.instant)
 
     return tpex
 
@@ -596,7 +606,7 @@ def to_pb_space_time_key(obj):
     """Converts an instance of ``SpaceTimeKey`` to ``ProtoSpaceTimeKey``.
 
     Args:
-        obj (:class:`~geopyspark.geotrellis.SpaceTimeKey`): An instance of ``SpaceTimeKey``.
+        obj (:obj:`~geopyspark.geotrellis.SpaceTimeKey`): An instance of ``SpaceTimeKey``.
 
     Returns:
         ProtoSpaceTimeKey
@@ -606,7 +616,7 @@ def to_pb_space_time_key(obj):
 
     space_time_key.col = obj.col
     space_time_key.row = obj.row
-    space_time_key.instant = obj.instant
+    space_time_key.instant = _convert_to_unix_time(obj.instant)
 
     return space_time_key
 
@@ -614,7 +624,7 @@ def space_time_key_encoder(obj):
     """Encodes a ``SpaceTimeKey`` into ``ProtoSpaceTimeKey`` bytes.
 
     Args:
-        obj (:class:`~geopyspark.geotrellis.SpaceTimeKey`): An instance of ``SpaceTimeKey``.
+        obj (:obj:`~geopyspark.geotrellis.SpaceTimeKey`): An instance of ``SpaceTimeKey``.
 
     Returns:
         bytes

--- a/geopyspark/geotrellis/protobufcodecs.py
+++ b/geopyspark/geotrellis/protobufcodecs.py
@@ -230,7 +230,7 @@ def from_pb_space_time_key(pb_space_time_key):
         pb_space_time_key (ProtoSpaceTimeKey): An instance of ``ProtoSpaceTimeKey``.
 
     Returns:
-        :obj:`~geopyspark.geotrellis.SpaceTimeKey`
+        :class:`~geopyspark.geotrellis.SpaceTimeKey`
     """
 
     return SpaceTimeKey(col=pb_space_time_key.col, row=pb_space_time_key.row,
@@ -243,7 +243,7 @@ def space_time_key_decoder(proto_bytes):
         proto_bytes (bytes): The ProtoBuf encoded bytes of the ProtoBuf class.
 
     Returns:
-        :obj:`~geopyspark.geotrellis.SpaceTimeKey`
+        :class:`~geopyspark.geotrellis.SpaceTimeKey`
     """
 
     pb_space_time_key = keyMessages_pb2.ProtoSpaceTimeKey.FromString(proto_bytes)
@@ -596,7 +596,7 @@ def to_pb_space_time_key(obj):
     """Converts an instance of ``SpaceTimeKey`` to ``ProtoSpaceTimeKey``.
 
     Args:
-        obj (:obj:`~geopyspark.geotrellis.SpaceTimeKey`): An instance of ``SpaceTimeKey``.
+        obj (:class:`~geopyspark.geotrellis.SpaceTimeKey`): An instance of ``SpaceTimeKey``.
 
     Returns:
         ProtoSpaceTimeKey
@@ -614,7 +614,7 @@ def space_time_key_encoder(obj):
     """Encodes a ``SpaceTimeKey`` into ``ProtoSpaceTimeKey`` bytes.
 
     Args:
-        obj (:obj:`~geopyspark.geotrellis.SpaceTimeKey`): An instance of ``SpaceTimeKey``.
+        obj (:class:`~geopyspark.geotrellis.SpaceTimeKey`): An instance of ``SpaceTimeKey``.
 
     Returns:
         bytes

--- a/geopyspark/tests/schema_tests/keys_schema_test.py
+++ b/geopyspark/tests/schema_tests/keys_schema_test.py
@@ -1,8 +1,10 @@
 import unittest
+import datetime
 import pytest
 
 from pyspark import RDD
 from pyspark.serializers import AutoBatchedSerializer
+from geopyspark.geotrellis import SpaceTimeKey
 from geopyspark.geotrellis.protobuf import keyMessages_pb2
 from geopyspark.geotrellis.protobufserializer import ProtoBufSerializer
 from geopyspark.geotrellis.protobufcodecs import (spatial_key_decoder,
@@ -49,10 +51,12 @@ class SpatialKeySchemaTest(BaseTestClass):
 
 
 class SpaceTimeKeySchemaTest(BaseTestClass):
+    time = datetime.datetime.strptime("2016-08-24T09:00:00Z", '%Y-%m-%dT%H:%M:%SZ')
+
     expected_keys = [
-        {'col': 7, 'row': 3, 'instant': 5},
-        {'col': 9, 'row': 4, 'instant': 10},
-        {'col': 11, 'row': 5, 'instant': 15}
+        SpaceTimeKey(7, 3, time)._asdict(),
+        SpaceTimeKey(9, 4, time)._asdict(),
+        SpaceTimeKey(11, 5, time)._asdict(),
     ]
 
     sc = BaseTestClass.pysc._jsc.sc()

--- a/geopyspark/tests/schema_tests/keys_schema_test.py
+++ b/geopyspark/tests/schema_tests/keys_schema_test.py
@@ -10,7 +10,8 @@ from geopyspark.geotrellis.protobufserializer import ProtoBufSerializer
 from geopyspark.geotrellis.protobufcodecs import (spatial_key_decoder,
                                                   spatial_key_encoder,
                                                   space_time_key_decoder,
-                                                  space_time_key_encoder)
+                                                  space_time_key_encoder,
+                                                  _convert_to_unix_time)
 from geopyspark.tests.base_test_class import BaseTestClass
 
 
@@ -87,7 +88,7 @@ class SpaceTimeKeySchemaTest(BaseTestClass):
 
             proto_space_time_key.col = x['col']
             proto_space_time_key.row = x['row']
-            proto_space_time_key.instant = x['instant']
+            proto_space_time_key.instant = _convert_to_unix_time(x['instant'])
 
             actual_encoded.append(proto_space_time_key.SerializeToString())
 
@@ -101,7 +102,7 @@ class SpaceTimeKeySchemaTest(BaseTestClass):
 
             proto_space_time_key.col = x['col']
             proto_space_time_key.row = x['row']
-            proto_space_time_key.instant = x['instant']
+            proto_space_time_key.instant = _convert_to_unix_time(x['instant'])
 
             actual_encoded.append(proto_space_time_key.SerializeToString())
 

--- a/geopyspark/tests/schema_tests/temporal_projected_extent_schema_test.py
+++ b/geopyspark/tests/schema_tests/temporal_projected_extent_schema_test.py
@@ -1,4 +1,5 @@
 import unittest
+import datetime
 import pytest
 
 from pyspark import RDD
@@ -12,10 +13,19 @@ from geopyspark.tests.base_test_class import BaseTestClass
 
 
 class TemporalProjectedExtentSchemaTest(BaseTestClass):
+    extents = [
+        Extent(0.0, 0.0, 1.0, 1.0),
+        Extent(1.0, 2.0, 3.0, 4.0),
+        Extent(5.0, 6.0, 7.0, 8.0),
+    ]
+
+    time = datetime.datetime.strptime("2016-08-24T09:00:00Z", '%Y-%m-%dT%H:%M:%SZ')
+
     expected_tpextents = [
-        {'epsg': 2004, 'extent': {'xmax': 1.0, 'xmin': 0.0, 'ymax': 1.0, 'ymin': 0.0}, 'instant': 0, 'proj4': None},
-        {'epsg': 2004, 'extent': {'xmax': 3.0, 'xmin': 1.0, 'ymax': 4.0, 'ymin': 2.0}, 'instant': 1, 'proj4': None},
-        {'epsg': 2004, 'extent': {'xmax': 7.0, 'xmin': 5.0, 'ymax': 8.0, 'ymin': 6.0}, 'instant': 2, 'proj4': None}]
+        TemporalProjectedExtent(epsg=2004, extent=extents[0], instant=time)._asdict(),
+        TemporalProjectedExtent(epsg=2004, extent=extents[1], instant=time)._asdict(),
+        TemporalProjectedExtent(epsg=2004, extent=extents[2], instant=time)._asdict()
+    ]
 
     sc = BaseTestClass.pysc._jsc.sc()
     ew = BaseTestClass.pysc._jvm.geopyspark.geotrellis.tests.schemas.TemporalProjectedExtentWrapper


### PR DESCRIPTION
This PR makes it so that all parameters that are time components are now expected to be `datetime.datetime` instances. This'll make it easier to work with spatial-temporal data in GeoPySpark

This PR resolves #420 