### PR TITLE
write Function Warning Message Fix

### DIFF
--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -443,7 +443,7 @@ def write(uri,
             be in camel case. If both options and keywords are set, then the options will be used.
     """
 
-    if not tiled_raster_layer.zoom_level:
+    if tiled_raster_layer.zoom_level is None:
         Log.warn(tiled_raster_layer.pysc, "The given layer doesn't not have a zoom_level. Writing to zoom 0.")
 
     options = options or kwargs or {}


### PR DESCRIPTION
This PR fixes the warning message in the `write` function`. Before, the message would be seen if `zoom_level` was either `None` or `0`. Now it'll only occur when it is `None`.