### PR TITLE
TiledRasterLayer.tile_to_layout Bug Fix

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialTiledRasterLayer.scala
@@ -92,6 +92,7 @@ class SpatialTiledRasterLayer(
 
   def tileToLayout(
     layoutDefinition: LayoutDefinition,
+    zoom: Option[Int],
     resampleMethod: ResampleMethod
   ): TiledRasterLayer[SpatialKey] = {
     val mapKeyTransform =
@@ -110,7 +111,17 @@ class SpatialTiledRasterLayer(
     val tileLayer =
       MultibandTileLayerRDD(projectedRDD.tileToLayout(retiledLayerMetadata, resampleMethod), retiledLayerMetadata)
 
-    SpatialTiledRasterLayer(None, tileLayer)
+    SpatialTiledRasterLayer(zoom, tileLayer)
+  }
+
+  def tileToLayout(
+    layoutType: LayoutType,
+    resampleMethod: ResampleMethod
+  ): TiledRasterLayer[SpatialKey] = {
+    val (layoutDefinition, zoom) =
+      layoutType.layoutDefinitionWithZoom(rdd.metadata.crs, rdd.metadata.extent, rdd.metadata.cellSize)
+
+    tileToLayout(layoutDefinition, zoom, resampleMethod)
   }
 
   def pyramid(resampleMethod: ResampleMethod): Array[TiledRasterLayer[SpatialKey]] = {

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
@@ -123,6 +123,7 @@ class TemporalTiledRasterLayer(
 
   def tileToLayout(
     layoutDefinition: LayoutDefinition,
+    zoom: Option[Int],
     resampleMethod: ResampleMethod
   ): TiledRasterLayer[SpaceTimeKey] = {
     val mapKeyTransform =
@@ -150,7 +151,17 @@ class TemporalTiledRasterLayer(
     val tileLayer =
       MultibandTileLayerRDD(temporalRDD.tileToLayout(retiledLayerMetadata, resampleMethod), retiledLayerMetadata)
 
-    TemporalTiledRasterLayer(None, tileLayer)
+    TemporalTiledRasterLayer(zoom, tileLayer)
+  }
+
+  def tileToLayout(
+    layoutType: LayoutType,
+    resampleMethod: ResampleMethod
+  ): TiledRasterLayer[SpaceTimeKey] = {
+    val (layoutDefinition, zoom) =
+      layoutType.layoutDefinitionWithZoom(rdd.metadata.crs, rdd.metadata.extent, rdd.metadata.cellSize)
+
+    tileToLayout(layoutDefinition, zoom, resampleMethod)
   }
 
   def pyramid(resampleMethod: ResampleMethod): Array[TiledRasterLayer[SpaceTimeKey]] = {

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
@@ -93,21 +93,21 @@ abstract class TiledRasterLayer[K: SpatialComponent: JsonFormat: ClassTag] exten
   def reproject(targetCRS: String, layoutDefinition: LayoutDefinition, resampleMethod: ResampleMethod): TiledRasterLayer[K]
 
   def tileToLayout(
-    layOutDefinition: LayoutDefinition,
+    layoutDefinition: LayoutDefinition,
     resampleMethod: ResampleMethod
-  ): TiledRasterLayer[K]
+  ): TiledRasterLayer[K] =
+    tileToLayout(layoutDefinition, None, resampleMethod)
 
   def tileToLayout(
     layoutType: LayoutType,
     resampleMethod: ResampleMethod
-  ): TiledRasterLayer[K] =
-    tileToLayout(
-      layoutType.layoutDefinition(
-        rdd.metadata.crs,
-        rdd.metadata.extent,
-        rdd.metadata.cellSize),
-      resampleMethod
-    )
+  ): TiledRasterLayer[K]
+
+  def tileToLayout(
+    layOutDefinition: LayoutDefinition,
+    zoom: Option[Int],
+    resampleMethod: ResampleMethod
+  ): TiledRasterLayer[K]
 
   def pyramid(resampleMethod: ResampleMethod): Array[_] // Array[TiledRasterLayer[K]]
 

--- a/geopyspark/tests/tiled_layer_tests/tiled_raster_layer_test.py
+++ b/geopyspark/tests/tiled_layer_tests/tiled_raster_layer_test.py
@@ -37,6 +37,11 @@ class TiledRasterLayerTest(BaseTestClass):
 
         self.assertDictEqual(actual.to_dict(), expected.to_dict())
 
+    def test_tile_to_layout_global_layout(self):
+        actual = self.tiled_layer.tile_to_layout(layout=GlobalLayout(zoom=5))
+
+        self.assertEqual(actual.zoom_level, 5)
+
     def test_tile_to_layout_with_reproject(self):
         proj4 = crs_to_proj4(3857)
         actual = self.result.tile_to_layout(layout=GlobalLayout(), target_crs=proj4).layer_metadata.crs


### PR DESCRIPTION
This PR fixes a bug where the `TiledRasterLayer.tile_to_layout` method would always return a new layer with a `zoom_level` of `None` regardless of the layout given. Now, the new layer will keep the given/produced `zoom_level` when the layout is either a `LocalLayout` or `GlobalLayout`.