### PR TITLE
datetime With Timezone Bug Fix

### DIFF
--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -5,6 +5,7 @@ import datetime
 import functools
 import datetime
 from shapely.geometry import box
+import pytz
 
 from geopyspark import get_spark_context
 from geopyspark.geotrellis.constants import CellType, NO_DATA_INT
@@ -14,7 +15,10 @@ _EPOCH = datetime.datetime.utcfromtimestamp(0)
 
 
 def _convert_to_unix_time(date_time):
-    return int((date_time - _EPOCH).total_seconds() * 1000)
+    if date_time.tzinfo:
+        return int((date_time.astimezone(pytz.utc) - _EPOCH.replace(tzinfo=pytz.utc)).total_seconds() * 1000)
+    else:
+        return int((date_time - _EPOCH).total_seconds() * 1000)
 
 
 def deprecated(func):

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -130,7 +130,13 @@ class ValueReader(object):
 
         zoom = zoom or self.zoom or 0
         zoom = zoom and int(zoom)
-        zdt = zdt and zdt.astimezone(pytz.utc).isoformat()
+
+        if zdt:
+            if zdt.tzinfo:
+                zdt = zdt.astimezone(pytz.utc).isoformat()
+            else:
+                zdt = zdt.replace(tzinfo=pytz.utc).isoformat()
+
         value = self.wrapper.readTile(self.layer_name, zoom, col, row, zdt)
         return value and multibandtile_decoder(value)
 
@@ -212,7 +218,12 @@ def query(uri,
         query_proj = str(query_proj)
 
     if time_intervals:
-        time_intervals = [time.astimezon(pytz.utc).isoformat() for time in time_intervals]
+        for x in range(0, len(time_intervals)):
+            time = time_intervals[x]
+            if time.tzinfo:
+                time_intervals[x] = time.astimezone(pytz.utc).isoformat()
+            else:
+                time_intervals[x] = time.replace(tzinfo=pytz.utc).isoformat()
     else:
         time_intervals = []
 


### PR DESCRIPTION
This PR fixes a bug that occurs when trying to query, serialize, or deserialize using `datetime.datetime` objects that had a timezone associated with them. The reason this error occurred is because naive `datetime.datetime`s (those that don't have a timezone) cannot be used in operations with `datetime.datetime` objects that do have a timezone.