### PR TITLE
Fixed Bug in tileToLayout for TiledRasterLayers

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialTiledRasterLayer.scala
@@ -97,17 +97,15 @@ class SpatialTiledRasterLayer(
     zoom: Option[Int],
     resampleMethod: ResampleMethod
   ): TiledRasterLayer[SpatialKey] = {
-    val mapKeyTransform =
-      MapKeyTransform(
-        layoutDefinition.extent,
-        layoutDefinition.layoutCols,
-        layoutDefinition.layoutRows)
-
+    val baseTransform = rdd.metadata.layout.mapTransform
+    val targetTransform = layoutDefinition.mapTransform
     val crs = rdd.metadata.crs
-    val projectedRDD = rdd.map{ x => (ProjectedExtent(mapKeyTransform(x._1), crs), x._2) }
+
+    val projectedRDD = rdd.map { case(k, v) => (ProjectedExtent(baseTransform(k), crs), v) }
+
     val retiledLayerMetadata = rdd.metadata.copy(
       layout = layoutDefinition,
-      bounds = KeyBounds(mapKeyTransform(rdd.metadata.extent))
+      bounds = KeyBounds(targetTransform(rdd.metadata.extent))
     )
 
     val tileLayer =


### PR DESCRIPTION
This PR fixes a bug present in the `tileToLayout` methods for the `TiledRasterLayer` classes by using the correct `MapKeyTransform` to convert the keys to extents.

This PR resolves #524