### PR TITLE
RasterLayer.merge Method

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterLayer.scala
@@ -65,4 +65,10 @@ abstract class RasterLayer[K](implicit ev0: ClassTag[K], ev1: Component[K, Proje
   protected def reproject(targetCRS: String, layoutType: LayoutType, resampleMethod: ResampleMethod): TiledRasterLayer[_]
   protected def reproject(targetCRS: String, layoutDefinition: LayoutDefinition, resampleMethod: ResampleMethod): TiledRasterLayer[_]
   protected def withRDD(result: RDD[(K, MultibandTile)]): RasterLayer[K]
+
+  def mergeDuplicateKeys(numPartitions: Integer): RasterLayer[K] =
+    numPartitions match {
+      case i: Integer => withRDD(rdd.merge(Some(new HashPartitioner(i))))
+      case null => withRDD(rdd.merge())
+    }
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterLayer.scala
@@ -66,7 +66,7 @@ abstract class RasterLayer[K](implicit ev0: ClassTag[K], ev1: Component[K, Proje
   protected def reproject(targetCRS: String, layoutDefinition: LayoutDefinition, resampleMethod: ResampleMethod): TiledRasterLayer[_]
   protected def withRDD(result: RDD[(K, MultibandTile)]): RasterLayer[K]
 
-  def mergeDuplicateKeys(numPartitions: Integer): RasterLayer[K] =
+  def merge(numPartitions: Integer): RasterLayer[K] =
     numPartitions match {
       case i: Integer => withRDD(rdd.merge(Some(new HashPartitioner(i))))
       case null => withRDD(rdd.merge())

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalRasterLayer.scala
@@ -139,26 +139,17 @@ class TemporalRasterLayer(val rdd: RDD[(TemporalProjectedExtent, MultibandTile)]
     PythonTranslator.toPython[(TemporalProjectedExtent, Array[Byte]), ProtoTuple](geotiffRDD)
   }
 
-  def toSpatialLayer(instant: Long, mergeDuplicates: Boolean): ProjectedRasterLayer = {
+  def toSpatialLayer(instant: Long): ProjectedRasterLayer = {
     val spatialRDD =
-      if (mergeDuplicates)
-        rdd
-          .filter { case (key, _) => key.instant == instant }
-          .map { x => (x._1.projectedExtent, x._2) }
-          .merge()
-      else
-        rdd
-          .filter { case (key, _) => key.instant == instant }
-          .map { x => (x._1.projectedExtent, x._2) }
+      rdd
+        .filter { case (key, _) => key.instant == instant }
+        .map { x => (x._1.projectedExtent, x._2) }
 
     ProjectedRasterLayer(spatialRDD)
   }
 
-  def toSpatialLayer(mergeDuplicates: Boolean): ProjectedRasterLayer =
-    if (mergeDuplicates)
-      ProjectedRasterLayer(rdd.map { x => (x._1.projectedExtent, x._2) }.merge())
-    else
-      ProjectedRasterLayer(rdd.map { x => (x._1.projectedExtent, x._2) })
+  def toSpatialLayer(): ProjectedRasterLayer =
+    ProjectedRasterLayer(rdd.map { x => (x._1.projectedExtent, x._2) })
 
   def collectKeys(): java.util.ArrayList[Array[Byte]] =
     PythonTranslator.toPython[TemporalProjectedExtent, ProtoTemporalProjectedExtent](rdd.keys.collect)

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
@@ -361,17 +361,11 @@ class TemporalTiledRasterLayer(
     PythonTranslator.toPython[(SpaceTimeKey, Array[Byte]), ProtoTuple](geotiffRDD)
   }
 
-  def toSpatialLayer(instant: Long, mergeDuplicates: Boolean): SpatialTiledRasterLayer = {
+  def toSpatialLayer(instant: Long): SpatialTiledRasterLayer = {
     val spatialRDD =
-      if (mergeDuplicates)
-        rdd
-          .filter { case (key, _) => key.instant == instant }
-          .map { x => (x._1.spatialKey, x._2) }
-          .merge()
-      else
-        rdd
-          .filter { case (key, _) => key.instant == instant }
-          .map { x => (x._1.spatialKey, x._2) }
+      rdd
+        .filter { case (key, _) => key.instant == instant }
+        .map { x => (x._1.spatialKey, x._2) }
 
     val (minKey, maxKey) = (spatialRDD.keys.min(), spatialRDD.keys.max())
 
@@ -381,12 +375,8 @@ class TemporalTiledRasterLayer(
     SpatialTiledRasterLayer(zoomLevel, ContextRDD(spatialRDD, spatialMetadata))
   }
 
-  def toSpatialLayer(mergeDuplicates: Boolean): SpatialTiledRasterLayer = {
-    val spatialRDD =
-      if (mergeDuplicates)
-        rdd.map { x => (x._1.spatialKey, x._2) }.merge()
-      else
-        rdd.map { x => (x._1.spatialKey, x._2) }
+  def toSpatialLayer(): SpatialTiledRasterLayer = {
+    val spatialRDD = rdd.map { x => (x._1.spatialKey, x._2) }
 
     val bounds = rdd.metadata.bounds.get
     val spatialMetadata =

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
@@ -323,7 +323,7 @@ abstract class TiledRasterLayer[K: SpatialComponent: JsonFormat: ClassTag: Bound
     withRDD(result.mapValues { tiles => MultibandTile(tiles) } )
   }
 
-  def mergeDuplicateKeys(numPartitions: Integer): TiledRasterLayer[K] =
+  def merge(numPartitions: Integer): TiledRasterLayer[K] =
     numPartitions match {
       case i: Integer => withRDD(
         ContextRDD(

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
@@ -323,6 +323,19 @@ abstract class TiledRasterLayer[K: SpatialComponent: JsonFormat: ClassTag: Bound
     withRDD(result.mapValues { tiles => MultibandTile(tiles) } )
   }
 
+  def mergeDuplicateKeys(numPartitions: Integer): TiledRasterLayer[K] =
+    numPartitions match {
+      case i: Integer => withRDD(
+        ContextRDD(
+          rdd
+            .asInstanceOf[RDD[(K, MultibandTile)]]
+            .merge(Some(new HashPartitioner(i))),
+            rdd.metadata
+          )
+        )
+      case null => withRDD(ContextRDD(rdd.asInstanceOf[RDD[(K, MultibandTile)]].merge(), rdd.metadata))
+    }
+
   def isFloatingPointLayer(): Boolean = rdd.metadata.cellType.isFloatingPoint
 
   protected def withRDD(result: RDD[(K, MultibandTile)]): TiledRasterLayer[K]

--- a/geopyspark/tests/merge_test.py
+++ b/geopyspark/tests/merge_test.py
@@ -61,7 +61,7 @@ class MergeTest(BaseTestClass):
         rdd = self.pysc.parallelize(pe_layer)
         layer = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
 
-        actual = layer.merge_duplicate_keys()
+        actual = layer.merge()
 
         self.assertEqual(actual.srdd.rdd().count(), 2)
 
@@ -84,7 +84,7 @@ class MergeTest(BaseTestClass):
         rdd = self.pysc.parallelize(pe_layer)
         layer = RasterLayer.from_numpy_rdd(LayerType.SPACETIME, rdd)
 
-        actual = layer.merge_duplicate_keys()
+        actual = layer.merge()
 
         self.assertEqual(actual.srdd.rdd().count(), 2)
 
@@ -115,7 +115,7 @@ class MergeTest(BaseTestClass):
         rdd = self.pysc.parallelize(key_layer)
         layer = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, md)
 
-        actual = layer.merge_duplicate_keys()
+        actual = layer.merge()
 
         self.assertEqual(actual.srdd.rdd().count(), 2)
 
@@ -146,7 +146,7 @@ class MergeTest(BaseTestClass):
         rdd = self.pysc.parallelize(temp_key_layer)
         layer = TiledRasterLayer.from_numpy_rdd(LayerType.SPACETIME, rdd, temp_md)
 
-        actual = layer.merge_duplicate_keys()
+        actual = layer.merge()
 
         self.assertEqual(actual.srdd.rdd().count(), 2)
 

--- a/geopyspark/tests/merge_test.py
+++ b/geopyspark/tests/merge_test.py
@@ -1,0 +1,157 @@
+import datetime
+import unittest
+import pytest
+import numpy as np
+
+from geopyspark.geotrellis import (ProjectedExtent,
+                                   Extent,
+                                   TemporalProjectedExtent,
+                                   SpatialKey,
+                                   SpaceTimeKey,
+                                   Tile,
+                                   Bounds,
+                                   TileLayout,
+                                   LayoutDefinition,
+                                   Metadata)
+from geopyspark.tests.base_test_class import BaseTestClass
+from geopyspark.geotrellis.layer import RasterLayer, TiledRasterLayer
+from geopyspark.geotrellis.constants import LayerType
+
+
+class MergeTest(BaseTestClass):
+    arr_1 = np.zeros((1, 4, 4))
+    arr_2 = np.ones((1, 4, 4))
+
+    tile_1 = Tile.from_numpy_array(arr_1)
+    tile_2 = Tile.from_numpy_array(arr_2)
+
+    crs = 4326
+    time = datetime.datetime.strptime("2016-08-24T09:00:00Z", '%Y-%m-%dT%H:%M:%SZ')
+
+    extents = [
+        Extent(0.0, 0.0, 4.0, 4.0),
+        Extent(0.0, 4.0, 4.0, 8.0),
+    ]
+
+    extent = Extent(0.0, 0.0, 8.0, 8.0)
+    layout = TileLayout(2, 2, 5, 5)
+
+    ct = 'float32ud-1.0'
+    md_proj = '+proj=longlat +datum=WGS84 +no_defs '
+    ld = LayoutDefinition(extent, layout)
+
+    @pytest.fixture(autouse=True)
+    def tearDown(self):
+        yield
+        BaseTestClass.pysc._gateway.close()
+
+    def test_projected_extent(self):
+        pes = [
+            ProjectedExtent(extent=self.extents[0], epsg=self.crs),
+            ProjectedExtent(extent=self.extents[1], epsg=self.crs),
+        ]
+
+        pe_layer = [
+            (pes[0], self.tile_1),
+            (pes[0], self.tile_2),
+            (pes[1], self.tile_1),
+            (pes[1], self.tile_2)
+        ]
+
+        rdd = self.pysc.parallelize(pe_layer)
+        layer = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
+
+        actual = layer.merge_duplicate_keys()
+
+        self.assertEqual(actual.srdd.rdd().count(), 2)
+
+        for k, v in actual.to_numpy_rdd().collect():
+            self.assertTrue((v.cells == self.arr_2).all())
+
+    def test_temporal_projected_extent(self):
+        pes = [
+            TemporalProjectedExtent(extent=self.extents[0], epsg=self.crs, instant=self.time),
+            TemporalProjectedExtent(extent=self.extents[1], epsg=self.crs, instant=self.time),
+        ]
+
+        pe_layer = [
+            (pes[0], self.tile_1),
+            (pes[1], self.tile_1),
+            (pes[0], self.tile_2),
+            (pes[1], self.tile_2)
+        ]
+
+        rdd = self.pysc.parallelize(pe_layer)
+        layer = RasterLayer.from_numpy_rdd(LayerType.SPACETIME, rdd)
+
+        actual = layer.merge_duplicate_keys()
+
+        self.assertEqual(actual.srdd.rdd().count(), 2)
+
+        for k, v in actual.to_numpy_rdd().collect():
+            self.assertTrue((v.cells == self.arr_2).all())
+
+    def test_spatial_keys(self):
+        keys = [
+            SpatialKey(0, 0),
+            SpatialKey(0, 1)
+        ]
+
+        key_layer = [
+            (keys[0], self.tile_1),
+            (keys[1], self.tile_1),
+            (keys[0], self.tile_2),
+            (keys[1], self.tile_2)
+        ]
+
+        bounds = Bounds(keys[0], keys[1])
+
+        md = Metadata(bounds=bounds,
+                      crs=self.md_proj,
+                      cell_type=self.ct,
+                      extent=self.extent,
+                      layout_definition=self.ld)
+
+        rdd = self.pysc.parallelize(key_layer)
+        layer = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, md)
+
+        actual = layer.merge_duplicate_keys()
+
+        self.assertEqual(actual.srdd.rdd().count(), 2)
+
+        for k, v in actual.to_numpy_rdd().collect():
+            self.assertTrue((v.cells == self.arr_2).all())
+
+    def test_space_time_keys(self):
+        temp_keys = [
+            SpaceTimeKey(0, 0, instant=self.time),
+            SpaceTimeKey(0, 1, instant=self.time)
+        ]
+
+        temp_key_layer = [
+            (temp_keys[0], self.tile_2),
+            (temp_keys[1], self.tile_2),
+            (temp_keys[0], self.tile_2),
+            (temp_keys[1], self.tile_2)
+        ]
+
+        temp_bounds = Bounds(temp_keys[0], temp_keys[1])
+
+        temp_md = Metadata(bounds=temp_bounds,
+                           crs=self.md_proj,
+                           cell_type=self.ct,
+                           extent=self.extent,
+                           layout_definition=self.ld)
+
+        rdd = self.pysc.parallelize(temp_key_layer)
+        layer = TiledRasterLayer.from_numpy_rdd(LayerType.SPACETIME, rdd, temp_md)
+
+        actual = layer.merge_duplicate_keys()
+
+        self.assertEqual(actual.srdd.rdd().count(), 2)
+
+        for k, v in actual.to_numpy_rdd().collect():
+            self.assertTrue((v.cells == self.arr_2).all())
+
+if __name__ == "__main__":
+    unittest.main()

--- a/geopyspark/tests/to_spatial_test.py
+++ b/geopyspark/tests/to_spatial_test.py
@@ -131,7 +131,7 @@ class ToSpatialLayerTest(BaseTestClass):
             self.assertTrue(x in expected)
 
     def test_to_spatial_target_time_tiled_layer(self):
-        converted = self.tiled_raster_rdd.to_spatial_layer(target_time=self.time_2)
+        converted = self.tiled_raster_rdd.to_spatial_layer(target_time=self.time_2, merge_duplicates=True)
         keys = converted.to_numpy_rdd().keys().collect()
         values = converted.to_numpy_rdd().values().collect()
 

--- a/geopyspark/tests/to_spatial_test.py
+++ b/geopyspark/tests/to_spatial_test.py
@@ -131,7 +131,7 @@ class ToSpatialLayerTest(BaseTestClass):
             self.assertTrue(x in expected)
 
     def test_to_spatial_target_time_tiled_layer(self):
-        converted = self.tiled_raster_rdd.to_spatial_layer(target_time=self.time_2, merge_duplicates=True)
+        converted = self.tiled_raster_rdd.to_spatial_layer(target_time=self.time_2)
         keys = converted.to_numpy_rdd().keys().collect()
         values = converted.to_numpy_rdd().values().collect()
 


### PR DESCRIPTION
This PR adds the `merge_duplicate_keys` method to `RasterLayer` and `TiledRasterLayer`. This will provide an easier means to getting rid of duplicate keys within a layer. In addition to the new method, `to_spatial_layer` now has the `merge_duplicates` parameter which will determine if the duplicate keys should be merged once they converted to `SpatialKey`s.

This PR resolves #502 