### PR TITLE
Core Concepts Docs for 0.2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ sys.path.insert(0, path.abspath(os.curdir))
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon', 'nbsphinx', 'sphinx.ext.mathjax']
 
 napoleon_google_docstring = True
 
@@ -85,7 +85,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '**.ipynb_checkpoints']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -131,6 +131,14 @@ a need for it.
 
 .. toctree::
   :maxdepth: 4
+  :caption: Notebook Guides
+  :glob:
+  :hidden:
+
+  notebook-demos/core-concepts
+
+.. toctree::
+  :maxdepth: 4
   :caption: User Guides
   :glob:
   :hidden:

--- a/docs/notebook-demos/core-concepts.ipynb
+++ b/docs/notebook-demos/core-concepts.ipynb
@@ -1,0 +1,418 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import datetime\n",
+    "import numpy as np\n",
+    "import geopyspark as gps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Core Concepts\n",
+    "\n",
+    "Because GeoPySpark is a binding of an existing project, [GeoTrellis](https://github.com/locationtech/geotrellis), some terminology and data representations have carried over. This section seeks to explain this jargon in addition to describing how GeoTrellis types are represented in GeoPySpark."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Rasters\n",
+    "\n",
+    "GeoPySpark differs in how it represents rasters from other geo-spatial Python libraries like rasterIO. In GeoPySpark, they are represented by the `Tile` class. This class contains a numpy array (refered to as `cells`) that represents the cells of the raster in addition to other information regarding the data. Along with `cells`, `Tile` can also have the `no_data_value` of the raster.\n",
+    "\n",
+    "**Note**: All rasters in GeoPySpark are represented as having multiple bands, even if the original raster just contained one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "arr = np.array([[[0, 0, 0, 0],\n",
+    "                 [1, 1, 1, 1],\n",
+    "                 [2, 2, 2, 2]]], dtype=np.int16)\n",
+    "\n",
+    "# The resulting Tile will set -10 as the no_data_value for the raster\n",
+    "gps.Tile.from_numpy_array(numpy_array=arr, no_data_value=-10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# The resulting Tile will have no no_data_value\n",
+    "gps.Tile.from_numpy_array(numpy_array=arr)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Extent\n",
+    "\n",
+    "Describes the area on Earth a raster represents. This area is represented by coordinates that are in some Coordinate Reference System. Thus, depending on the system in use, the values that outline the `extent` can vary. `Extent` can also be refered to as a *bounding box*.\n",
+    "\n",
+    "**Note**: The values within the `Extent` must be `float`s and not `double`s."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "extent = gps.Extent(0.0, 0.0, 10.0, 10.0)\n",
+    "extent"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## ProjectedExtent\n",
+    "\n",
+    "`ProjectedExtent` describes both the area on Earth a raster represents in addition to its CRS. Either the EPSG code or a proj4 string can be used to indicate the CRS of the `ProjectedExtent`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Using an EPSG code\n",
+    "\n",
+    "gps.ProjectedExtent(extent=extent, epsg=3857)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Using a Proj4 String\n",
+    "\n",
+    "proj4 = \"+proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +a=6378137 +b=6378137 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs \"\n",
+    "gps.ProjectedExtent(extent=extent, proj4=proj4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## TemporalProjectedExtent\n",
+    "\n",
+    "Similar to `ProjectedExtent`, `TemporalProjectedExtent` describes the area on Earth the raster represents, its CRS, and the time the data was represents. This point of time, called `instant`, is an instance of `datetime.datetime`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "time = datetime.datetime.now()\n",
+    "gps.TemporalProjectedExtent(extent=extent, instant=time, epsg=3857)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## TileLayout\n",
+    "\n",
+    "``TileLayout`` describes the grid which represents how rasters are orginized and assorted in a layer. `layoutCols` and `layoutRows` detail how many columns and rows the grid itself has, respectively. While `tileCols` and `tileRows` tell how many columns and rows each individual raster has."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Describes a layer where there are four rasters in a 2x2 grid. Each raster has 256 cols and rows.\n",
+    "\n",
+    "tile_layout = gps.TileLayout(layoutCols=2, layoutRows=2, tileCols=256, tileRows=256)\n",
+    "tile_layout"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## LayoutDefinition\n",
+    "\n",
+    "`LayoutDefinition` describes both how the rasters are orginized in a layer as well as the area covered by the grid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "layout_definition = gps.LayoutDefinition(extent=extent, tileLayout=tile_layout)\n",
+    "layout_definition"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tiling Strategies\n",
+    "\n",
+    "It is often the case that the exact layout of the layer is unknown. Rather than having to go through the effort of trying to figure out the optimal layout, there exists two different tiling strategies that will produce a layout based on the data they are given."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### LocalLayout\n",
+    "\n",
+    "`LocalLayout` is the first tiling strategy that produces a layout where the grid is constructed over all of the pixels within a layer of a given tile size. The resulting layout will match the original resolution of the cells within the rasters.\n",
+    "\n",
+    "**Note**: This layout **cannot be used for creating display layers. Rather, it is best used for layers where operations and analysis will be performed.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Creates a LocalLayout where each tile within the grid will be 256x256 pixels.\n",
+    "gps.LocalLayout()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Creates a LocalLayout where each tile within the grid will be 512x512 pixels.\n",
+    "gps.LocalLayout(tile_size=512)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Creates a LocalLayout where each tile within the grid will be 256x512 pixels.\n",
+    "gps.LocalLayout(tile_cols=256, tile_rows=512)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### GlobalLayout\n",
+    "\n",
+    "The other tiling strategy is `GlobalLayout` which makes a layout where the grid is constructed over the global extent CRS. The cell resolution of the resulting layer be multiplied by a power of 2 for the CRS. Thus, using this strategy will result in either up or down sampling of the original raster.\n",
+    "\n",
+    "**Note**: This layout strategy **should be used when the resulting layer is to be dispalyed in a TMS server.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Creates a GobalLayout instance with the default values\n",
+    "gps.GlobalLayout()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Creates a GlobalLayout instance for a zoom of 12\n",
+    "gps.GlobalLayout(zoom=12)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You may have noticed from the above two examples that `GlobalLayout` does not create layout for a given zoom level by default. Rather, it determines what the zoom should be based on the size of the cells within the rasters. If you do want to create a layout for a specific zoom level, then the `zoom` parameter must be set."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## SpatialKey\n",
+    "\n",
+    "`SpatialKey`s describe the positions of rasters within the grid of the layout. This grid is a 2D plane where the location of a raster is represented by a pair of coordinates, `col` and `row`, respectively. As its name and attributes suggest, `SpatialKey` deals solely with spatial data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "gps.SpatialKey(col=0, row=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## SpaceTimeKey\n",
+    "\n",
+    "Like `SpatialKey`s, `SpaceTimeKey`s describe the position of a raster in a layout. However, the grid is a 3D plane where a location of a raster is represented by a pair of coordinates, `col` and `row`, as well as a z value that represents a point in time called, `instant`. Like the `instant` in `TemporalProjectedExtent`, this is also an instance of `datetime.datetime`. Thus, `SpaceTimeKey`s deal with spatial-temporal data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "gps.SpaceTimeKey(col=0, row=0, instant=time)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bounds\n",
+    "\n",
+    "`Bounds` represents the the extent of the layout grid in terms of keys. It has both a `minKey` and a `maxKey` attributes. These can either be a `SpatialKey` or a `SpaceTimeKey` depending on the type of data within the layer. The `minKey` is the left, uppermost cell in the grid and the `maxKey` is the right, bottommost cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Creating a Bounds from SpatialKeys\n",
+    "\n",
+    "min_spatial_key = gps.SpatialKey(0, 0)\n",
+    "max_spatial_key = gps.SpatialKey(10, 10)\n",
+    "\n",
+    "bounds = gps.Bounds(min_spatial_key, max_spatial_key)\n",
+    "bounds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Creating a Bounds from SpaceTimeKeys\n",
+    "\n",
+    "min_space_time_key = gps.SpaceTimeKey(0, 0, 1.0)\n",
+    "max_space_time_key = gps.SpaceTimeKey(10, 10, 1.0)\n",
+    "\n",
+    "gps.Bounds(min_space_time_key, max_space_time_key)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Metadata\n",
+    "\n",
+    "`Metadata` contains information of the values within a layer. This data pertains to the layout, projection, and extent of the data contained within the layer.\n",
+    "\n",
+    "The below example shows how to construct `Metadata` by hand, however, this is almost never required and `Metadata` can be produced using easier means. For `RasterLayer`, one call the method, `collect_metadata()` and `TiledRasterLayer` has the attribute, `layer_metadata`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Creates Metadata for a layer with rasters that have a cell type of int16 with the previously defined\n",
+    "# bounds, crs, extent, and layout definition.\n",
+    "gps.Metadata(bounds=bounds,\n",
+    "             crs=proj4,\n",
+    "             cell_type=gps.CellType.INT16.value,\n",
+    "             extent=extent,\n",
+    "             layout_definition=layout_definition)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1+"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR adds the `core-concept` notebook that goes over the fundamental concepts used in GeoPySpark.