### PR TITLE
Links and Formatting Fixes for the Docs

### DIFF
--- a/docs/guides/core-concepts.rst
+++ b/docs/guides/core-concepts.rst
@@ -1,10 +1,3 @@
-
-.. code:: python3
-
-   import datetime
-   import numpy as np
-   import geopyspark as gps
-
 Core Concepts
 =============
 
@@ -14,12 +7,21 @@ terminology and data representations have carried over. This section
 seeks to explain this jargon in addition to describing how GeoTrellis
 types are represented in GeoPySpark.
 
+Before begining, all examples in this guide need the following boilerplate
+code:
+
+.. code:: python3
+
+   import datetime
+   import numpy as np
+   import geopyspark as gps
+
 Rasters
 -------
 
 GeoPySpark differs in how it represents rasters from other geo-spatial
 Python libraries like rasterIO. In GeoPySpark, they are represented by
-the ``Tile`` class. This class contains a numpy array (refered to as
+the :class:`~geopyspark.geotrellis.Tile` class. This class contains a numpy array (refered to as
 ``cells``) that represents the cells of the raster in addition to other
 information regarding the data. Along with ``cells``, ``Tile`` can also
 have the ``no_data_value`` of the raster.
@@ -32,7 +34,7 @@ bands, even if the original raster just contained one.
     arr = np.array([[[0, 0, 0, 0],
                      [1, 1, 1, 1],
                      [2, 2, 2, 2]]], dtype=np.int16)
-    
+
     # The resulting Tile will set -10 as the no_data_value for the raster
     gps.Tile.from_numpy_array(numpy_array=arr, no_data_value=-10)
 
@@ -47,7 +49,7 @@ Extent
 Describes the area on Earth a raster represents. This area is
 represented by coordinates that are in some Coordinate Reference System.
 Thus, depending on the system in use, the values that outline the
-``extent`` can vary. ``Extent`` can also be refered to as a *bounding
+:class:`~geopyspark.geotrellis.Extent` can vary. ``Extent`` can also be refered to as a *bounding
 box*.
 
 **Note**: The values within the ``Extent`` must be ``float``\ s and not
@@ -61,27 +63,27 @@ box*.
 ProjectedExtent
 ---------------
 
-``ProjectedExtent`` describes both the area on Earth a raster represents
+:class:`~geopyspark.geotrellis.ProjectedExtent` describes both the area on Earth a raster represents
 in addition to its CRS. Either the EPSG code or a proj4 string can be
 used to indicate the CRS of the ``ProjectedExtent``.
 
 .. code:: python3
 
     # Using an EPSG code
-    
+
     gps.ProjectedExtent(extent=extent, epsg=3857)
 
 .. code:: python3
 
     # Using a Proj4 String
-    
+
     proj4 = "+proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +a=6378137 +b=6378137 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs "
     gps.ProjectedExtent(extent=extent, proj4=proj4)
 
 TemporalProjectedExtent
 -----------------------
 
-Similar to ``ProjectedExtent``, ``TemporalProjectedExtent`` describes
+Similar to ``ProjectedExtent``, :class:`~geopyspark.geotrellis.TemporalProjectedExtent` describes
 the area on Earth the raster represents, its CRS, and the time the data
 was represents. This point of time, called ``instant``, is an instance
 of ``datetime.datetime``.
@@ -94,7 +96,7 @@ of ``datetime.datetime``.
 TileLayout
 ----------
 
-``TileLayout`` describes the grid which represents how rasters are
+:class:`~geopyspark.geotrellis.TileLayout` describes the grid which represents how rasters are
 orginized and assorted in a layer. ``layoutCols`` and ``layoutRows``
 detail how many columns and rows the grid itself has, respectively.
 While ``tileCols`` and ``tileRows`` tell how many columns and rows each
@@ -103,14 +105,14 @@ individual raster has.
 .. code:: python3
 
     # Describes a layer where there are four rasters in a 2x2 grid. Each raster has 256 cols and rows.
-    
+
     tile_layout = gps.TileLayout(layoutCols=2, layoutRows=2, tileCols=256, tileRows=256)
     tile_layout
 
 LayoutDefinition
 ----------------
 
-``LayoutDefinition`` describes both how the rasters are orginized in a
+:class:`~geopyspark.geotrellis.LayoutDefinition` describes both how the rasters are orginized in a
 layer as well as the area covered by the grid.
 
 .. code:: python3
@@ -129,7 +131,7 @@ produce a layout based on the data they are given.
 LocalLayout
 ~~~~~~~~~~~
 
-``LocalLayout`` is the first tiling strategy that produces a layout
+:class:`~geopyspark.geotrellis.LocalLayout` is the first tiling strategy that produces a layout
 where the grid is constructed over all of the pixels within a layer of a
 given tile size. The resulting layout will match the original resolution
 of the cells within the rasters.
@@ -156,7 +158,7 @@ performed.**
 GlobalLayout
 ~~~~~~~~~~~~
 
-The other tiling strategy is ``GlobalLayout`` which makes a layout where
+The other tiling strategy is :class:`~geopyspark.geotrellis.GlobalLayout` which makes a layout where
 the grid is constructed over the global extent CRS. The cell resolution
 of the resulting layer be multiplied by a power of 2 for the CRS. Thus,
 using this strategy will result in either up or down sampling of the
@@ -184,7 +186,7 @@ level, then the ``zoom`` parameter must be set.
 SpatialKey
 ----------
 
-``SpatialKey``\ s describe the positions of rasters within the grid of
+:class:`~geopyspark.geotrellis.SpatialKey`\ s describe the positions of rasters within the grid of
 the layout. This grid is a 2D plane where the location of a raster is
 represented by a pair of coordinates, ``col`` and ``row``, respectively.
 As its name and attributes suggest, ``SpatialKey`` deals solely with
@@ -197,7 +199,7 @@ spatial data.
 SpaceTimeKey
 ------------
 
-Like ``SpatialKey``\ s, ``SpaceTimeKey``\ s describe the position of a
+Like ``SpatialKey``\ s, :class:`~geopyspark.geotrellis.SpaceTimeKey`\ s describe the position of a
 raster in a layout. However, the grid is a 3D plane where a location of
 a raster is represented by a pair of coordinates, ``col`` and ``row``,
 as well as a z value that represents a point in time called,
@@ -212,7 +214,7 @@ deal with spatial-temporal data.
 Bounds
 ------
 
-``Bounds`` represents the the extent of the layout grid in terms of
+:class:`~geopyspark.geotrellis.Bounds` represents the the extent of the layout grid in terms of
 keys. It has both a ``minKey`` and a ``maxKey`` attributes. These can
 either be a ``SpatialKey`` or a ``SpaceTimeKey`` depending on the type
 of data within the layer. The ``minKey`` is the left, uppermost cell in
@@ -221,34 +223,34 @@ the grid and the ``maxKey`` is the right, bottommost cell.
 .. code:: python3
 
     # Creating a Bounds from SpatialKeys
-    
+
     min_spatial_key = gps.SpatialKey(0, 0)
     max_spatial_key = gps.SpatialKey(10, 10)
-    
+
     bounds = gps.Bounds(min_spatial_key, max_spatial_key)
     bounds
 
 .. code:: python3
 
     # Creating a Bounds from SpaceTimeKeys
-    
+
     min_space_time_key = gps.SpaceTimeKey(0, 0, 1.0)
     max_space_time_key = gps.SpaceTimeKey(10, 10, 1.0)
-    
+
     gps.Bounds(min_space_time_key, max_space_time_key)
 
 Metadata
 --------
 
-``Metadata`` contains information of the values within a layer. This
+:class:`~geopyspark.geotrellis.Metadata` contains information of the values within a layer. This
 data pertains to the layout, projection, and extent of the data
 contained within the layer.
 
 The below example shows how to construct ``Metadata`` by hand, however,
 this is almost never required and ``Metadata`` can be produced using
-easier means. For ``RasterLayer``, one call the method,
-``collect_metadata()`` and ``TiledRasterLayer`` has the attribute,
-``layer_metadata``.
+easier means. For ``RasterLayer``, one can call the method,
+:meth:`~geopyspark.geotrellis.Metadata.collect_metadata` and
+``TiledRasterLayer`` has the attribute, ``layer_metadata``.
 
 .. code:: python3
 

--- a/docs/guides/tms.rst
+++ b/docs/guides/tms.rst
@@ -32,7 +32,7 @@ layer with some custom color map.  This is accomplished easily:
 
 Of course, other color maps can be used.  See the documentation for
 :class:`~geopyspark.geotrellis.color.ColorMap` for more details.
-   
+
 :code:`TMS.build` can display data from catalogs—which are represented as a
 string-string pair containing the URI of the catalog root and the name of the
 layer—or from a :class:`~geopyspark.geotrellis.layer.Pyramid` object.  One may also


### PR DESCRIPTION
This PR adds links and fixes the formatting of the guides for GeoPySpark.