### PR TITLE
Fixed SpatialKeys in Metadata

### DIFF
--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -505,8 +505,14 @@ class Metadata(object):
             min_key = SpatialKey(**bounds_dict['minKey'])
             max_key = SpatialKey(**bounds_dict['maxKey'])
         else:
-            min_key = SpaceTimeKey(**bounds_dict['minKey'])
-            max_key = SpaceTimeKey(**bounds_dict['maxKey'])
+            scala_min_key = bounds_dict['minKey']
+            scala_max_key = bounds_dict['maxKey']
+
+            scala_min_key['instant'] = datetime.datetime.utcfromtimestamp(scala_min_key['instant'] / 1000)
+            scala_max_key['instant'] = datetime.datetime.utcfromtimestamp(scala_max_key['instant'] / 1000)
+
+            min_key = SpaceTimeKey(**scala_min_key)
+            max_key = SpaceTimeKey(**scala_max_key)
 
         bounds = Bounds(min_key, max_key)
         extent = Extent(**metadata_dict['extent'])

--- a/geopyspark/tests/to_spatial_test.py
+++ b/geopyspark/tests/to_spatial_test.py
@@ -63,6 +63,16 @@ class ToSpatialLayerTest(BaseTestClass):
         yield
         BaseTestClass.pysc._gateway.close()
 
+    # This test should be moved to a more appropriate file once more spatial-temporal
+    # tests are made.
+    def test_spatial_metadata(self):
+        metadata = self.raster_rdd.collect_metadata()
+        min_key = metadata.bounds.minKey
+        max_key = metadata.bounds.maxKey
+
+        self.assertEqual(min_key.instant, self.time)
+        self.assertEqual(max_key.instant, self.time)
+
     def test_to_spatial_raster_layer(self):
         actual = [k for k, v in self.raster_rdd.to_spatial_layer().to_numpy_rdd().collect()]
 


### PR DESCRIPTION
This PR fixes the returned `SpatialKey`s in `Metadata` so that `instant` is now a `datetime.datetime` instance instead of an `int`.