### PR TITLE
Querying With a Geometry in a Different Projection Bug Fix

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerReaderWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerReaderWrapper.scala
@@ -128,12 +128,13 @@ class LayerReaderWrapper(sc: SparkContext) {
     ev1: LayerFilter[K, Intersects.type, Polygon, M],
     ev2: LayerFilter[K, Intersects.type, MultiPolygon, M]
   ): LayerQuery[K, M] = {
-    val projectedGeom = queryCRS match {
-      case Some(crs) =>
-        queryGeom.reproject(layerCRS, crs)
-      case None =>
-        queryGeom
-    }
+    val projectedGeom =
+      queryCRS match {
+        case Some(crs) =>
+          queryGeom.reproject(crs, layerCRS)
+        case None =>
+          queryGeom
+      }
 
     projectedGeom match {
       case point: Point =>

--- a/geopyspark/tests/io_tests/catalog_test.py
+++ b/geopyspark/tests/io_tests/catalog_test.py
@@ -55,7 +55,7 @@ class CatalogTest(BaseTestClass):
         self.assertEqual(tiled, None)
 
     @pytest.mark.skipif('TRAVIS' in os.environ,
-                         reason="test_query_1 causes issues on Travis")
+                        reason="test_query_1 causes issues on Travis")
     def test_query1(self):
         intersection = box(8348915.46680623, 543988.943201519, 8348915.4669, 543988.943201520)
         queried = query(self.uri, self.layer_name, 11, intersection)
@@ -92,9 +92,9 @@ class CatalogTest(BaseTestClass):
         self.assertEqual(queried.to_numpy_rdd().first()[0], SpatialKey(1450, 996))
 
     def test_query_crs(self):
-        intersection = box(8348915.46680623, 543988.943201519, 8348915.4669, 543988.943201520)
+        intersection = box(74.99958369653905, 4.8808219582513095, 74.99958369738141, 4.880821958251324)
         queried = query(self.uri, self.layer_name, 11, intersection,
-                        query_proj=3857)
+                        query_proj=4326)
 
         self.assertEqual(queried.to_numpy_rdd().first()[0], SpatialKey(1450, 996))
 
@@ -133,6 +133,7 @@ class CatalogTest(BaseTestClass):
         store.layer(layer_name, 34).delete("val")
         with pytest.raises(KeyError):
             store.layer(layer_name, 34)["val"]
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/notebook-demos/catalog.ipynb
+++ b/notebook-demos/catalog.ipynb
@@ -467,14 +467,15 @@
    "source": [
     "# The queried Extent is in a different projection than the base layer\n",
     "metadata = spatial_tiled_layer.tile_to_layout(layout=gps.GlobalLayout(), target_crs=4326).layer_metadata\n",
-    "metadata.layout_definition.extent, spatial_tiled_layer.layer_metadata.layout_definition.extent"
+    "metadata.extent, spatial_tiled_layer.layer_metadata.extent"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -482,8 +483,8 @@
     "querried_spatial_layer = gps.query(uri=\"file:///tmp/spatial-catalog\",\n",
     "                                   layer_name=\"spatial-layer\",\n",
     "                                   layer_zoom=11,\n",
-    "                                   query_geom=metadata.layout_definition.extent.to_polygon,\n",
-    "                                   query_proj=\"EPSG:3857\")"
+    "                                   query_geom=metadata.extent,\n",
+    "                                   query_proj=4326)"
    ]
   },
   {


### PR DESCRIPTION
This PR fixes a bug in the `query` code where the query geometry wasn't being reprojected to the correct projection. The reason this bug occurred is because source and target `CRS`s had their places switched in the `Geometry.reproject` method.