### PR TITLE
Serve TMS catalogs from any GT-supported back end

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tms/TileReader.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tms/TileReader.scala
@@ -158,7 +158,6 @@ object TileReaders {
   def createCatalogReader(uriString: String, layerName: String): TileReader = {
     val uri = new java.net.URI(uriString)
 
-    val attribStore = AttributeStore(uri)
     val valueReader = ValueReader(uri)
 
     new CatalogTileReader(valueReader, layerName)

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tms/TileReader.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tms/TileReader.scala
@@ -158,14 +158,8 @@ object TileReaders {
   def createCatalogReader(uriString: String, layerName: String): TileReader = {
     val uri = new java.net.URI(uriString)
 
-    // TODO: extend to other backends when SPI facilities are available for ValueReader construction
-
-    if (uri.getScheme != "s3") {
-      throw new IllegalArgumentException("Only S3 URIs are supported at this time")
-    }
-
     val attribStore = AttributeStore(uri)
-    val valueReader = new s3.S3ValueReader(attribStore)
+    val valueReader = ValueReader(uri)
 
     new CatalogTileReader(valueReader, layerName)
   }


### PR DESCRIPTION
With the addition of locationtech/geotrellis#2286, we can now display catalogs from any supported backend specified by a URI through a TMS server.  This PR extends the `TMS.build` method to allow for arbitrary URIs.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>