### PR TITLE
LayerType Creation Isuse Fix

### DIFF
--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -315,7 +315,7 @@ class RasterLayer(CachableLayer, TileLayer):
     def __init__(self, layer_type, srdd):
         CachableLayer.__init__(self)
         self.pysc = get_spark_context()
-        self.layer_type = layer_type
+        self.layer_type = LayerType(layer_type)
         self.srdd = srdd
 
     @classmethod
@@ -735,7 +735,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
     def __init__(self, layer_type, srdd):
         CachableLayer.__init__(self)
         self.pysc = get_spark_context()
-        self.layer_type = layer_type
+        self.layer_type = LayerType(layer_type)
         self.srdd = srdd
 
         self.is_floating_point_layer = self.srdd.isFloatingPointLayer()
@@ -1268,7 +1268,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
             self.srdd.saveStitched(path)
 
     def star_series(self, geometries, fn):
-        if not self.layer_type == LayerType.SPACETIME:
+        if self.layer_type != LayerType.SPACETIME:
             raise ValueError("Only Spatio-Temporal layers can use this function.")
 
         if not isinstance(geometries, list):


### PR DESCRIPTION
This PR resolves an issue that can occur during the creation of a layer where the resulting`layer_type` is not an instance of `LayerType`. This occurred in `geotiff.get` due to the following line:

https://github.com/locationtech-labs/geopyspark/blob/686ad28724d7648bec5e7e1a39cd48d5d80fca79/geopyspark/geotrellis/geotiff.py#L93

In addition to `geotiff.get`, this problem could also arise when creating the layer via the `from_numpy_rdd` methods, so those have been fixed as well in this PR.

This PR resolves #492 