### PR TITLE
Union Function

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ProjectedRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ProjectedRasterLayer.scala
@@ -1,6 +1,7 @@
 package geopyspark.geotrellis
 
 import GeoTrellisUtils._
+
 import geotrellis.proj4._
 import geotrellis.raster._
 import geotrellis.raster.io.geotiff.{GeoTiffOptions, MultibandGeoTiff, Tags}
@@ -10,12 +11,19 @@ import geotrellis.spark.io._
 import geotrellis.spark.reproject._
 import geotrellis.spark.tiling._
 import geotrellis.vector._
+
 import org.apache.spark.api.java.JavaRDD
+import org.apache.spark._
 import org.apache.spark.rdd._
+
 import protos.tupleMessages.ProtoTuple
 import protos.extentMessages.ProtoProjectedExtent
 
 import scala.util.{Either, Left, Right}
+import scala.collection.JavaConverters._
+
+import java.util.ArrayList
+
 import spray.json._
 
 
@@ -147,4 +155,10 @@ object ProjectedRasterLayer {
 
   def apply(rdd: RDD[(ProjectedExtent, MultibandTile)]): ProjectedRasterLayer =
     new ProjectedRasterLayer(rdd)
+
+  def unionLayers(
+    sc: SparkContext,
+    layers: ArrayList[ProjectedRasterLayer]
+  ): ProjectedRasterLayer =
+    ProjectedRasterLayer(sc.union(layers.asScala.map(_.rdd)))
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalRasterLayer.scala
@@ -9,13 +9,21 @@ import geotrellis.spark.io._
 import geotrellis.spark.io.json._
 import geotrellis.spark.tiling.{FloatingLayoutScheme, LayoutDefinition, LayoutScheme, ZoomedLayoutScheme}
 import geotrellis.spark.reproject._
+
 import org.apache.spark.api.java.JavaRDD
+import org.apache.spark._
 import org.apache.spark.rdd.RDD
+
 import protos.tupleMessages.ProtoTuple
 import protos.extentMessages.ProtoTemporalProjectedExtent
-import spray.json._
 
 import scala.util.{Either, Left, Right}
+import scala.collection.JavaConverters._
+
+import java.util.ArrayList
+
+import spray.json._
+
 
 class TemporalRasterLayer(val rdd: RDD[(TemporalProjectedExtent, MultibandTile)]) extends RasterLayer[TemporalProjectedExtent] {
 
@@ -158,4 +166,10 @@ object TemporalRasterLayer {
 
   def apply(rdd: RDD[(TemporalProjectedExtent, MultibandTile)]): TemporalRasterLayer =
     new TemporalRasterLayer(rdd)
+
+  def unionLayers(
+    sc: SparkContext,
+    layers: ArrayList[TemporalRasterLayer]
+  ): TemporalRasterLayer =
+    TemporalRasterLayer(sc.union(layers.asScala.map(_.rdd)))
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
@@ -50,7 +50,7 @@ import scala.collection.mutable.ArrayBuffer
 import spire.syntax.cfor._
 
 
-abstract class TiledRasterLayer[K: SpatialComponent: JsonFormat: ClassTag] extends TileLayer[K] {
+abstract class TiledRasterLayer[K: SpatialComponent: JsonFormat: ClassTag: Boundable] extends TileLayer[K] {
   import Constants._
 
   type keyType = K

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -590,6 +590,7 @@ from .layer import *
 from .neighborhood import *
 from .rasterize import *
 from .tms import *
+from .union import *
 
 __all__ += catalog.__all__
 __all__ += color.__all__
@@ -603,3 +604,4 @@ __all__ += layer.__all__
 __all__ += neighborhood.__all__
 __all__ += ['rasterize']
 __all__ += tms.__all__
+__all__ += ['union']

--- a/geopyspark/geotrellis/union.py
+++ b/geopyspark/geotrellis/union.py
@@ -1,0 +1,84 @@
+from geopyspark import get_spark_context
+from geopyspark.geotrellis import LayerType
+from geopyspark.geotrellis.layer import RasterLayer, TiledRasterLayer
+
+
+__all__ = ['union']
+
+
+def union(*layers):
+    """Unions togther two or more ``RasterLayer``\s or ``TiledRasterLayer``\s.
+
+    All layers must have the same ``layer_type``. If the layers are ``TiledRasterLayer``\s,
+    then all of the layers must also have the same :class:`~geopyspark.geotrellis.TileLayout`
+    and ``CRS``.
+
+    Note:
+        If the layers to be unioned share one or more keys, then the resulting layer will contain
+        duplicates of that key. One copy for each instance of the key.
+
+    Args:
+        layers (*:class:`~geopyspark.RasterLayer` or *:class:`~geopyspark.TiledRasterLayer`): An
+            arbitrary number (that is more than one) of layers to be unioned together.
+
+    Returns:
+        :class:`~geopyspark.RasterLayer` or :class:`~geopyspark.TiledRasterLayer`
+    """
+
+    if len(layers) == 1:
+        raise ValueError("Union can only performed on 2 or more layers")
+
+    base_layer = layers[0]
+    base_layer_type = base_layer.layer_type
+    base_tile_layout = None
+    base_crs = None
+
+    if not all(isinstance(x, type(base_layer)) for x in layers[1:]):
+        raise TypeError("All of the layers to be unioned must be the same type")
+
+    def check_layer(layer):
+        type_check = layer.layer_type == base_layer_type
+
+        if base_tile_layout:
+            layout_check = layer.layer_metadata.layout_definition.tileLayout == base_tile_layout
+            crs_check = layer.layer_metadata.crs == base_crs
+
+            if layout_check and type_check and crs_check:
+                return True
+            else:
+                return False
+        else:
+            return type_check
+
+
+    if isinstance(base_layer, RasterLayer):
+        if not all([check_layer(x) for x in layers[1:]]):
+            raise ValueError("The layers to be unioned must have the same layer_type")
+
+        pysc = get_spark_context()
+
+        if base_layer_type == LayerType.SPATIAL:
+            result = pysc._gateway.jvm.geopyspark.geotrellis.ProjectedRasterLayer.unionLayers(pysc._jsc.sc(),
+                                                                                              [x.srdd for x in layers])
+        else:
+            result = pysc._gateway.jvm.geopyspark.geotrellis.TemporalRasterLayer.unionLayers(pysc._jsc.sc(),
+                                                                                             [x.srdd for x in layers])
+
+        return RasterLayer(base_layer_type, result)
+
+    else:
+        base_tile_layout = base_layer.layer_metadata.layout_definition.tileLayout
+        base_crs = base_layer.layer_metadata.crs
+
+        if not all([check_layer(x) for x in layers[1:]]):
+            raise ValueError("The layers to be unioned must have the same TileLayout, CRS, and layer_type")
+
+        pysc = get_spark_context()
+
+        if base_layer_type == LayerType.SPATIAL:
+            result = pysc._gateway.jvm.geopyspark.geotrellis.SpatialTiledRasterLayer.unionLayers(pysc._jsc.sc(),
+                                                                                                 [x.srdd for x in layers])
+        else:
+            result = pysc._gateway.jvm.geopyspark.geotrellis.TemporalTiledRasterLayer.unionLayers(pysc._jsc.sc(),
+                                                                                                  [x.srdd for x in layers])
+        return TiledRasterLayer(base_layer_type, result)

--- a/geopyspark/tests/union_test.py
+++ b/geopyspark/tests/union_test.py
@@ -1,0 +1,117 @@
+import unittest
+import datetime
+import pytest
+import numpy as np
+
+from geopyspark.tests.base_test_class import BaseTestClass
+from geopyspark.tests.python_test_utils import check_directory, geotiff_test_path
+from geopyspark.geotrellis import (GlobalLayout, ProjectedExtent, TemporalProjectedExtent,
+                                   Extent, Tile, Bounds, SpatialKey, SpaceTimeKey)
+from geopyspark.geotrellis.layer import RasterLayer, TiledRasterLayer
+from geopyspark.geotrellis.constants import LayerType
+from geopyspark.geotrellis.union import union
+from geopyspark.geotrellis.geotiff import get
+
+
+check_directory()
+
+epsg_code = 3857
+extent = Extent(0.0, 0.0, 10.0, 10.0)
+extent_2 = Extent(10.0, 10.0, 20.0, 20.0)
+
+class UnionSpatialTest(BaseTestClass):
+    projected_extent_1 = ProjectedExtent(extent, epsg_code)
+    projected_extent_2 = ProjectedExtent(extent_2, epsg_code)
+
+    arr = np.zeros((1, 16, 16))
+    tile = Tile(arr, 'FLOAT', -500.0)
+
+    rdd_1 = BaseTestClass.pysc.parallelize([(projected_extent_1, tile)])
+    rdd_2 = BaseTestClass.pysc.parallelize([(projected_extent_2, tile)])
+
+    layer_1 = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd_1)
+    layer_2 = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd_2)
+
+    tiled_layer_1 = layer_1.tile_to_layout(GlobalLayout())
+    tiled_layer_2 = layer_2.tile_to_layout(GlobalLayout())
+
+    @pytest.fixture(autouse=True)
+    def tearDown(self):
+        yield
+        BaseTestClass.pysc._gateway.close()
+
+    def test_union_of_raster_layers(self):
+        result = union(self.layer_1, self.layer_2)
+
+        self.assertTrue(result.srdd.rdd().count(), 2)
+
+    def test_union_of_tiled_raster_layers(self):
+        result = union(self.tiled_layer_1, self.tiled_layer_2)
+
+        bounds_1 = self.tiled_layer_1.layer_metadata.bounds
+        bounds_2 = self.tiled_layer_2.layer_metadata.bounds
+
+        min_col = min(bounds_1.minKey.col, bounds_2.minKey.col)
+        min_row = min(bounds_1.minKey.row, bounds_2.minKey.row)
+        max_col = max(bounds_1.maxKey.col, bounds_2.maxKey.col)
+        max_row = max(bounds_1.maxKey.row, bounds_2.maxKey.row)
+
+        min_key = SpatialKey(min_col, min_row)
+        max_key = SpatialKey(max_col, max_row)
+
+        self.assertTrue(result.srdd.rdd().count(), 2)
+        self.assertEqual(result.layer_metadata.bounds, Bounds(min_key, max_key))
+
+
+class UnionTemporalTest(BaseTestClass):
+    time_1 = datetime.datetime.strptime("1993-09-19T07:01:00Z", '%Y-%m-%dT%H:%M:%SZ')
+    time_2 = datetime.datetime.strptime("2017-09-19T07:01:00Z", '%Y-%m-%dT%H:%M:%SZ')
+
+    temp_projected_extent_1 = TemporalProjectedExtent(extent, time_1, epsg_code)
+    temp_projected_extent_2 = TemporalProjectedExtent(extent, time_2, epsg_code)
+
+    arr = np.zeros((1, 16, 16))
+    tile = Tile(arr, 'FLOAT', -500.0)
+
+    rdd_1 = BaseTestClass.pysc.parallelize([(temp_projected_extent_1, tile)])
+    rdd_2 = BaseTestClass.pysc.parallelize([(temp_projected_extent_2, tile)])
+
+    layer_1 = RasterLayer.from_numpy_rdd(LayerType.SPACETIME, rdd_1)
+    layer_2 = RasterLayer.from_numpy_rdd(LayerType.SPACETIME, rdd_2)
+
+    tiled_layer_1 = layer_1.tile_to_layout(GlobalLayout())
+    tiled_layer_2 = layer_2.tile_to_layout(GlobalLayout())
+
+    @pytest.fixture(autouse=True)
+    def tearDown(self):
+        yield
+        BaseTestClass.pysc._gateway.close()
+
+    def test_union_of_raster_layers(self):
+        result = union(self.layer_1, self.layer_2)
+
+        self.assertTrue(result.srdd.rdd().count(), 2)
+
+    def test_union_of_tiled_raster_layers(self):
+        result = union(self.tiled_layer_1, self.tiled_layer_2)
+
+        bounds_1 = self.tiled_layer_1.layer_metadata.bounds
+        bounds_2 = self.tiled_layer_2.layer_metadata.bounds
+
+        min_col = min(bounds_1.minKey.col, bounds_2.minKey.col)
+        min_row = min(bounds_1.minKey.row, bounds_2.minKey.row)
+        min_instant = min(bounds_1.minKey.instant, bounds_2.minKey.instant)
+
+        max_col = max(bounds_1.maxKey.col, bounds_2.maxKey.col)
+        max_row = max(bounds_1.maxKey.row, bounds_2.maxKey.row)
+        max_instant = max(bounds_1.maxKey.instant, bounds_2.maxKey.instant)
+
+        min_key = SpaceTimeKey(min_col, min_row, min_instant)
+        max_key = SpaceTimeKey(max_col, max_row, max_instant)
+
+        self.assertTrue(result.srdd.rdd().count(), 2)
+        self.assertEqual(result.layer_metadata.bounds, Bounds(min_key, max_key))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds the `union` module and function to geopyspark. This will make it easier to union together layers as the user will no longer have to bring the `RDD`s over to python in order to perform the operation.