### PR TITLE
Refactored the saveStitched Method

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialTiledRasterLayer.scala
@@ -192,36 +192,36 @@ class SpatialTiledRasterLayer(
     PythonTranslator.toPython[Tile, ProtoTile](contextRDD.stitch.tile)
   }
 
-  def save_stitched(path: String): Unit =
-    _save_stitched(path, None, None)
+  def saveStitched(path: String): Unit =
+    saveStitched(path, None, None)
 
-  def save_stitched(path: String, cropBounds: ArrayList[Double]): Unit =
-    _save_stitched(path, Some(cropBounds), None)
+  def saveStitched(path: String, cropBounds: java.util.Map[String, Double]): Unit =
+    saveStitched(path, Some(cropBounds), None)
 
-  def save_stitched(path: String, cropBounds: ArrayList[Double], cropDimensions: ArrayList[Int]): Unit =
-    _save_stitched(path, Some(cropBounds), Some(cropDimensions))
+  def saveStitched(
+    path: String,
+    cropBounds: java.util.Map[String, Double],
+    cropDimensions: ArrayList[Int]
+  ): Unit =
+    saveStitched(path, Some(cropBounds), Some(cropDimensions))
 
-  private def _save_stitched(path: String, cropBounds: Option[ArrayList[Double]], cropDimensions: Option[ArrayList[Int]]): Unit = {
-
+  def saveStitched(
+    path: String,
+    cropBounds: Option[java.util.Map[String, Double]],
+    cropDimensions: Option[ArrayList[Int]]
+  ): Unit = {
     val contextRDD = ContextRDD(
       rdd.map({ case (k, v) => (k, v.band(0)) }),
       rdd.metadata
     )
+
     val stitched: Raster[Tile] = contextRDD.stitch()
 
     val adjusted = {
-      val cropExtent =
-        cropBounds.map { b =>
-          val bounds = b.asScala.toArray
-          Extent(bounds(0), bounds(1), bounds(2), bounds(3))
-        }
-
       val cropped =
-        cropExtent match {
-          case Some(extent) =>
-            stitched.crop(extent)
-          case None =>
-            stitched
+        cropBounds match {
+          case Some(extent) => stitched.crop(extent.toExtent)
+          case None => stitched
         }
 
       val resampled =

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -1112,12 +1112,19 @@ class TiledRasterLayer(CachableLayer):
         """Stitch all of the rasters within the Layer into one raster.
 
         Args:
-            path (str): The path of the geotiff to save.
-            crop_bounds (list, optional): bounds with which to crop the raster before saving.
-            crop_dimensions (list, optional): cols and rows of the image to save
+            path (str): The path of the geotiff to save. The path must be on the local file system.
+            crop_bounds (:class:`~geopyspark.geotrellis.Extent`, optional): The sub ``Extent`` with
+                which to crop the raster before saving. If ``None``, then the whole raster will be
+                saved.
+            crop_dimensions (tuple(int) or list(int), optional): cols and rows of the image to save
+                represented as either a tuple or list. If ``None`` then all cols and rows of the
+                raster will be save.
 
         Note:
             This can only be used on ``LayerType.SPATIAL`` ``TiledRasterLayer``\s.
+
+        Note:
+            If ``crop_dimensions`` is set then ``crop_bounds`` must also be set.
         """
 
         if self.layer_type != LayerType.SPATIAL:
@@ -1125,13 +1132,13 @@ class TiledRasterLayer(CachableLayer):
 
         if crop_bounds:
             if crop_dimensions:
-                self.srdd.save_stitched(path, list(crop_bounds), list(crop_dimensions))
+                self.srdd.saveStitched(path, crop_bounds._asdict(), list(crop_dimensions))
             else:
-                self.srdd.save_stitched(path, list(crop_bounds))
+                self.srdd.saveStitched(path, crop_bounds._asdict())
         elif crop_dimensions:
             raise Exception("crop_dimensions requires crop_bounds")
         else:
-            self.srdd.save_stitched(path)
+            self.srdd.saveStitched(path)
 
     def mask(self, geometries):
         """Masks the ``TiledRasterLayer`` so that only values that intersect the geometries will


### PR DESCRIPTION
This PR refactors the `saveStitched` method so that it is easier to use. This was done mainly by changing one of the parameters to be an `Extent`, simplifying the code, and renaming certain methods.