### PR TITLE
Add overzooming capability to TMS servers

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tms/TileReader.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tms/TileReader.scala
@@ -24,25 +24,54 @@ trait TileReader {
 
 object TileReaders {
 
+  private def rezoom(zoom: Int, x: Int, y: Int, maxZoom: Int, read: SpatialKey => Tile) = {
+    val dz = zoom - maxZoom
+    val key = SpatialKey((x / math.pow(2, dz)).toInt, (y / math.pow(2, dz)).toInt)
+    val dx = x - key._1 * math.pow(2, dz).toInt
+    val dy = y - key._2 * math.pow(2, dz).toInt
+    val tile = read(key)
+    val w = tile.cols
+    val h = tile.rows
+    val tw = (w / math.pow(2, dz)).toInt
+    val th = (h / math.pow(2, dz)).toInt
+    val x0 = tw * dx
+    val x1 = tw * (dx + 1)
+    val y0 = th * dy
+    val y1 = th * (dy + 1)
+    tile.crop(x0, y0, x1, y1).resample(w, h)
+  }
+
   private class CatalogTileReader(
     valueReader: ValueReader[LayerId],
-    catalog: String
+    catalog: String,
+    overzooming: Boolean
   ) extends TileReader {
 
     private val layers = TrieMap.empty[Int, Reader[SpatialKey, Tile]]
+    private val zoomLevels = 
+      for { LayerId(name, zoom) <- valueReader.attributeStore.layerIds if name == catalog } yield zoom
+    private val maxZoom = zoomLevels.max
 
     def retrieve(zoom: Int, x: Int, y: Int) = {
-      val key = SpatialKey(x, y)
       Future {
-        val reader = layers.getOrElseUpdate(zoom, valueReader.reader[SpatialKey, Tile](LayerId(catalog, zoom)))
-        Try(MultibandTile(reader(key))) match {
-          case Success(tile) => Some(tile)
-          case Failure(_: ValueNotFoundError) => None
-          case Failure(e: Throwable) => throw e
+        if (overzooming && zoom > maxZoom) {
+          val reader = layers.getOrElseUpdate(maxZoom, valueReader.reader[SpatialKey, Tile](LayerId(catalog, maxZoom)))
+          Try(rezoom(zoom, x, y, maxZoom, reader(_))) match {
+            case Success(tile) => Some(MultibandTile(tile))
+            case Failure(_: ValueNotFoundError) => None
+            case Failure(e: Throwable) => throw e
+          }
+        } else {
+          val key = SpatialKey(x, y)
+          val reader = layers.getOrElseUpdate(zoom, valueReader.reader[SpatialKey, Tile](LayerId(catalog, zoom)))
+          Try(MultibandTile(reader(key))) match {
+            case Success(tile) => Some(tile)
+            case Failure(_: ValueNotFoundError) => None
+            case Failure(e: Throwable) => throw e
+          }
         }
       }
     }
-
   }
 
   private sealed trait AggregatorCommand
@@ -76,15 +105,19 @@ object TileReaders {
 
   private object RDDLookup {
     val interval = 150 milliseconds
-    def props(levels: scala.collection.Map[Int, RDD[(SpatialKey, MultibandTile)]],
-              aggregator: ActorRef
-            ) = Props(new RDDLookup(levels, aggregator))
+    def props(levels: scala.collection.Map[Int, RDD[(SpatialKey, Tile)]],
+              aggregator: ActorRef,
+              overzooming: Boolean
+            ) = Props(new RDDLookup(levels, aggregator, overzooming))
   }
 
   private class RDDLookup(
-    levels: scala.collection.Map[Int, RDD[(SpatialKey, MultibandTile)]],
-    aggregator: ActorRef
+    levels: scala.collection.Map[Int, RDD[(SpatialKey, Tile)]],
+    aggregator: ActorRef,
+    overzooming: Boolean
   )(implicit ec: ExecutionContext) extends Actor {
+    private val maxZoom = levels.keys.max
+
     def receive = {
       case Initialize =>
         context.system.scheduler.scheduleOnce(RDDLookup.interval, aggregator, DumpRequests)
@@ -107,11 +140,25 @@ object TileReaders {
                   promise success (
                     results
                       .find{ case (rddKey, _) => rddKey == key }
-                      .map{ case (_, tile) => tile }
+                      .map{ case (_, tile) => MultibandTile(tile) }
                   )
                 }}
               case None =>
-                reqs.foreach{ case QueueRequest(_, _, _, promise) => promise success None }
+                if (overzooming && zoom > maxZoom) {
+                  val rdd = levels(maxZoom)
+                  val kps = reqs.map{ case QueueRequest(_, x, y, promise) => (SpatialKey(x, y), promise) }
+                  val dz = zoom - maxZoom
+                  val remap: SpatialKey => SpatialKey = { 
+                    case SpatialKey(x, y) => SpatialKey((x / math.pow(2, dz)).toInt, (y / math.pow(2, dz)).toInt) 
+                  }
+                  val keys = kps.map{ case (key, _) => remap(key) }.toSet
+                  val rawTiles = new MultiValueRDDFunctions(rdd).multilookup(keys)
+                  val fetch: SpatialKey => Tile = { toFind => rawTiles.find{ case (rddKey, _) => rddKey == toFind }.get._2 }
+                  kps.foreach{ case (key, promise) => 
+                    promise success (Try(rezoom(zoom, key._1, key._2, maxZoom, fetch)).toOption.map(MultibandTile(_)))
+                  }
+                } else
+                  reqs.foreach{ case QueueRequest(_, _, _, promise) => promise success None }
             }
           }}
       }
@@ -119,8 +166,9 @@ object TileReaders {
   }
 
   private class SpatialRddTileReader(
-    levels: scala.collection.Map[Int, RDD[(SpatialKey, MultibandTile)]],
-    system: ActorSystem
+    levels: scala.collection.Map[Int, RDD[(SpatialKey, Tile)]],
+    system: ActorSystem,
+    overzooming: Boolean
   ) extends TileReader {
 
     import java.util.UUID
@@ -135,7 +183,7 @@ object TileReaders {
         throw new IllegalStateException("Cannot start: TMS server already running")
 
       _aggregator = system.actorOf(RequestAggregator.props, UUID.randomUUID.toString)
-      _fulfiller = system.actorOf(RDDLookup.props(levels, aggregator), UUID.randomUUID.toString)
+      _fulfiller = system.actorOf(RDDLookup.props(levels, aggregator, overzooming), UUID.randomUUID.toString)
       _fulfiller ! Initialize
     }
 
@@ -159,18 +207,23 @@ object TileReaders {
     }
   }
 
-  def createCatalogReader(uriString: String, layerName: String): TileReader = {
+  def createCatalogReader(uriString: String, layerName: String, overzooming: Boolean): TileReader = {
     val uri = new java.net.URI(uriString)
 
     val valueReader = ValueReader(uri)
 
-    new CatalogTileReader(valueReader, layerName)
+    new CatalogTileReader(valueReader, layerName, overzooming)
   }
 
   def createSpatialRddReader(
     levels: java.util.HashMap[Int, TiledRasterLayer[SpatialKey]],
-    system: ActorSystem
-  ): TileReader =
-    new SpatialRddTileReader(levels.mapValues(_.rdd), system)
+    system: ActorSystem, 
+    overzooming: Boolean
+  ): TileReader = {
+    val tiles = levels.mapValues{ layer =>
+      layer.rdd.mapValues { mb => mb.bands(0) }
+    }
+    new SpatialRddTileReader(tiles, system, overzooming)
+  }
 
 }

--- a/geopyspark/geotrellis/tms.py
+++ b/geopyspark/geotrellis/tms.py
@@ -179,7 +179,7 @@ class TMS(object):
         """Shuts down the TMS service, freeing the assigned port."""
         if not self.bound:
             raise RuntimeError("Cannot unbind TMS server: Not bound!")
-        
+
         self.server.unbind()
         self._port = None
         self._host = None

--- a/geopyspark/geotrellis/tms.py
+++ b/geopyspark/geotrellis/tms.py
@@ -124,15 +124,13 @@ class TMS(object):
     def __init__(self, server):
         self.pysc = get_spark_context()
         self.server = server
-        self.handshake = ''
         self.bound = False
         self._host = None
         self._port = None
         self.pysc._gateway.start_callback_server()
 
     def set_handshake(self, handshake):
-        self.server.set_handshake(handshake)
-        self.handshake = handshake
+        self.server.setHandshake(handshake)
 
     def bind(self, host=None, requested_port=None):
         """Starts up a TMS server.


### PR DESCRIPTION
This PR allows TMS servers to overzoom or not based on the `allow_overzooming` flag passed to `TMS.build` (defaults to true).

This PR will be ready to review after confirming proper functioning in ...
 - [x] catalog-backed TMS servers
 - [x] RDD-backed TMS servers 