### PR TITLE
Updated Version Numbers to RC-4

### DIFF
--- a/geopyspark/command/configuration.py
+++ b/geopyspark/command/configuration.py
@@ -10,7 +10,7 @@ import argparse
 from geopyspark.geopyspark_constants import JAR, CWD
 
 
-JAR_URL = 'https://github.com/locationtech-labs/geopyspark/releases/download/v0.2.0-RC3/' + JAR
+JAR_URL = 'https://github.com/locationtech-labs/geopyspark/releases/download/v0.2.0-RC4/' + JAR
 DEFAULT_JAR_PATH = path.join(CWD, 'jars')
 CONF = path.join(CWD, 'command', 'geopyspark.conf')
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if sys.version_info < (3, 3):
 
 setup_args = dict(
     name='geopyspark',
-    version='0.2.0-RC3',
+    version='0.2.0-RC4',
     author='Jacob Bouffard, James McClain',
     author_email='jbouffard@azavea.com, jmcclain@azavea.com',
     download_url='http://github.com/locationtech-labs/geopyspark',


### PR DESCRIPTION
This PR updates the version numbers of GeoPySpark to RC-4.