### PR TITLE
Separate Testing for Each Test on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,5 @@ cache:
 script:
   - export SPARK_HOME=./spark-2.1.1-bin-hadoop2.7/
   - export JAVA_HOME=/usr/lib/jvm/java-8-oracle
-  - pytest -k "schema" geopyspark/tests/schema_tests/
-  - pytest -k "tiled_layer" geopyspark/tests/tiled_layer_tests/
-  - pytest -k "io" geopyspark/tests/io_tests/
-  - pytest -k "not schema" -k "not tiled_layer" -k "not io" geopyspark/tests/*test.py
+  - ./test_script.sh
   - pylint geopyspark

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+testpath="geopyspark/tests/"
+testpattern="*_test.py"
+
+for f in $testpath$testpattern $testpath/**/$testpattern;
+do
+  pytest $f
+done


### PR DESCRIPTION
This PR adds a script that will run each unittest separately on Travis. This will _hopefully_  resolve the frequent build failures that occur due to memory issues on Travis.