### PR TITLE
Refactor histogram methods

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TileLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TileLayer.scala
@@ -5,6 +5,7 @@ import geopyspark.geotrellis.GeoTrellisUtils._
 import geotrellis.proj4._
 import geotrellis.raster._
 import geotrellis.raster.render._
+import geotrellis.raster.histogram._
 import geotrellis.raster.io.geotiff._
 import geotrellis.raster.io.geotiff.compression._
 import geotrellis.raster.resample.ResampleMethod
@@ -174,6 +175,11 @@ abstract class TileLayer[K: ClassTag] {
       .mapValues(_.band(0))
       .histogramExactInt
       .quantileBreaks(n)
+
+
+  def getIntHistograms(): Array[Histogram[Int]] = rdd.histogramExactInt
+
+  def getDoubleHistograms(): Array[Histogram[Double]] = rdd.histogram
 
   protected def reclassify(reclassifiedRDD: RDD[(K, MultibandTile)]): TileLayer[_]
   protected def reclassifyDouble(reclassifiedRDD: RDD[(K, MultibandTile)]): TileLayer[_]

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
@@ -9,7 +9,6 @@ import protos.tupleMessages._
 import geotrellis.proj4._
 import geotrellis.raster._
 import geotrellis.raster.distance._
-import geotrellis.raster.histogram._
 import geotrellis.raster.io.geotiff._
 import geotrellis.raster.io.geotiff.compression._
 import geotrellis.raster.rasterize._
@@ -288,10 +287,6 @@ abstract class TiledRasterLayer[K: SpatialComponent: JsonFormat: ClassTag] exten
     }
 
   def isFloatingPointLayer(): Boolean = rdd.metadata.cellType.isFloatingPoint
-
-  def getIntHistograms(): Histogram[Int] = rdd.histogramExactInt.head
-
-  def getDoubleHistograms(): Histogram[Double] = rdd.histogram.head
 
   protected def withRDD(result: RDD[(K, MultibandTile)]): TiledRasterLayer[K]
 }

--- a/geopyspark/tests/tiled_layer_tests/histogram_test.py
+++ b/geopyspark/tests/tiled_layer_tests/histogram_test.py
@@ -100,7 +100,7 @@ class HistogramTest(BaseTestClass):
         tiled2 = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd2,
                                                  metadata2)
 
-        hist2 = tiled2.get_histogram()
+        hist2 = tiled2.get_class_histogram()
         bin_counts = hist2.bin_counts()
 
         self.assertEqual(bin_counts, [(1, 10), (3, 3), (4, 2), (5, 1)])


### PR DESCRIPTION
- get_histogram always uses StreamingHistogram
- get_class_histogram always uses IntHistogram
- refactor stat methods to TileLayer class
- histogram methods support multi-band results