### PR TITLE
stitch and saveStitched Now Work With MultibandTiles

### DIFF
--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -1329,7 +1329,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
             raise ValueError("Only TiledRasterLayers with a layer_type of Spatial can use stitch()")
 
         value = self.srdd.stitch()
-        ser = ProtoBufSerializer.create_value_serializer("Tile")
+        ser = ProtoBufSerializer.create_value_serializer("MultibandTile")
         return ser.loads(value)[0]
 
     def save_stitched(self, path, crop_bounds=None, crop_dimensions=None):

--- a/geopyspark/tests/tiled_layer_tests/stitch_test.py
+++ b/geopyspark/tests/tiled_layer_tests/stitch_test.py
@@ -18,10 +18,10 @@ class StitchTest(BaseTestClass):
         [1.0, 1.0, 1.0, 1.0, 1.0],
         [1.0, 1.0, 1.0, 1.0, 0.0]]])
 
-    layer = [(SpatialKey(0, 0), Tile(cells, 'FLOAT', -1.0)),
-             (SpatialKey(1, 0), Tile(cells, 'FLOAT', -1.0,)),
-             (SpatialKey(0, 1), Tile(cells, 'FLOAT', -1.0,)),
-             (SpatialKey(1, 1), Tile(cells, 'FLOAT', -1.0,))]
+    layer = [(SpatialKey(0, 0), Tile(np.array([cells, cells]), 'FLOAT', -1.0)),
+             (SpatialKey(1, 0), Tile(np.array([cells, cells]), 'FLOAT', -1.0,)),
+             (SpatialKey(0, 1), Tile(np.array([cells, cells]), 'FLOAT', -1.0,)),
+             (SpatialKey(1, 1), Tile(np.array([cells, cells]), 'FLOAT', -1.0,))]
     rdd = BaseTestClass.pysc.parallelize(layer)
 
     extent = {'xmin': 0.0, 'ymin': 0.0, 'xmax': 33.0, 'ymax': 33.0}
@@ -45,7 +45,7 @@ class StitchTest(BaseTestClass):
 
     def test_stitch(self):
         result = self.raster_rdd.stitch()
-        self.assertTrue(result.cells.shape == (1, 10, 10))
+        self.assertTrue(result.cells.shape == (2, 10, 10))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR changes the logic in the `stitch` and `saveStitched` methods by having them now work with `MultibandTile`s instead of just `Tile`s.

This PR resolves #536 