### PR TITLE
TiledRasterLayer.repartition uses HashPartitioner

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
@@ -56,7 +56,7 @@ abstract class TiledRasterLayer[K: SpatialComponent: JsonFormat: ClassTag] exten
   def zoomLevel: Option[Int]
 
   def repartition(numPartitions: Int): TiledRasterLayer[K] =
-    withRDD(rdd.repartition(numPartitions))
+    withRDD(rdd.partitionBy(new HashPartitioner(numPartitions)))
 
   def bands(band: Int): TiledRasterLayer[K] =
     withRDD(rdd.mapValues { multibandTile => multibandTile.subsetBands(band) })

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -989,7 +989,17 @@ class TiledRasterLayer(CachableLayer):
 
         return TiledRasterLayer(self.layer_type, srdd)
 
-    def repartition(self, num_partitions):
+    def repartition(self, num_partitions=None):
+        """Repartition underlying RDD using HashPartitioner.
+        If ``num_partitions`` is None, existing number of partitions will be used.
+
+        Args:
+            num_partitions(int, optional): Desired number of partitions
+
+        Returns:
+            :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
+        """
+        num_partitions = num_partitions or self.getNumPartitions()
         return TiledRasterLayer(self.layer_type, self.srdd.repartition(num_partitions))
 
     def lookup(self, col, row):


### PR DESCRIPTION
Previous call resulted in use of RDD.coalesce which does not impose a partitioner.