### PR TITLE
Added Check For GEOPYSPARK_JARS_PATH

### DIFF
--- a/geopyspark/__init__.py
+++ b/geopyspark/__init__.py
@@ -75,6 +75,9 @@ def geopyspark_conf(master=None, appName=None, additional_jar_dirs=[]):
     if master:
         conf.setMaster(master)
 
+    if 'GEOPYSPARK_JARS_PATH' in os.environ:
+        additional_jar_dirs = additional_jar_dirs + os.environ['GEOPYSPARK_JARS_PATH'].split(':')
+
     conf.set(key='spark.ui.enabled', value='false')
     conf.set(key='spark.serializer', value='org.apache.spark.serializer.KryoSerializer')
     conf.set(key='spark.kryo.registrator', value='geotrellis.spark.io.kryo.KryoRegistrator')


### PR DESCRIPTION
In PR #532, the check for `GEOPYSPARK_JARS_PATH` was removed. However, it appears that variable was still being used on EMR https://github.com/geodocker/geodocker-jupyter-geopyspark/blob/86d88c10df2deff6f76aa34bab93dcd1f8bcab0a/terraform-nodocker/bootstrap.sh#L49

This PR adds the check back in.