### PR TITLE
TiledRasterLayer.reproject Bug Fix

### DIFF
--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -891,6 +891,9 @@ class TiledRasterLayer(CachableLayer):
 
         resample_method = ResampleMethod(resample_method)
 
+        if isinstance(target_crs, int):
+            target_crs = str(target_crs)
+
         srdd = self.srdd.reproject(target_crs, resample_method)
 
         return TiledRasterLayer(self.layer_type, srdd)


### PR DESCRIPTION
This PR fixes a bug in `TiledRasterLayer.reproject` where the operation would fail if `target_crs` was an `int`.