### PR TITLE
AttributeStore

### DIFF
--- a/geopyspark-backend/geotrellis/build.sbt
+++ b/geopyspark-backend/geotrellis/build.sbt
@@ -11,7 +11,7 @@ libraryDependencies ++= Seq(
   "org.locationtech.geotrellis" %% "geotrellis-cassandra"  % Version.geotrellis,
   "org.locationtech.geotrellis" %% "geotrellis-hbase"      % Version.geotrellis,
   "org.locationtech.geotrellis" %% "geotrellis-s3"         % Version.geotrellis,
-  "org.locationtech.geotrellis" %% "geotrellis-s3-testkit" % "1.0.0",
+  "org.locationtech.geotrellis" %% "geotrellis-s3-testkit" % Version.geotrellis,
   "org.locationtech.geotrellis" %% "geotrellis-spark"      % Version.geotrellis,
   "org.typelevel"               %% "cats"                  % "0.9.0",
   "com.typesafe.akka"     %% "akka-actor"                        % Version.akka,

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Json.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Json.scala
@@ -17,10 +17,10 @@ object Json {
 
   def readHistogram(hist: String): Histogram[_] = {
     val json = hist.parseJson
-    json.asJsObject.getFields("maxBucketCount") match {
-      case Seq(JsNumber(maxBucketCount)) =>
+    json match {
+      case js: JsObject =>
         json.convertTo[Histogram[Double]]
-      case Seq() =>
+      case js: JsArray =>
         json.convertTo[Histogram[Int]]
     }
   }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Json.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Json.scala
@@ -1,0 +1,27 @@
+package geopyspark.geotrellis
+
+import geotrellis.raster.histogram._
+import geotrellis.raster.io._
+import spray.json._
+
+object Json {
+
+  def writeHistogram(hist: Histogram[_]): String = hist match {
+    case h: FastMapHistogram =>
+      h.asInstanceOf[Histogram[Int]].toJson.compactPrint
+    case h: StreamingHistogram =>
+      h.asInstanceOf[Histogram[Double]].toJson.compactPrint
+    case _ =>
+      throw new IllegalArgumentException(s"Unable to write $hist as JSON.")
+  }
+
+  def readHistogram(hist: String): Histogram[_] = {
+    val json = hist.parseJson
+    json.asJsObject.getFields("maxBucketCount") match {
+      case Seq(JsNumber(maxBucketCount)) =>
+        json.convertTo[Histogram[Double]]
+      case Seq() =>
+        json.convertTo[Histogram[Int]]
+    }
+  }
+}

--- a/geopyspark/__init__.py
+++ b/geopyspark/__init__.py
@@ -1,7 +1,7 @@
 import os
 import glob
 from pkg_resources import resource_filename
-
+from py4j.java_gateway import JavaClass
 from geopyspark.geopyspark_utils import ensure_pyspark
 ensure_pyspark()
 
@@ -16,6 +16,12 @@ def get_spark_context():
         return SparkContext._active_spark_context
     else:
         raise RuntimeError("SparkContext must be initialized")
+
+
+def scala_companion(class_name, gateway_client=None):
+    """Returns referece to Scala companion object"""
+    gateway_client = gateway_client or get_spark_context()._gateway._gateway_client
+    return JavaClass(class_name + "$", gateway_client).__getattr__("MODULE$")
 
 
 def map_key_input(key_type, is_boundable):

--- a/geopyspark/__init__.py
+++ b/geopyspark/__init__.py
@@ -1,14 +1,13 @@
 import os
 import glob
 from pkg_resources import resource_filename
-from py4j.java_gateway import JavaClass
 from geopyspark.geopyspark_utils import ensure_pyspark
 ensure_pyspark()
 
 from geopyspark.geopyspark_constants import JAR
-
 from pyspark import RDD, SparkConf, SparkContext
 from pyspark.serializers import AutoBatchedSerializer
+from py4j.java_gateway import JavaClass
 
 
 def get_spark_context():

--- a/geopyspark/geotrellis/histogram.py
+++ b/geopyspark/geotrellis/histogram.py
@@ -27,10 +27,10 @@ class Histogram(object):
         self.scala_histogram = scala_histogram
 
     @classmethod
-    def from_dict(cls, d):
+    def from_dict(cls, value):
         """Encodes histogram as a dictionary"""
         pysc = get_spark_context()
-        histogram_json = json.dumps(d)
+        histogram_json = json.dumps(value)
         scala_histogram = pysc._gateway.jvm.geopyspark.geotrellis.Json.readHistogram(histogram_json)
         return cls(scala_histogram)
 
@@ -186,7 +186,11 @@ class Histogram(object):
         return Histogram(self.scala_histogram.merge(other_histogram.scala_histogram))
 
     def to_dict(self):
-        """Encodes histogram as a dictionary"""
+        """Encodes histogram as a dictionary
+
+        Returns:
+           ``dict``
+        """
 
         pysc = get_spark_context()
         histogram_json = pysc._gateway.jvm.geopyspark.geotrellis.Json.writeHistogram(self.scala_histogram)

--- a/geopyspark/geotrellis/histogram.py
+++ b/geopyspark/geotrellis/histogram.py
@@ -2,8 +2,8 @@
 class.
 """
 
-from geopyspark import get_spark_context
 import json
+from geopyspark import get_spark_context
 
 __all__ = ['Histogram']
 

--- a/geopyspark/geotrellis/histogram.py
+++ b/geopyspark/geotrellis/histogram.py
@@ -2,6 +2,8 @@
 class.
 """
 
+from geopyspark import get_spark_context
+import json
 
 __all__ = ['Histogram']
 
@@ -23,6 +25,14 @@ class Histogram(object):
 
     def __init__(self, scala_histogram):
         self.scala_histogram = scala_histogram
+
+    @classmethod
+    def from_dict(cls, d):
+        """Encodes histogram as a dictionary"""
+        pysc = get_spark_context()
+        histogram_json = json.dumps(d)
+        scala_histogram = pysc._gateway.jvm.geopyspark.geotrellis.Json.readHistogram(histogram_json)
+        return cls(scala_histogram)
 
     def min(self):
         """The smallest value of the histogram.
@@ -174,3 +184,10 @@ class Histogram(object):
         """
 
         return Histogram(self.scala_histogram.merge(other_histogram.scala_histogram))
+
+    def to_dict(self):
+        """Encodes histogram as a dictionary"""
+
+        pysc = get_spark_context()
+        histogram_json = pysc._gateway.jvm.geopyspark.geotrellis.Json.writeHistogram(self.scala_histogram)
+        return json.loads(histogram_json)

--- a/geopyspark/tests/io_tests/catalog_test.py
+++ b/geopyspark/tests/io_tests/catalog_test.py
@@ -5,7 +5,7 @@ import pytest
 from shapely.geometry import box
 
 from geopyspark.geotrellis import Extent, SpatialKey, GlobalLayout
-from geopyspark.geotrellis.catalog import read, read_value, query, read_layer_metadata, get_layer_ids
+from geopyspark.geotrellis.catalog import read, read_value, query, read_layer_metadata, get_layer_ids, AttributeStore
 from geopyspark.geotrellis.constants import LayerType
 from geopyspark.geotrellis.geotiff import get
 from geopyspark.tests.base_test_class import BaseTestClass
@@ -159,6 +159,19 @@ class CatalogTest(BaseTestClass):
 
         self.assertTrue(len(ids) == 11)
 
+    def test_attributestore(self):
+        store = AttributeStore(self.uri)
+        layer_name = "boop-epsg-bop"
+        value = {"first": 113, "second": "44two"}
+        store.layer(layer_name, 34).write("val", value)
+        self.assertEqual(value,
+                         store.layer(layer_name, 34).read("val"))
+
+        self.assertEqual(value,
+                         store.layer(layer_name, 34)["val"])
+        store.layer(layer_name, 34).delete("val")
+        with pytest.raises(KeyError):
+            store.layer(layer_name, 34)["val"]
 
 if __name__ == "__main__":
     unittest.main()

--- a/geopyspark/tests/io_tests/s3_geotiff_rdd_test.py
+++ b/geopyspark/tests/io_tests/s3_geotiff_rdd_test.py
@@ -74,6 +74,11 @@ class Multiband(S3GeoTiffIOTest, BaseTestClass):
         rasterio_tiles = self.read_geotiff_rasterio([self.file_path], False)
 
         for x, y in zip(geotrellis_tiles, rasterio_tiles):
+            print("x.cells type: ", type(x.cells))
+            print(x.cells)
+            print("y['cells] type:", type(y['cells']))
+            print(y['cells'])
+            print("result:", (x.cells == y['cells']))
             self.assertTrue((x.cells == y['cells']).all())
 
     def windowed_result_checker(self, windowed_tiles):

--- a/geopyspark/tests/io_tests/s3_geotiff_rdd_test.py
+++ b/geopyspark/tests/io_tests/s3_geotiff_rdd_test.py
@@ -11,6 +11,15 @@ from geopyspark.tests.base_test_class import BaseTestClass
 
 
 class S3GeoTiffIOTest(object):
+    def assertTilesEqual(self, a, b):
+        """compare two numpy arrays that are tiles"""
+        self.assertEqual(a.shape, b.shape)
+        cmp = (a == b)  # result must be array of matching cells
+        diff = np.argwhere(cmp == False)
+        if np.size(diff) > 0:
+            raise Exception("Tiles differ at: ", diff)
+        return True
+
     def get_filepaths(self, dir_path):
         files = []
 
@@ -81,7 +90,7 @@ class Multiband(S3GeoTiffIOTest, BaseTestClass):
             print('\n')
             print('This is read in from geotrellis', x.cells.shape)
             print('This is read in from rasterio', y['cells'].shape)
-            self.assertTrue(np.array_equal(x.cells, y['cells']))
+            self.assertTilesEqual(x.cells, y['cells'])
 
     def windowed_result_checker(self, windowed_tiles):
         self.assertEqual(len(windowed_tiles), 4)

--- a/geopyspark/tests/io_tests/s3_geotiff_rdd_test.py
+++ b/geopyspark/tests/io_tests/s3_geotiff_rdd_test.py
@@ -17,7 +17,7 @@ class S3GeoTiffIOTest(object):
         cmp = (a == b)  # result must be array of matching cells
         diff = np.argwhere(cmp == False)
         if np.size(diff) > 0:
-            raise Exception("Tiles differ at: ", diff)
+            raise Exception("Tiles differ at: ", np.size(diff), diff)
         return True
 
     def get_filepaths(self, dir_path):

--- a/geopyspark/tests/tiled_layer_tests/histogram_test.py
+++ b/geopyspark/tests/tiled_layer_tests/histogram_test.py
@@ -2,7 +2,7 @@ import unittest
 import pytest
 import numpy as np
 
-from geopyspark.geotrellis import SpatialKey, Tile
+from geopyspark.geotrellis import SpatialKey, Tile, Histogram
 from geopyspark.geotrellis.constants import LayerType
 from geopyspark.geotrellis.layer import TiledRasterLayer
 from geopyspark.tests.base_test_class import BaseTestClass
@@ -123,6 +123,14 @@ class HistogramTest(BaseTestClass):
 
         self.assertEqual(merged.values(), [1.0, 2.0, 3.0, 4.0])
         self.assertEqual(merged.mean(), 1.75)
+
+    def test_dict_methods(self):
+        dict_hist = self.hist.to_dict()
+        # value produced by histogram of doubles
+        self.assertEqual(dict_hist['maxBucketCount'], 80)
+
+        rebuilt_hist = Histogram.from_dict(dict_hist)
+        self.assertEqual(self.hist.min_max(), rebuilt_hist.min_max())
 
 
 if __name__ == "__main__":

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,2 @@
 [metadata]
 license_file = LICENSE
-
-[flake8]
-ignore = E501
-max-line-length = 160

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [metadata]
 license_file = LICENSE
+
+[flake8]
+ignore = E501
+max-line-length = 160


### PR DESCRIPTION
Exposes AttributeStore as an object in geopyspark.
Because it is so central to many GeoTrellis operations it was given a class rather than just read/write methods.

Because we can't really keep track of what type the objects are, all reading and writing is done on `dict` values.

Motivating use case is saving and reading histograms:
```py
In [1]: import geopyspark as gps

In [2]: store = gps.geotrellis.catalog.AttributeStore("s3://azavea-datahub/catalog")

In [3]: store.layer("us-pennsylvania-philadelphia-nlcd2011-landcover-30m-epsg3857",7).read("histogram")
Out[3]:
[[95, 43],
 [90, 133],
 [82, 14],
 [81, 51],
 [71, 5],
 [52, 33],
 [43, 31],
 [42, 2],
 [41, 394],
 [31, 12],
 [24, 623],
 [23, 952],
 [22, 892],
 [21, 979],
 [11, 188]]

In [4]: gps.Histogram.from_dict(Out[3])
Out[4]: <geopyspark.geotrellis.histogram.Histogram at 0x109ffd400>

In [5]: gps.Histogram.from_dict(Out[3]).min_max()
Out[5]: (11, 95)
```