### PR TITLE
get_min_max Can Now Return (NaN, NaN)

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TileLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TileLayer.scala
@@ -148,11 +148,20 @@ abstract class TileLayer[K: ClassTag] {
   }
 
   def getMinMax: (Double, Double) = {
-    val minMaxs: Array[(Double, Double)] = rdd.histogram.map{ x => x.minMaxValues.get }
+    val minMaxs: Array[(Double, Double)] =
+      rdd.histogram.map { x =>
+        x.minMaxValues.get match {
+          case None => (Double.NaN, Double.NaN)
+          case Some(minMaxs) => minMaxs
+        }
+      }
 
-    minMaxs.foldLeft(minMaxs(0)) {
-      (acc, elem) =>
-      (math.min(acc._1, elem._1), math.max(acc._2, elem._2))
+    minMaxs.foldLeft(minMaxs(0)) { (acc, elem) =>
+      if (isData(elem._1)) {
+        (math.min(acc._1, elem._1), math.max(acc._2, elem._2))
+      } else {
+        acc
+      }
     }
   }
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TileLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TileLayer.scala
@@ -150,7 +150,7 @@ abstract class TileLayer[K: ClassTag] {
   def getMinMax: (Double, Double) = {
     val minMaxs: Array[(Double, Double)] =
       rdd.histogram.map { x =>
-        x.minMaxValues.get match {
+        x.minMaxValues match {
           case None => (Double.NaN, Double.NaN)
           case Some(minMaxs) => minMaxs
         }


### PR DESCRIPTION
This PR fixes a bug where calling `get_min_max` on a Tile with all `NaN` values would cause it to fail. Now instead of failing `(NaN, NaN)`  will be returned.