### PR TITLE
Improved TiledRasterLayer.normalize Method

### DIFF
--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -1198,20 +1198,33 @@ class TiledRasterLayer(CachableLayer):
         min_max = self.srdd.getMinMax()
         return (min_max._1(), min_max._2())
 
-    def normalize(self, old_min, old_max, new_min, new_max):
+    def normalize(self, new_min, new_max, old_min=None, old_max=None):
         """Finds the min value that is contained within the given geometry.
 
+        Note:
+            If ``old_max - old_min <= 0`` or ``new_max - new_min <= 0``, then the normalization
+            will fail.
+
         Args:
-            old_min (float): Old minimum.
-            old_max (float): Old maximum.
-            new_min (float): New minimum to normalize to.
-            new_max (float): New maximum to normalize to.
+            old_min (int or float, optional): Old minimum. If not given, then the minimum value
+                of this layer will be used.
+            old_max (int or float, optional): Old maximum. If not given, then the minimum value
+                of this layer will be used.
+            new_min (int or float): New minimum to normalize to.
+            new_max (int or float): New maximum to normalize to.
 
         Returns:
             :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
         """
 
-        srdd = self.srdd.normalize(old_min, old_max, new_min, new_max)
+        if not old_min and not old_max:
+            old_min, old_max = self.get_min_max()
+        elif not old_min:
+            old_min = self.get_min_max()[0]
+        elif not old_max:
+            old_max = self.get_min_max()[1]
+
+        srdd = self.srdd.normalize(float(old_min), float(old_max), float(new_min), float(new_max))
 
         return TiledRasterLayer(self.layer_type, srdd)
 

--- a/geopyspark/tests/tiled_layer_tests/normalize_test.py
+++ b/geopyspark/tests/tiled_layer_tests/normalize_test.py
@@ -1,0 +1,69 @@
+import os
+import unittest
+import numpy as np
+
+import pytest
+
+from geopyspark.geotrellis import SpatialKey, Tile
+from geopyspark.tests.base_test_class import BaseTestClass
+from geopyspark.geotrellis.layer import TiledRasterLayer
+from geopyspark.geotrellis.constants import LayerType
+
+
+class NormalizeTest(BaseTestClass):
+    cells = np.array([[
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0, 0.0]]])
+
+    layer = [(SpatialKey(0, 0), Tile(cells + 0, 'FLOAT', -1.0)),
+             (SpatialKey(1, 0), Tile(cells + 1, 'FLOAT', -1.0,)),
+             (SpatialKey(0, 1), Tile(cells + 2, 'FLOAT', -1.0,)),
+             (SpatialKey(1, 1), Tile(cells + 3, 'FLOAT', -1.0,))]
+
+    rdd = BaseTestClass.pysc.parallelize(layer)
+
+    extent = {'xmin': 0.0, 'ymin': 0.0, 'xmax': 33.0, 'ymax': 33.0}
+    layout = {'layoutCols': 2, 'layoutRows': 2, 'tileCols': 5, 'tileRows': 5}
+    metadata = {'cellType': 'float32ud-1.0',
+                'extent': extent,
+                'crs': '+proj=longlat +datum=WGS84 +no_defs ',
+                'bounds': {
+                    'minKey': {'col': 0, 'row': 0},
+                    'maxKey': {'col': 1, 'row': 1}},
+                'layoutDefinition': {
+                    'extent': extent,
+                    'tileLayout': {'tileCols': 5, 'tileRows': 5, 'layoutCols': 2, 'layoutRows': 2}}}
+
+    raster_rdd = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, metadata)
+
+    @pytest.fixture(autouse=True)
+    def tearDown(self):
+        yield
+        BaseTestClass.pysc._gateway.close()
+
+    def test_normalize_all_parameters(self):
+        normalized = self.raster_rdd.normalize(old_min=0.0, old_max=4.0, new_min=5.0, new_max=10.0)
+
+        self.assertEqual(normalized.get_min_max(), (5.0, 10.0))
+
+    def test_normalize_no_optinal_parameters(self):
+        normalized = self.raster_rdd.normalize(new_min=5.0, new_max=10.0)
+
+        self.assertEqual(normalized.get_min_max(), (5.0, 10.0))
+
+    def test_normalize_old_min(self):
+        normalized = self.raster_rdd.normalize(old_min=-1, new_min=5.0, new_max=10.0)
+
+        self.assertEqual(normalized.get_min_max(), (6.0, 10.0))
+
+    def test_normalize_old_max(self):
+        normalized = self.raster_rdd.normalize(old_max=5.0, new_min=5.0, new_max=10.0)
+
+        self.assertEqual(normalized.get_min_max(), (5.0, 9.0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR improves the `TiledRasterLayer.normalize` method by making `old_min` and `old_max` optional. In addition, the parameters can now be either `int`s or `float`s. Tests for `TiledRasterLayer.normalize` have also been added.