### PR TITLE
Implement multi-value lookup on RDD

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tms/MultiValueRDDFunctions.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tms/MultiValueRDDFunctions.scala
@@ -1,0 +1,35 @@
+package geopyspark.geotrellis.tms
+
+import org.apache.spark._
+import org.apache.spark.rdd._
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect._
+
+class MultiValueRDDFunctions[K, V](self: RDD[(K, V)])
+  (implicit kt: ClassTag[K], vt: ClassTag[V], ord: Ordering[K] = null)
+    extends Serializable {
+
+  /**
+   * Return the list of values in the RDD for each key.
+   * This operation is done efficiently if the RDD has a known partitioner
+   * by only searching the partitions that the keys map to.
+   */
+  def multilookup(keys: Set[K]): Seq[(K,V)] =  {
+    self.partitioner match {
+      case Some(p) =>
+        val indecies = keys.map(p.getPartition(_)).toSeq
+        val process = (it: Iterator[(K, V)]) => {
+          val buf = new ArrayBuffer[(K, V)]
+          for (pair <- it if keys contains pair._1) {
+            buf += pair
+          }
+          buf
+        } : Seq[(K, V)]
+        val res = self.context.runJob(self, process, indecies)
+        res.toSeq.flatten
+      case None =>
+        self.filter{pair => keys.contains(pair._1) }.collect()
+    }
+  }
+
+}

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tms/TileReader.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tms/TileReader.scala
@@ -98,7 +98,7 @@ object TileReaders {
               case Some(rdd) =>
                 val kps = reqs.map{ case QueueRequest(_, x, y, promise) => (SpatialKey(x, y), promise) }
                 val keys = reqs.map{ case QueueRequest(_, x, y, _) => SpatialKey(x, y) }.toSet
-                val results = rdd.filter{ elem => keys.contains(elem._1) }.collect()
+                val results = new MultiValueRDDFunctions(rdd).multilookup(keys)
                 kps.foreach{ case (key, promise) => {
                   promise success (
                     results


### PR DESCRIPTION
There is an interesting behavior in GeoTrellis where `Pyramid` will erase the partitioner, despite its own best efforts. Until that is fixed the multi-value lookup is going to fall back to filtering for all but the base level of the pyramid.

Transition from filter fallback to multivalue lookup:
<img width="1048" alt="screen shot 2017-08-04 at 3 03 54 pm" src="https://user-images.githubusercontent.com/1158084/28983106-30ee1afc-7926-11e7-8104-d1750bb55f10.png">
