### PR TITLE
Fixed no_data_value Logic Error

### DIFF
--- a/geopyspark/geotrellis/protobufcodecs.py
+++ b/geopyspark/geotrellis/protobufcodecs.py
@@ -373,7 +373,7 @@ def to_pb_tile(obj):
     tile.cols = cols
     tile.rows = rows
 
-    if obj.no_data_value:
+    if obj.no_data_value is not None and obj.no_data_value is not False:
         cell_type.hasNoData = True
         cell_type.nd = obj.no_data_value
     else:


### PR DESCRIPTION
This PR fixes a bug that occurs when creating a layer from a numpy `RDD` where the `Tile`s have a `no_data_value` of 0. The source of this bug is found on this [line](https://github.com/locationtech-labs/geopyspark/blob/master/geopyspark/geotrellis/protobufcodecs.py#L376). That line is the source because `if 0` returns `False` in Python. Therefore, the check needed to be changed.

This PR resolves #432   