### PR TITLE
Default zoom to 0 on read/write/delete in AttributeStore

### DIFF
--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -370,14 +370,16 @@ class AttributeStore(object):
             Returns:
                 ``dict``: Attribute value
             """
-            value_json = self.store.wrapper.read(self.layer_name, self.layer_zoom, name)
+            zoom = self.zoom or 0
+            value_json = self.store.wrapper.read(self.layer_name, zoom, name)
             if value_json:
                 return json.loads(value_json)
             else:
                 raise KeyError(self.store.uri, self.layer_name, self.layer_zoom, name)
 
         def layer_metadata(self):
-            value_json = self.store.wrapper.readMetadata(self.layer_name, self.layer_zoom)
+            zoom = self.zoom or 0
+            value_json = self.store.wrapper.readMetadata(self.layer_name, zoom)
             if value_json:
                 metadata_dict = json.loads(value_json)
                 return Metadata.from_dict(metadata_dict)
@@ -391,8 +393,9 @@ class AttributeStore(object):
                 name (str): Attribute name
                 value (dict): Attribute value
             """
+            zoom = self.zoom or 0
             value_json = json.dumps(value)
-            self.store.wrapper.write(self.layer_name, self.layer_zoom, name, value_json)
+            self.store.wrapper.write(self.layer_name, zoom, name, value_json)
 
         def delete(self, name):
             """Delete attribute by name
@@ -400,7 +403,8 @@ class AttributeStore(object):
             Args:
                 name (str): Attribute name
             """
-            self.store.wrapper.delete(self.layer_name, self.layer_zoom, name)
+            zoom = self.zoom or 0
+            self.store.wrapper.delete(self.layer_name, zoom, name)
 
     def layer(self, name, zoom=None):
         """Layer Attributes object for given layer

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -370,7 +370,7 @@ class AttributeStore(object):
             Returns:
                 ``dict``: Attribute value
             """
-            zoom = self.zoom or 0
+            zoom = self.layer_zoom or 0
             value_json = self.store.wrapper.read(self.layer_name, zoom, name)
             if value_json:
                 return json.loads(value_json)
@@ -378,7 +378,7 @@ class AttributeStore(object):
                 raise KeyError(self.store.uri, self.layer_name, self.layer_zoom, name)
 
         def layer_metadata(self):
-            zoom = self.zoom or 0
+            zoom = self.layer_zoom or 0
             value_json = self.store.wrapper.readMetadata(self.layer_name, zoom)
             if value_json:
                 metadata_dict = json.loads(value_json)
@@ -393,7 +393,7 @@ class AttributeStore(object):
                 name (str): Attribute name
                 value (dict): Attribute value
             """
-            zoom = self.zoom or 0
+            zoom = self.layer_zoom or 0
             value_json = json.dumps(value)
             self.store.wrapper.write(self.layer_name, zoom, name, value_json)
 
@@ -403,7 +403,7 @@ class AttributeStore(object):
             Args:
                 name (str): Attribute name
             """
-            zoom = self.zoom or 0
+            zoom = self.layer_zoom or 0
             self.store.wrapper.delete(self.layer_name, zoom, name)
 
     def layer(self, name, zoom=None):


### PR DESCRIPTION
Keeping `self.layer_zoom` as `None` helps keep the convention in the API but not setting it to `0` when calling the API produces:
```
Traceback (most recent call last):
  File "/working/run/create-mock-layers.py", line 88, in <module>
    args.num_partitions)
  File "/working/run/create-mock-layers.py", line 53, in create_mock_layers
    store.layer(output_layer_name).write("histogram", result_hist.to_dict())
  File "/usr/local/lib/python3.4/dist-packages/geopyspark/geotrellis/catalog.py", line 395, in write
    self.store.wrapper.write(self.layer_name, self.layer_zoom, name, value_json)
  File "/vagrant/spark-2.2.0-bin-hadoop2.7/python/lib/py4j-0.10.4-src.zip/py4j/java_gateway.py", line 1133, in __call__
  File "/vagrant/spark-2.2.0-bin-hadoop2.7/python/lib/py4j-0.10.4-src.zip/py4j/protocol.py", line 323, in get_return_value
py4j.protocol.Py4JError: An error occurred while calling o38.write. Trace:
py4j.Py4JException: Method write([class java.lang.String, null, class java.lang.String, class java.lang.String]) does not exist
	at py4j.reflection.ReflectionEngine.getMethod(ReflectionEngine.java:318)
	at py4j.reflection.ReflectionEngine.getMethod(ReflectionEngine.java:326)
	at py4j.Gateway.invoke(Gateway.java:272)
	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
	at py4j.commands.CallCommand.execute(CallCommand.java:79)
	at py4j.GatewayConnection.run(GatewayConnection.java:214)
	at java.lang.Thread.run(Thread.java:748)
```