### PR TITLE
Fix issue with Metadata from_dict, move time series to return datetime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,9 @@ geopyspark/jars/*.jar
 # Unit test performance results
 prof/
 .ensime_cache
+
+# Emacs
+.ensime
+\#*#
+*~
+.#*

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
@@ -111,56 +111,61 @@ class TemporalTiledRasterLayer(
 
   def sumSeries(
     wkbs: java.util.ArrayList[Array[Byte]]
-  ): Array[(ZonedDateTime, Double)] = {
+  ): Array[(Long, Double)] = {
     val polygon: MultiPolygon = wkbsToMultiPolygon(wkbs)
     val metadata = rdd.metadata
     ContextRDD(rdd.mapValues({ m => m.bands(0) }), metadata)
       .sumSeries(polygon)
       .toArray
+      .map { case (dt, v) => (dt.toInstant.toEpochMilli, v) }
       .sortWith({ (t1, t2) => (t1._1.compareTo(t2._1) <= 0) })
   }
 
   def minSeries(
     wkbs: java.util.ArrayList[Array[Byte]]
-  ): Array[(ZonedDateTime, Double)] = {
+  ): Array[(Long, Double)] = {
     val polygon: MultiPolygon = wkbsToMultiPolygon(wkbs)
     val metadata = rdd.metadata
     ContextRDD(rdd.mapValues({ m => m.bands(0) }), metadata)
       .minSeries(polygon)
       .toArray
+      .map { case (dt, v) => (dt.toInstant.toEpochMilli, v) }
       .sortWith({ (t1, t2) => (t1._1.compareTo(t2._1) <= 0) })
   }
 
   def maxSeries(
     wkbs: java.util.ArrayList[Array[Byte]]
-  ): Array[(ZonedDateTime, Double)] = {
+  ): Array[(Long, Double)] = {
     val polygon: MultiPolygon = wkbsToMultiPolygon(wkbs)
     val metadata = rdd.metadata
     ContextRDD(rdd.mapValues({ m => m.bands(0) }), metadata)
       .maxSeries(polygon)
       .toArray
+      .map { case (dt, v) => (dt.toInstant.toEpochMilli, v) }
       .sortWith({ (t1, t2) => (t1._1.compareTo(t2._1) <= 0) })
   }
 
   def meanSeries(
     wkbs: java.util.ArrayList[Array[Byte]]
-  ): Array[(ZonedDateTime, Double)] = {
+  ): Array[(Long, Double)] = {
     val polygon: MultiPolygon = wkbsToMultiPolygon(wkbs)
     val metadata = rdd.metadata
     ContextRDD(rdd.mapValues({ m => m.bands(0) }), metadata)
       .meanSeries(polygon)
       .toArray
+      .map { case (dt, v) => (dt.toInstant.toEpochMilli, v) }
       .sortWith({ (t1, t2) => (t1._1.compareTo(t2._1) <= 0) })
   }
 
   def histogramSeries(
     wkbs: java.util.ArrayList[Array[Byte]]
-  ): Array[(ZonedDateTime, Histogram[Double])] = {
+  ): Array[(Long, Histogram[Double])] = {
     val polygon: MultiPolygon = wkbsToMultiPolygon(wkbs)
     val metadata = rdd.metadata
     ContextRDD(rdd.mapValues({ m => m.bands(0) }), metadata)
       .histogramSeries(polygon)
       .toArray
+      .map { case (dt, v) => (dt.toInstant.toEpochMilli, v) }
       .sortWith({ (t1, t2) => (t1._1.compareTo(t2._1) <= 0) })
   }
 

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -12,7 +12,6 @@ from geopyspark.geotrellis.constants import CellType, NO_DATA_INT
 
 _EPOCH = datetime.datetime.utcfromtimestamp(0)
 
-
 def _convert_to_unix_time(date_time):
     return int((date_time - _EPOCH).total_seconds() * 1000)
 
@@ -493,8 +492,6 @@ class Metadata(object):
         Returns:
             :class:`~geopyspark.geotrellis.Metadata`
         """
-
-        cls._metadata_dict = metadata_dict
 
         crs = metadata_dict['crs']
         cell_type = metadata_dict['cellType']

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -4,6 +4,7 @@ classes are wrappers of their Scala counterparts. These will be used in leau of 
 when performing operations.
 '''
 import json
+import datetime
 import shapely.wkb
 from shapely.geometry import Polygon, MultiPolygon
 from geopyspark.geotrellis.protobufcodecs import multibandtile_decoder
@@ -1148,7 +1149,7 @@ class TiledRasterLayer(CachableLayer):
             geometries = [geometries]
         wkbs = [shapely.wkb.dumps(g) for g in geometries]
 
-        return [(t._1(), t._2()) for t in list(fn(wkbs))]
+        return [(datetime.datetime.utcfromtimestamp(t._1() / 1000), t._2()) for t in list(fn(wkbs))]
 
     def histogram_series(self, geometries):
         fn = self.srdd.histogramSeries


### PR DESCRIPTION
- Time series methods now return a `datetime.datetime` for the keys.
- Fixes issue where metatdata was being set on the Metadata class, which was causing incorrect behavior.
- Adds emacs files to .gitignore