### PR TITLE
collect_keys Method

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ProjectedRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ProjectedRasterLayer.scala
@@ -13,6 +13,7 @@ import geotrellis.vector._
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.rdd._
 import protos.tupleMessages.ProtoTuple
+import protos.extentMessages.ProtoProjectedExtent
 
 import scala.util.{Either, Left, Right}
 import spray.json._
@@ -131,6 +132,9 @@ class ProjectedRasterLayer(val rdd: RDD[(ProjectedExtent, MultibandTile)]) exten
 
     PythonTranslator.toPython[(ProjectedExtent, Array[Byte]), ProtoTuple](geotiffRDD)
   }
+
+  def collectKeys(): java.util.ArrayList[Array[Byte]] =
+    PythonTranslator.toPython[ProjectedExtent, ProtoProjectedExtent](rdd.keys.collect)
 }
 
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/PythonTranslator.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/PythonTranslator.scala
@@ -22,11 +22,11 @@ object PythonTranslator {
     codec.encode(tile).toByteArray
 
   def toPython[T, M <: GeneratedMessage](
-    tiles: Seq[T]
+    values: Seq[T]
   )(implicit codec: ProtoBufCodec[T, M]): java.util.ArrayList[Array[Byte]] = {
     val array_list: java.util.ArrayList[Array[Byte]] = new java.util.ArrayList()
 
-    tiles
+   values
       .map({ v => codec.encode(v).toByteArray })
       .foreach({ ar => array_list.add(ar) })
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterLayer.scala
@@ -43,6 +43,8 @@ abstract class RasterLayer[K](implicit ev0: ClassTag[K], ev1: Component[K, Proje
 
   def toProtoRDD(): JavaRDD[Array[Byte]]
 
+  def collectKeys(): java.util.ArrayList[Array[Byte]]
+
   def bands(band: Int): RasterLayer[K] =
     withRDD(rdd.mapValues { multibandTile => multibandTile.subsetBands(band) })
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialTiledRasterLayer.scala
@@ -4,6 +4,7 @@ import geopyspark.geotrellis._
 import geopyspark.geotrellis.GeoTrellisUtils._
 
 import protos.tileMessages._
+import protos.keyMessages._
 import protos.tupleMessages._
 
 import geotrellis.proj4._
@@ -321,6 +322,9 @@ class SpatialTiledRasterLayer(
 
     PythonTranslator.toPython[(SpatialKey, Array[Byte]), ProtoTuple](geotiffRDD)
   }
+
+  def collectKeys(): java.util.ArrayList[Array[Byte]] =
+    PythonTranslator.toPython[SpatialKey, ProtoSpatialKey](rdd.keys.collect)
 }
 
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalRasterLayer.scala
@@ -12,6 +12,7 @@ import geotrellis.spark.reproject._
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.rdd.RDD
 import protos.tupleMessages.ProtoTuple
+import protos.extentMessages.ProtoTemporalProjectedExtent
 import spray.json._
 
 import scala.util.{Either, Left, Right}
@@ -132,6 +133,9 @@ class TemporalRasterLayer(val rdd: RDD[(TemporalProjectedExtent, MultibandTile)]
 
   def toSpatialLayer(): ProjectedRasterLayer =
     ProjectedRasterLayer(rdd.map { x => (x._1.projectedExtent, x._2) })
+
+  def collectKeys(): java.util.ArrayList[Array[Byte]] =
+    PythonTranslator.toPython[TemporalProjectedExtent, ProtoTemporalProjectedExtent](rdd.keys.collect)
 }
 
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
@@ -4,6 +4,7 @@ import geopyspark.geotrellis._
 import geopyspark.geotrellis.GeoTrellisUtils._
 
 import protos.tileMessages._
+import protos.keyMessages._
 import protos.tupleMessages._
 
 import geotrellis.proj4._
@@ -375,6 +376,9 @@ class TemporalTiledRasterLayer(
 
     SpatialTiledRasterLayer(zoomLevel, ContextRDD(spatialRDD, spatialMetadata))
   }
+
+  def collectKeys(): java.util.ArrayList[Array[Byte]] =
+    PythonTranslator.toPython[SpaceTimeKey, ProtoSpaceTimeKey](rdd.keys.collect)
 }
 
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
@@ -73,6 +73,8 @@ abstract class TiledRasterLayer[K: SpatialComponent: JsonFormat: ClassTag] exten
   /** Encode RDD as Avro bytes and return it with avro schema used */
   def toProtoRDD(): JavaRDD[Array[Byte]]
 
+  def collectKeys(): java.util.ArrayList[Array[Byte]]
+
   def layerMetadata: String = rdd.metadata.toJson.prettyPrint
 
   def mask(wkbs: java.util.ArrayList[Array[Byte]]): TiledRasterLayer[K] = {

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -410,7 +410,7 @@ class Bounds(namedtuple("Bounds", 'minKey maxKey')):
         min_key_dict = self.minKey._asdict()
         max_key_dict = self.maxKey._asdict()
 
-        if hasattr(self.minKey, 'instant'):
+        if 'instant' in min_key_dict.keys():
             min_key_dict['instant'] = _convert_to_unix_time(min_key_dict['instant'])
             max_key_dict['instant'] = _convert_to_unix_time(max_key_dict['instant'])
 
@@ -494,8 +494,6 @@ class Metadata(object):
             :class:`~geopyspark.geotrellis.Metadata`
         """
 
-        cls._metadata_dict = metadata_dict
-
         crs = metadata_dict['crs']
         cell_type = metadata_dict['cellType']
 
@@ -530,19 +528,18 @@ class Metadata(object):
             ``dict``
         """
 
-        if not hasattr(self, '_metadata_dict'):
-            self._metadata_dict = {
-                'bounds': self.bounds._asdict(),
-                'crs': self.crs,
-                'cellType': self.cell_type,
-                'extent': self.extent._asdict(),
-                'layoutDefinition': {
-                    'extent': self.layout_definition.extent._asdict(),
-                    'tileLayout': self.tile_layout._asdict()
-                }
+        metadata_dict = {
+            'bounds': self.bounds._asdict(),
+            'crs': self.crs,
+            'cellType': self.cell_type,
+            'extent': self.extent._asdict(),
+            'layoutDefinition': {
+                'extent': self.layout_definition.extent._asdict(),
+                'tileLayout': self.tile_layout._asdict()
             }
+        }
 
-        return self._metadata_dict
+        return metadata_dict
 
     def __repr__(self):
         return "Metadata({}, {}, {}, {}, {}, {}, {})".format(self.bounds, self.cell_type,

--- a/geopyspark/tests/collect_keys_test.py
+++ b/geopyspark/tests/collect_keys_test.py
@@ -1,0 +1,156 @@
+import datetime
+import unittest
+import pytest
+import numpy as np
+
+from geopyspark.geotrellis import (ProjectedExtent,
+                                   Extent,
+                                   TemporalProjectedExtent,
+                                   SpatialKey,
+                                   SpaceTimeKey,
+                                   Tile,
+                                   Bounds,
+                                   TileLayout,
+                                   LayoutDefinition,
+                                   Metadata)
+from geopyspark.tests.base_test_class import BaseTestClass
+from geopyspark.geotrellis.layer import RasterLayer, TiledRasterLayer
+from geopyspark.geotrellis.constants import LayerType
+
+
+class CollectKeysTest(BaseTestClass):
+    arr = np.zeros((1, 4, 4))
+    tile = Tile.from_numpy_array(arr)
+
+    crs = 4326
+    time = datetime.datetime.strptime("2016-08-24T09:00:00Z", '%Y-%m-%dT%H:%M:%SZ')
+
+    extents = [
+        Extent(0.0, 0.0, 4.0, 4.0),
+        Extent(0.0, 4.0, 4.0, 8.0),
+        Extent(4.0, 0.0, 8.0, 4.0),
+        Extent(4.0, 4.0, 8.0, 8.0)
+    ]
+
+    extent = Extent(0.0, 0.0, 8.0, 8.0)
+    layout = TileLayout(2, 2, 5, 5)
+
+    ct = 'float32ud-1.0'
+    md_proj = '+proj=longlat +datum=WGS84 +no_defs '
+    ld = LayoutDefinition(extent, layout)
+
+    @pytest.fixture(autouse=True)
+    def tearDown(self):
+        yield
+        BaseTestClass.pysc._gateway.close()
+
+    def test_projected_extent(self):
+        pes = [
+            ProjectedExtent(extent=self.extents[0], epsg=self.crs),
+            ProjectedExtent(extent=self.extents[1], epsg=self.crs),
+            ProjectedExtent(extent=self.extents[2], epsg=self.crs),
+            ProjectedExtent(extent=self.extents[3], epsg=self.crs)
+        ]
+
+        pe_layer = [
+            (pes[0], self.tile),
+            (pes[1], self.tile),
+            (pes[2], self.tile),
+            (pes[3], self.tile)
+        ]
+
+        rdd = self.pysc.parallelize(pe_layer)
+        layer = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
+
+        actual = layer.collect_keys()
+
+        for x in actual:
+            self.assertTrue(x in pes)
+
+    def test_temporal_projected_extent(self):
+        pes = [
+            TemporalProjectedExtent(extent=self.extents[0], epsg=self.crs, instant=self.time),
+            TemporalProjectedExtent(extent=self.extents[1], epsg=self.crs, instant=self.time),
+            TemporalProjectedExtent(extent=self.extents[2], epsg=self.crs, instant=self.time),
+            TemporalProjectedExtent(extent=self.extents[3], epsg=self.crs, instant=self.time)
+        ]
+
+        pe_layer = [
+            (pes[0], self.tile),
+            (pes[1], self.tile),
+            (pes[2], self.tile),
+            (pes[3], self.tile)
+        ]
+
+        rdd = self.pysc.parallelize(pe_layer)
+        layer = RasterLayer.from_numpy_rdd(LayerType.SPACETIME, rdd)
+
+        actual = layer.collect_keys()
+
+        for x in actual:
+            self.assertTrue(x in pes)
+
+    def test_spatial_keys(self):
+        keys = [
+            SpatialKey(0, 0),
+            SpatialKey(0, 1),
+            SpatialKey(1, 0),
+            SpatialKey(1, 1)
+        ]
+
+        key_layer = [
+            (keys[0], self.tile),
+            (keys[1], self.tile),
+            (keys[2], self.tile),
+            (keys[3], self.tile)
+        ]
+
+        bounds = Bounds(keys[0], keys[3])
+
+        md = Metadata(bounds=bounds,
+                      crs=self.md_proj,
+                      cell_type=self.ct,
+                      extent=self.extent,
+                      layout_definition=self.ld)
+
+        rdd = self.pysc.parallelize(key_layer)
+        layer = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, md)
+
+        actual = layer.collect_keys()
+
+        for x in actual:
+            self.assertTrue(x in keys)
+
+    def test_space_time_keys(self):
+        temp_keys = [
+            SpaceTimeKey(0, 0, instant=self.time),
+            SpaceTimeKey(0, 1, instant=self.time),
+            SpaceTimeKey(1, 0, instant=self.time),
+            SpaceTimeKey(1, 1, instant=self.time)
+        ]
+
+        temp_key_layer = [
+            (temp_keys[0], self.tile),
+            (temp_keys[1], self.tile),
+            (temp_keys[2], self.tile),
+            (temp_keys[3], self.tile)
+        ]
+
+        temp_bounds = Bounds(temp_keys[0], temp_keys[3])
+
+        temp_md = Metadata(bounds=temp_bounds,
+                           crs=self.md_proj,
+                           cell_type=self.ct,
+                           extent=self.extent,
+                           layout_definition=self.ld)
+
+        rdd = self.pysc.parallelize(temp_key_layer)
+        layer = TiledRasterLayer.from_numpy_rdd(LayerType.SPACETIME, rdd, temp_md)
+
+        actual = layer.collect_keys()
+
+        for x in actual:
+            self.assertTrue(x in temp_keys)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds the `collect_keys` method which returns a list of all of the keys within the layer. In addition, it also fixes a bug in `Metadata` where it would produce the wrong `Metadata` in certain instances.