### PR TITLE
query and read_value Fix For Spatial-Temporal Data

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/ValueReaderFactory.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/ValueReaderFactory.scala
@@ -19,7 +19,7 @@ import org.apache.spark._
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.rdd.RDD
 
-import java.time.Instant
+import java.time.ZonedDateTime
 import java.util.ArrayList
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -38,55 +38,36 @@ abstract class ValueReaderWrapper() {
     attributeStore.readHeader[LayerHeader](id).valueClass
 
   def readTile(
+    keyType: String,
     layerName: String,
     zoom: Int,
     col: Int,
     row: Int,
-    zdt: Long
-  ): Array[Byte] =
-    readTile(layerName, zoom, col, row, Some(zdt))
-
-  def readTile(
-    layerName: String,
-    zoom: Int,
-    col: Int,
-    row: Int
-  ): Array[Byte] =
-    readTile(layerName, zoom, col, row, None)
-
-  def readTile(
-    layerName: String,
-    zoom: Int,
-    col: Int,
-    row: Int,
-    zdt: Option[Long]
+    zdt: String
   ): Array[Byte] = {
     val id = LayerId(layerName, zoom)
-    val valueClass: String = getValueClass(id)
+    val valueClass = getValueClass(id)
 
-    (zdt, valueClass) match {
-      case (None, "geotrellis.raster.Tile") => {
+    (keyType, valueClass) match {
+      case ("SpatialKey", "geotrellis.raster.Tile") => {
         val spatialKey = SpatialKey(col, row)
         val result = valueReader.reader[SpatialKey, Tile](id).read(spatialKey)
         PythonTranslator.toPython[MultibandTile, ProtoMultibandTile](MultibandTile(result))
       }
-      case (None, "geotrellis.raster.MultibandTile") => {
+      case ("SpatialKey", "geotrellis.raster.MultibandTile") => {
         val spatialKey = SpatialKey(col, row)
         val result = valueReader.reader[SpatialKey, MultibandTile](id).read(spatialKey)
         PythonTranslator.toPython[MultibandTile, ProtoMultibandTile](result)
       }
-      case (Some(instant), "geotrellis.raster.Tile") => {
-        val spaceKey = SpaceTimeKey(col, row, instant)
+      case ("SpaceTimeKey", "geotrellis.raster.Tile") => {
+        val spaceKey = SpaceTimeKey(col, row, ZonedDateTime.parse(zdt))
         val result = valueReader.reader[SpaceTimeKey, Tile](id).read(spaceKey)
         PythonTranslator.toPython[MultibandTile, ProtoMultibandTile](MultibandTile(result))
       }
-      case (Some(instant), "geotrellis.raster.MultibandTile") => {
-        val spaceKey = SpaceTimeKey(col, row, instant)
+      case ("SpaceTimeKey", "geotrellis.raster.MultibandTile") => {
+        val spaceKey = SpaceTimeKey(col, row, ZonedDateTime.parse(zdt))
         val result = valueReader.reader[SpaceTimeKey, MultibandTile](id).read(spaceKey)
         PythonTranslator.toPython[MultibandTile, ProtoMultibandTile](result)
-      }
-      case (_, _) => {
-        throw new Exception("Could not retrieve the tile.")
       }
     }
   }

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 from shapely.geometry import Polygon, MultiPolygon, Point
 from shapely.wkt import dumps
 import shapely.wkb
+import pytz
 
 from geopyspark import map_key_input, get_spark_context, scala_companion
 from geopyspark.geotrellis.constants import LayerType, IndexingMethod, TimeUnit
@@ -268,7 +269,7 @@ def read_value(layer_type,
         options = options or kwargs or {}
 
         if zdt:
-            zdt = zdt.isoformat() + 'Z'
+            zdt = zdt.astimezone(pytz.utc).isoformat()
         else:
             zdt = ''
 
@@ -369,7 +370,7 @@ def query(layer_type,
 
     else:
         if time_intervals:
-            time_intervals = [time.isoformat() + "Z" for time in time_intervals]
+            time_intervals = [time.astimezone(pytz.utc).isoformat() for time in time_intervals]
         else:
             time_intervals = []
 

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -365,14 +365,14 @@ def query(layer_type,
 
     else:
         if time_intervals:
-            time_intervals = [time.isoformat() for time in time_intervals]
+            time_intervals = [time.isoformat() + "Z" for time in time_intervals]
         else:
             time_intervals = []
 
         query_proj = query_proj or ""
 
         if isinstance(query_proj, int):
-            query_proj = "EPSG:{}".format(query_proj)
+            query_proj = str(query_proj)
 
         if isinstance(query_geom, (Polygon, MultiPolygon, Point)):
             srdd = cached.reader.query(key,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ shapely>=1.6b3
 rasterio>=1.0a7
 setuptools
 protobuf>=3.3.0
+pytz

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup_args = dict(
         'protobuf>=3.3.0',
         'numpy>=1.8',
         'shapely>=1.6b3',
+        'pytz'
     ],
     packages=[
         'geopyspark',


### PR DESCRIPTION
This PR fixes a bug present in the `query` and `read_value` functions. This bug appeared when the user tries to work with spatial-temporal data. The cause of this issue was that the ISO strings sent from Python were not properly formatted.