### PR TITLE
Reading From S3 Bug Fix

### DIFF
--- a/geopyspark-backend/geotrellis/build.sbt
+++ b/geopyspark-backend/geotrellis/build.sbt
@@ -20,6 +20,8 @@ libraryDependencies ++= Seq(
   "net.sf.py4j"           % "py4j"                               % "0.10.5"
 )
 
+dependencyOverrides += "com.amazonaws" % "aws-java-sdk-s3" % "1.11.105"
+
 assemblyMergeStrategy in assembly := {
   case "reference.conf" => MergeStrategy.concat
   case "application.conf" => MergeStrategy.concat

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/geotiff/GeoTiffRDD.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/geotiff/GeoTiffRDD.scala
@@ -58,6 +58,14 @@ object GeoTiffRDD {
         else
           None
 
+      val partitionBytes =
+        if (javaMap.contains("partition_bytes") && !intMap.contains("max_tile_size"))
+          Some(javaMap.get("partition_bytes").asInstanceOf[Long])
+        else if (!intMap.contains("max_tile_size"))
+          default.partitionBytes
+        else
+          None
+
       val getS3Client: () => S3Client =
         stringMap.get("s3_client") match {
           case Some(client) =>
@@ -76,6 +84,7 @@ object GeoTiffRDD {
         timeFormat = stringMap.getOrElse("time_format", default.timeFormat),
         maxTileSize = intMap.get("max_tile_size"),
         numPartitions = intMap.get("num_partitions"),
+        partitionBytes = partitionBytes,
         chunkSize = intMap.get("chunk_size"),
         getS3Client = getS3Client)
     }

--- a/geopyspark/geotrellis/geotiff.py
+++ b/geopyspark/geotrellis/geotiff.py
@@ -40,6 +40,18 @@ def get(layer_type,
         num_partitions (int, optional): The number of repartitions Spark
             will make when the data is repartitioned. If ``None``, then the
             data will not be repartitioned.
+        partition_bytes (int, optional): The desired number of bytes per partition.
+            This is will ensure that at least one item is assigned for each partition.
+            If ``None`` and ``max_tile_size`` is not set, then the default size per
+            partition is 128 Mb.
+
+            Note:
+                This option is only available when reading from S3.
+
+            Note:
+                This option is incompatible with the ``max_tile_size`` option.
+                If both are set, then ``max_tile_size`` will be used instead of
+                ``partition_bytes``.
         chunk_size (int, optional): How many bytes of the file should be
             read in at a time. If ``None``, then files will be read in 65536
             byte chunks.


### PR DESCRIPTION
This PR fixes a bug that occurred when trying to read geotiff(s) from S3 with `max_tile_size` and `num_partitions` set. The cause of this bug was due to GeoTrellis changing the version number of one of its dependencies, `aws-java-sdk-s3`. To fix this, a `dependencyOverrides` was added so that an early version of `aws-java-sdk-s3` will be used.

This PR resolves #466 