### PR TITLE
combine_bands Method for RasterLayers and TiledRasterLayers

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ProjectedRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ProjectedRasterLayer.scala
@@ -161,4 +161,7 @@ object ProjectedRasterLayer {
     layers: ArrayList[ProjectedRasterLayer]
   ): ProjectedRasterLayer =
     ProjectedRasterLayer(sc.union(layers.asScala.map(_.rdd)))
+
+  def combineBands(sc: SparkContext, layers: ArrayList[ProjectedRasterLayer]): ProjectedRasterLayer =
+    ProjectedRasterLayer(TileLayer.combineBands[ProjectedExtent, ProjectedRasterLayer](sc, layers))
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialTiledRasterLayer.scala
@@ -517,4 +517,12 @@ object SpatialTiledRasterLayer {
 
     SpatialTiledRasterLayer(zoomLevel, ContextRDD(result, unionedMetadata))
   }
+
+  def combineBands(sc: SparkContext, layers: ArrayList[SpatialTiledRasterLayer]): SpatialTiledRasterLayer = {
+    val baseLayer: SpatialTiledRasterLayer = layers.get(0)
+    val result: RDD[(SpatialKey, MultibandTile)] =
+      TileLayer.combineBands[SpatialKey, SpatialTiledRasterLayer](sc, layers)
+
+    SpatialTiledRasterLayer(baseLayer.zoomLevel, ContextRDD(result, baseLayer.rdd.metadata))
+  }
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalRasterLayer.scala
@@ -171,4 +171,7 @@ object TemporalRasterLayer {
     layers: ArrayList[TemporalRasterLayer]
   ): TemporalRasterLayer =
     TemporalRasterLayer(sc.union(layers.asScala.map(_.rdd)))
+
+  def combineBands(sc: SparkContext, layers: ArrayList[TemporalRasterLayer]): TemporalRasterLayer =
+    TemporalRasterLayer(TileLayer.combineBands[TemporalProjectedExtent, TemporalRasterLayer](sc, layers))
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
@@ -546,4 +546,12 @@ object TemporalTiledRasterLayer {
 
     TemporalTiledRasterLayer(zoomLevel, ContextRDD(result, unionedMetadata))
   }
+
+  def combineBands(sc: SparkContext, layers: ArrayList[TemporalTiledRasterLayer]): TemporalTiledRasterLayer = {
+    val baseLayer: TemporalTiledRasterLayer = layers.get(0)
+    val result: RDD[(SpaceTimeKey, MultibandTile)] =
+      TileLayer.combineBands[SpaceTimeKey, TemporalTiledRasterLayer](sc, layers)
+
+    TemporalTiledRasterLayer(baseLayer.zoomLevel, ContextRDD(result, baseLayer.rdd.metadata))
+  }
 }

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -57,6 +57,26 @@ def crs_to_proj4(crs):
     return scala_crs.toProj4String()
 
 
+def check_layers(base_layer, base_layer_type, layers):
+    if not all(isinstance(x, type(base_layer)) for x in layers[1:]):
+        raise TypeError("All of the layers to be unioned must be the same type")
+
+    if isinstance(base_layer, RasterLayer):
+        return True
+    else:
+        base_layout = base_layer.layer_metadata.layout_definition.tileLayout
+        base_crs = base_layer.layer_metadata.crs
+
+        for layer in layers[1:]:
+            layout = layer.layer_metadata.layout_definition.tileLayout
+            crs = layer.layer_metadata.crs
+
+            if layout != base_layout or crs != base_crs:
+                raise ValueError("The layers to be unioned must have the same TileLayout and CRS")
+
+        return True
+
+
 class Tile(namedtuple("Tile", 'cells cell_type no_data_value')):
     """Represents a raster in GeoPySpark.
 
@@ -591,6 +611,7 @@ from .neighborhood import *
 from .rasterize import *
 from .tms import *
 from .union import *
+from .combine_bands import *
 
 __all__ += catalog.__all__
 __all__ += color.__all__
@@ -605,3 +626,4 @@ __all__ += neighborhood.__all__
 __all__ += ['rasterize']
 __all__ += tms.__all__
 __all__ += ['union']
+__all__ += ['combine_bands']

--- a/geopyspark/geotrellis/combine_bands.py
+++ b/geopyspark/geotrellis/combine_bands.py
@@ -1,0 +1,65 @@
+from geopyspark import get_spark_context
+from geopyspark.geotrellis import LayerType, check_layers
+from geopyspark.geotrellis.layer import RasterLayer, TiledRasterLayer
+
+
+__all__ = ['combine_bands']
+
+
+def combine_bands(layers):
+    """Combines the bands of values that share the same key in two or more ``TiledRasterLayer``\s.
+
+    This method will concat the bands of two or more values with the same key. For example,
+    ``layer a`` has values that have 2 bands and ``layer b`` has values with 1 band. When
+    ``combine_bands`` is used on both of these layers, then the resulting layer will have
+    values with 3 bands, 2 from ``layer a`` and 1 from ``layer b``.
+
+    Note:
+        All layers must have the same ``layer_type``. If the layers are ``TiledRasterLayer``\s,
+        then all of the layers must also have the same :class:`~geopyspark.geotrellis.TileLayout`
+        and ``CRS``.
+
+    Args:
+        layers ([:class:`~geopyspark.RasterLayer`] or [:class:`~geopyspark.TiledRasterLayer`] or (:class:`~geopyspark.RasterLayer`) or (:class:`~geopyspark.TiledRasterLayer`)): A
+            colection of two or more ``RasterLayer``\s or ``TiledRasterLayer``\s. **The order of the
+            layers determines the order in which the bands are concatenated**. With the bands being
+            ordered based on the position of their respective layer.
+
+            For example, the first layer in ``layers`` is ``layer a`` which contains 2 bands and
+            the second layer is ``layer b`` whose values have 1 band. The resulting layer will
+            have values with 3 bands: the first 2 are from ``layer a`` and the third from ``layer b``.
+            If the positions of ``layer a`` and ``layer b`` are reversed, then the resulting values'
+            first band will be from ``layer b`` and the last 2 will be from ``layer a``.
+
+    Returns:
+        :class:`~geopyspark.RasterLayer` or :class:`~geopyspark.TiledRasterLayer`
+    """
+
+    if len(layers) == 1:
+        raise ValueError("combine_bands can only be performed on 2 or more layers")
+
+    base_layer = layers[0]
+    base_layer_type = base_layer.layer_type
+
+    check_layers(base_layer, base_layer_type, layers)
+
+    pysc = get_spark_context()
+
+    if isinstance(base_layer, RasterLayer):
+        if base_layer_type == LayerType.SPATIAL:
+            result = pysc._gateway.jvm.geopyspark.geotrellis.ProjectedRasterLayer.combineBands(pysc._jsc.sc(),
+                                                                                               [x.srdd for x in layers])
+        else:
+            result = pysc._gateway.jvm.geopyspark.geotrellis.TemporalRasterLayer.combineBands(pysc._jsc.sc(),
+                                                                                              [x.srdd for x in layers])
+
+        return RasterLayer(base_layer_type, result)
+
+    else:
+        if base_layer_type == LayerType.SPATIAL:
+            result = pysc._gateway.jvm.geopyspark.geotrellis.SpatialTiledRasterLayer.combineBands(pysc._jsc.sc(),
+                                                                                                  [x.srdd for x in layers])
+        else:
+            result = pysc._gateway.jvm.geopyspark.geotrellis.TemporalTiledRasterLayer.combineBands(pysc._jsc.sc(),
+                                                                                                   [x.srdd for x in layers])
+        return TiledRasterLayer(base_layer_type, result)

--- a/geopyspark/geotrellis/union.py
+++ b/geopyspark/geotrellis/union.py
@@ -1,5 +1,5 @@
 from geopyspark import get_spark_context
-from geopyspark.geotrellis import LayerType
+from geopyspark.geotrellis import LayerType, check_layers
 from geopyspark.geotrellis.layer import RasterLayer, TiledRasterLayer
 
 
@@ -26,37 +26,16 @@ def union(*layers):
     """
 
     if len(layers) == 1:
-        raise ValueError("Union can only performed on 2 or more layers")
+        raise ValueError("union can only be performed on 2 or more layers")
 
     base_layer = layers[0]
     base_layer_type = base_layer.layer_type
-    base_tile_layout = None
-    base_crs = None
 
-    if not all(isinstance(x, type(base_layer)) for x in layers[1:]):
-        raise TypeError("All of the layers to be unioned must be the same type")
+    check_layers(base_layer, base_layer_type, layers)
 
-    def check_layer(layer):
-        type_check = layer.layer_type == base_layer_type
-
-        if base_tile_layout:
-            layout_check = layer.layer_metadata.layout_definition.tileLayout == base_tile_layout
-            crs_check = layer.layer_metadata.crs == base_crs
-
-            if layout_check and type_check and crs_check:
-                return True
-            else:
-                return False
-        else:
-            return type_check
-
+    pysc = get_spark_context()
 
     if isinstance(base_layer, RasterLayer):
-        if not all([check_layer(x) for x in layers[1:]]):
-            raise ValueError("The layers to be unioned must have the same layer_type")
-
-        pysc = get_spark_context()
-
         if base_layer_type == LayerType.SPATIAL:
             result = pysc._gateway.jvm.geopyspark.geotrellis.ProjectedRasterLayer.unionLayers(pysc._jsc.sc(),
                                                                                               [x.srdd for x in layers])
@@ -67,14 +46,6 @@ def union(*layers):
         return RasterLayer(base_layer_type, result)
 
     else:
-        base_tile_layout = base_layer.layer_metadata.layout_definition.tileLayout
-        base_crs = base_layer.layer_metadata.crs
-
-        if not all([check_layer(x) for x in layers[1:]]):
-            raise ValueError("The layers to be unioned must have the same TileLayout, CRS, and layer_type")
-
-        pysc = get_spark_context()
-
         if base_layer_type == LayerType.SPATIAL:
             result = pysc._gateway.jvm.geopyspark.geotrellis.SpatialTiledRasterLayer.unionLayers(pysc._jsc.sc(),
                                                                                                  [x.srdd for x in layers])

--- a/geopyspark/tests/combine_bands_test.py
+++ b/geopyspark/tests/combine_bands_test.py
@@ -1,0 +1,152 @@
+import os
+import datetime
+import unittest
+import pytest
+import numpy as np
+
+from geopyspark.geotrellis import (SpatialKey, SpaceTimeKey, Extent,
+                                   Tile, ProjectedExtent, TemporalProjectedExtent,
+                                   LocalLayout)
+from geopyspark.geotrellis.combine_bands import combine_bands
+from geopyspark.geotrellis.layer import TiledRasterLayer, RasterLayer
+from geopyspark.tests.base_test_class import BaseTestClass
+from geopyspark.geotrellis.constants import LayerType, Operation
+
+
+now = datetime.datetime.now()
+crs = '+proj=longlat +datum=WGS84 +no_defs '
+extent = Extent(0.0, 0.0, 33.0, 33.0)
+
+e_1 = Extent(0, 0, 16.5, 16.5)
+e_2 = Extent(0, 16.5, 16.5, 33)
+e_3 = Extent(16.5, 16.5, 33, 33)
+e_4 = Extent(16.5, 0, 33, 16.5)
+
+def create_spatial_layer(tile):
+    layer = [(ProjectedExtent(e_1, proj4=crs), tile),
+             (ProjectedExtent(e_2, proj4=crs), tile),
+             (ProjectedExtent(e_3, proj4=crs), tile),
+             (ProjectedExtent(e_4, proj4=crs), tile)]
+
+    return layer
+
+def create_temporal_layer(tile):
+    layer = [(TemporalProjectedExtent(e_1, now, proj4=crs), tile),
+             (TemporalProjectedExtent(e_2, now, proj4=crs), tile),
+             (TemporalProjectedExtent(e_3, now, proj4=crs), tile),
+             (TemporalProjectedExtent(e_4, now, proj4=crs), tile)]
+
+    return layer
+
+first = np.array([[
+    [1.0, 2.0, 3.0, 4.0, 5.0],
+    [1.0, 2.0, 3.0, 4.0, 5.0],
+    [1.0, 2.0, 3.0, 4.0, 5.0],
+    [1.0, 2.0, 3.0, 4.0, 5.0],
+    [1.0, 2.0, 3.0, 4.0, 5.0]]])
+
+second = np.array([[
+    [0.0, 0.0, 0.0, 0.0, 0.0],
+    [0.0, 0.0, 0.0, 0.0, 0.0],
+    [0.0, 0.0, 0.0, 0.0, 0.0],
+    [0.0, 0.0, 0.0, 0.0, 0.0],
+    [0.0, 0.0, 0.0, 0.0, 0.0]]])
+
+third = np.array([[
+    [10.0, 10.0, 10.0, 10.0, 10.0],
+    [10.0, 10.0, 10.0, 10.0, 10.0],
+    [10.0, 10.0, 10.0, 10.0, 10.0],
+    [10.0, 10.0, 10.0, 10.0, 10.0],
+    [10.0, 10.0, 10.0, 10.0, 10.0]]])
+
+tile_1 = Tile.from_numpy_array(first, -1.0)
+tile_2 = Tile.from_numpy_array(second, -1.0)
+tile_3 = Tile.from_numpy_array(third, -1.0)
+
+
+class CombineSpatialBandsTest(BaseTestClass):
+    layer_1 = create_spatial_layer(tile_1)
+    layer_2 = create_spatial_layer(tile_2)
+    layer_3 = create_spatial_layer(tile_3)
+
+    r1 = BaseTestClass.pysc.parallelize(layer_1)
+    r2 = BaseTestClass.pysc.parallelize(layer_2)
+    r3 = BaseTestClass.pysc.parallelize(layer_3)
+
+    rdd_1 = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, r1)
+    rdd_2 = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, r2)
+    rdd_3 = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, r3)
+
+    tiled_rdd_1 = rdd_1.tile_to_layout(LocalLayout(5, 5))
+    tiled_rdd_2 = rdd_2.tile_to_layout(LocalLayout(5, 5))
+    tiled_rdd_3 = rdd_3.tile_to_layout(LocalLayout(5, 5))
+
+    @pytest.fixture(autouse=True)
+    def tearDown(self):
+        yield
+        BaseTestClass.pysc._gateway.close()
+
+    def test_combine_bands_raster_layers(self):
+        actual = combine_bands([self.rdd_1, self.rdd_2, self.rdd_3]).to_numpy_rdd().values().collect()
+
+        for x in actual:
+            self.assertEqual(x.cells.shape, (3, 5, 5))
+            self.assertTrue((x.cells[0, :, :] == first).all())
+            self.assertTrue((x.cells[1, :, :] == second).all())
+            self.assertTrue((x.cells[2, :, :] == third).all())
+
+    def test_combine_bands_tiled_layers(self):
+        actual = combine_bands([self.tiled_rdd_3, self.tiled_rdd_2, self.tiled_rdd_1]) \
+                .to_numpy_rdd().values().collect()
+
+        for x in actual:
+            self.assertEqual(x.cells.shape, (3, 5, 5))
+            self.assertTrue((x.cells[0, :, :] == third).all())
+            self.assertTrue((x.cells[1, :, :] == second).all())
+            self.assertTrue((x.cells[2, :, :] == first).all())
+
+
+class CombineTemporalBandsTest(BaseTestClass):
+    layer_1 = create_temporal_layer(tile_1)
+    layer_2 = create_temporal_layer(tile_2)
+    layer_3 = create_temporal_layer(tile_3)
+
+    r1 = BaseTestClass.pysc.parallelize(layer_1)
+    r2 = BaseTestClass.pysc.parallelize(layer_2)
+    r3 = BaseTestClass.pysc.parallelize(layer_3)
+
+    rdd_1 = RasterLayer.from_numpy_rdd(LayerType.SPACETIME, r1)
+    rdd_2 = RasterLayer.from_numpy_rdd(LayerType.SPACETIME, r2)
+    rdd_3 = RasterLayer.from_numpy_rdd(LayerType.SPACETIME, r3)
+
+    tiled_rdd_1 = rdd_1.tile_to_layout(LocalLayout(5, 5))
+    tiled_rdd_2 = rdd_2.tile_to_layout(LocalLayout(5, 5))
+    tiled_rdd_3 = rdd_3.tile_to_layout(LocalLayout(5, 5))
+
+    @pytest.fixture(autouse=True)
+    def tearDown(self):
+        yield
+        BaseTestClass.pysc._gateway.close()
+
+    def test_combine_bands_raster_layers(self):
+        actual = combine_bands([self.rdd_3, self.rdd_2]).to_numpy_rdd().values().collect()
+
+        for x in actual:
+            self.assertEqual(x.cells.shape, (2, 5, 5))
+            self.assertTrue((x.cells[0, :, :] == third).all())
+            self.assertTrue((x.cells[1, :, :] == second).all())
+
+    def test_combine_bands_tiled_layers(self):
+        actual = combine_bands([self.tiled_rdd_2, self.tiled_rdd_1, self.tiled_rdd_3]) \
+                .to_numpy_rdd().values().collect()
+
+        for x in actual:
+            self.assertEqual(x.cells.shape, (3, 5, 5))
+            self.assertTrue((x.cells[0, :, :] == second).all())
+            self.assertTrue((x.cells[1, :, :] == first).all())
+            self.assertTrue((x.cells[2, :, :] == third).all())
+
+
+if __name__ == "__main__":
+    unittest.main()
+    BaseTestClass.pysc.stop()


### PR DESCRIPTION
This PR will allow the user to combine bands from different layers so that the resulting layer will have a `bandCount` equal to the sum of the `bandCount`s of the input layers. For example, if `layer a` has 2 bands and `layer b` has one, then the resulting layer will have a `bandCount` of 3. Where 2 of the bands come from `layer a` and 1 comes from `layer b`.

This PR resolves #539 