### PR TITLE
create_tuple_serializer Fix

### DIFF
--- a/geopyspark/geotrellis/protobufserializer.py
+++ b/geopyspark/geotrellis/protobufserializer.py
@@ -36,7 +36,7 @@ class ProtoBufSerializer(FramedSerializer):
         decoder = create_partial_tuple_decoder(key_type=key_type)
         encoder = create_partial_tuple_encoder(key_type=key_type)
 
-        return AutoBatchedSerializer(cls(decoder, encoder))
+        return cls(decoder, encoder)
 
     @classmethod
     def create_value_serializer(cls, value_type):


### PR DESCRIPTION
This PR fixes the return type of `ProtoBufSerializer.create_tuple_serializer` so that now `RDD`s that are reserialized will have the correct number of items.

This PR resolves #496 