### PR TITLE
Polygonal Summary For Each Band

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
@@ -243,51 +243,46 @@ abstract class TiledRasterLayer[K: SpatialComponent: JsonFormat: ClassTag: Bound
       }
     }
 
-  def singleTileLayerRDD: TileLayerRDD[K] = TileLayerRDD(
-    rdd.mapValues({ v => v.band(0) }),
-    rdd.metadata
-  )
-
-  def polygonalMin(geom: Array[Byte]): Int =
+  def polygonalMin(geom: Array[Byte]): Array[Int] =
     WKB.read(geom) match {
-      case poly: Polygon => singleTileLayerRDD.polygonalMin(poly)
-      case multi: MultiPolygon => singleTileLayerRDD.polygonalMin(multi)
+      case poly: Polygon => rdd.polygonalMin(poly)
+      case multi: MultiPolygon => rdd.polygonalMin(multi)
     }
 
-  def polygonalMinDouble(geom: Array[Byte]): Double =
+  def polygonalMinDouble(geom: Array[Byte]): Array[Double] =
     WKB.read(geom) match {
-      case poly: Polygon => singleTileLayerRDD.polygonalMinDouble(poly)
-      case multi: MultiPolygon => singleTileLayerRDD.polygonalMinDouble(multi)
+      case poly: Polygon => rdd.polygonalMinDouble(poly)
+      case multi: MultiPolygon => rdd.polygonalMinDouble(multi)
     }
 
-  def polygonalMax(geom: Array[Byte]): Int =
+  def polygonalMax(geom: Array[Byte]): Array[Int] =
     WKB.read(geom) match {
-      case poly: Polygon => singleTileLayerRDD.polygonalMax(poly)
-      case multi: MultiPolygon => singleTileLayerRDD.polygonalMax(multi)
+      case poly: Polygon => rdd.polygonalMax(poly)
+      case multi: MultiPolygon => rdd.polygonalMax(multi)
     }
 
-  def polygonalMaxDouble(geom: Array[Byte]): Double =
+  def polygonalMaxDouble(geom: Array[Byte]): Array[Double] =
     WKB.read(geom) match {
-      case poly: Polygon => singleTileLayerRDD.polygonalMaxDouble(poly)
-      case multi: MultiPolygon => singleTileLayerRDD.polygonalMaxDouble(multi)
+      case poly: Polygon => rdd.polygonalMaxDouble(poly)
+      case multi: MultiPolygon => rdd.polygonalMaxDouble(multi)
     }
 
-  def polygonalMean(geom: Array[Byte]): Double =
+  def polygonalMean(geom: Array[Byte]): Array[Double] =
     WKB.read(geom) match {
-      case poly: Polygon => singleTileLayerRDD.polygonalMean(poly)
-      case multi: MultiPolygon => singleTileLayerRDD.polygonalMean(multi)
+      case poly: Polygon => rdd.polygonalMean(poly)
+      case multi: MultiPolygon => rdd.polygonalMean(multi)
     }
 
-  def polygonalSum(geom: Array[Byte]): Long =
+  def polygonalSum(geom: Array[Byte]): Array[Long] =
     WKB.read(geom) match {
-      case poly: Polygon => singleTileLayerRDD.polygonalSum(poly)
-      case multi: MultiPolygon => singleTileLayerRDD.polygonalSum(multi)
+      case poly: Polygon => rdd.polygonalSum(poly)
+      case multi: MultiPolygon => rdd.polygonalSum(multi)
     }
 
-  def polygonalSumDouble(geom: Array[Byte]): Double =
+  def polygonalSumDouble(geom: Array[Byte]): Array[Double] =
     WKB.read(geom) match {
-      case poly: Polygon => singleTileLayerRDD.polygonalSumDouble(poly)
-      case multi: MultiPolygon => singleTileLayerRDD.polygonalSumDouble(multi)
+      case poly: Polygon => rdd.polygonalSumDouble(poly)
+      case multi: MultiPolygon => rdd.polygonalSumDouble(multi)
     }
 
   def aggregateByCell(operation: String): TiledRasterLayer[K] = {

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -1621,10 +1621,10 @@ class TiledRasterLayer(CachableLayer, TileLayer):
         if not isinstance(geometry, bytes):
             raise TypeError("Expected geometry to be bytes but given this instead", type(geometry))
 
-        return operation(geometry)
+        return list(operation(geometry))
 
     def polygonal_min(self, geometry, data_type):
-        """Finds the min value that is contained within the given geometry.
+        """Finds the min value for each band that is contained within the given geometry.
 
         Args:
             geometry (shapely.geometry.Polygon or shapely.geometry.MultiPolygon or bytes): A
@@ -1634,7 +1634,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
                 float.
 
         Returns:
-            int or float depending on ``data_type``.
+            [int] or [float] depending on ``data_type``.
 
         Raises:
             TypeError: If ``data_type`` is not an int or float.
@@ -1648,7 +1648,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
             raise TypeError("data_type must be either int or float.")
 
     def polygonal_max(self, geometry, data_type):
-        """Finds the max value that is contained within the given geometry.
+        """Finds the max value for each band that is contained within the given geometry.
 
         Args:
             geometry (shapely.geometry.Polygon or shapely.geometry.MultiPolygon or bytes): A
@@ -1658,7 +1658,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
                 float.
 
         Returns:
-            int or float depending on ``data_type``.
+            [int] or [float] depending on ``data_type``.
 
         Raises:
             TypeError: If ``data_type`` is not an int or float.
@@ -1672,7 +1672,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
             raise TypeError("data_type must be either int or float.")
 
     def polygonal_sum(self, geometry, data_type):
-        """Finds the sum of all of the values that are contained within the given geometry.
+        """Finds the sum of all of the values in each band that are contained within the given geometry.
 
         Args:
             geometry (shapely.geometry.Polygon or shapely.geometry.MultiPolygon or bytes): A
@@ -1682,7 +1682,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
                 float.
 
         Returns:
-            int or float depending on ``data_type``.
+            [int] or [float] depending on ``data_type``.
 
         Raises:
             TypeError: If ``data_type`` is not an int or float.
@@ -1696,7 +1696,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
             raise TypeError("data_type must be either int or float.")
 
     def polygonal_mean(self, geometry):
-        """Finds the mean of all of the values that are contained within the given geometry.
+        """Finds the mean of all of the values for each band that are contained within the given geometry.
 
         Args:
             geometry (shapely.geometry.Polygon or shapely.geometry.MultiPolygon or bytes): A
@@ -1704,7 +1704,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
                 should be computed; or a WKB representation of the geometry.
 
         Returns:
-            float
+            [float]
         """
 
         return self._process_polygonal_summary(geometry, self.srdd.polygonalMean)

--- a/geopyspark/tests/tiled_layer_tests/polygonal_summaries_test.py
+++ b/geopyspark/tests/tiled_layer_tests/polygonal_summaries_test.py
@@ -11,13 +11,22 @@ from geopyspark.geotrellis.layer import TiledRasterLayer
 from geopyspark.geotrellis.constants import LayerType
 
 
-class CostDistanceTest(BaseTestClass):
-    cells = np.array([[
+class PolygonalSummariesTest(BaseTestClass):
+    cells_1 = np.array([[
         [1.0, 1.0, 1.0, 1.0, 1.0],
         [1.0, 1.0, 1.0, 1.0, 1.0],
         [1.0, 1.0, 1.0, 1.0, 1.0],
         [1.0, 1.0, 1.0, 1.0, 1.0],
         [1.0, 1.0, 1.0, 1.0, 0.0]]])
+
+    cells_2 = np.array([[
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0, 0.0]]])
+
+    cells = np.array([cells_1, cells_2])
 
     layer = [(SpatialKey(0, 0), Tile(cells, 'FLOAT', -1.0)),
              (SpatialKey(1, 0), Tile(cells, 'FLOAT', -1.0,)),
@@ -49,25 +58,25 @@ class CostDistanceTest(BaseTestClass):
         polygon = Polygon([(0.0, 0.0), (0.0, 33.0), (33.0, 33.0), (33.0, 0.0), (0.0, 0.0)])
         result = self.tiled_rdd.polygonal_min(polygon, float)
 
-        self.assertEqual(result, 0.0)
+        self.assertEqual(result, [0.0, 0.0])
 
     def test_polygonal_max(self):
         polygon = Polygon([(1.0, 1.0), (1.0, 10.0), (10.0, 10.0), (10.0, 1.0)])
         result = self.tiled_rdd.polygonal_max(polygon, float)
 
-        self.assertEqual(result, 1.0)
+        self.assertEqual(result, [1.0, 1.0])
 
     def test_polygonal_sum(self):
         polygon = Polygon([(0.0, 0.0), (0.0, 33.0), (33.0, 33.0), (33.0, 0.0), (0.0, 0.0)])
         result = self.tiled_rdd.polygonal_sum(polygon, float)
 
-        self.assertEqual(result, 96.0)
+        self.assertEqual(result, [96.0, 96.0])
 
     def test_polygonal_mean(self):
         polygon = Polygon([(1.0, 1.0), (1.0, 10.0), (10.0, 10.0), (10.0, 1.0)])
         result = self.tiled_rdd.polygonal_mean(polygon)
 
-        self.assertEqual(result, 1.0)
+        self.assertEqual(result, [1.0, 1.0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR makes it so that the `polygonal_summary` methods will now return a summary for each band instead of just the first one. This GeoTrellis PR https://github.com/locationtech/geotrellis/pull/2441 should be merged before this one.

This PR resolves #209 