### PR TITLE
ReadTheDocs requirements.txt File

### DIFF
--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -1,0 +1,5 @@
+numpy>=1.8
+shapely>=1.6b3
+rasterio>=1.0a7
+pytz
+nbsphinx>=0.2.14


### PR DESCRIPTION
This PR adds the `rtd_requirements.txt` file which contains a list of dependencies needed to build the notebooks in ReadTheDocs.