### PR TITLE
Better Temporal Resolution Control When Writing Layer

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerWriterWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerWriterWrapper.scala
@@ -51,6 +51,7 @@ class LayerWriterWrapper(attributeStore: AttributeStore, uri: String) {
       case ("zorder", "minutes") => ZCurveKeyIndexMethod.byMinute
       case ("zorder", "hours") => ZCurveKeyIndexMethod.byHour
       case ("zorder", "days") => ZCurveKeyIndexMethod.byDay
+      case ("zorder", "weeks") => ZCurveKeyIndexMethod.byDays(7)
       case ("zorder", "months") => ZCurveKeyIndexMethod.byMonth
       case ("zorder", "years") => ZCurveKeyIndexMethod.byYear
       case ("hilbert", _) => {

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -231,6 +231,7 @@ def write(uri,
           tiled_raster_layer,
           index_strategy=IndexingMethod.ZORDER,
           time_unit=None,
+          time_resolution=None,
           store=None):
     """Writes a tile layer to a specified destination.
 
@@ -250,6 +251,15 @@ def write(uri,
             each index. Meaning, what time intervals are used to seperate each record. While this is
             set to ``None`` as default, it must be set if saving spatial-temporal data.
             Depending on the indexing method chosen, different time units are used.
+        time_resolution (str or int, optional): Determines how data for each ``time_unit`` should be
+            grouped together. By default, no grouping will occur.
+
+            As an example, having a ``time_unit`` of ``WEEKS`` and a ``time_resolution`` of 5 will
+            cause the data to be grouped and stored together in units of 5 weeks. If however
+            ``time_resolution`` is not specified, then the data will be grouped and stored in units
+            of single weeks.
+
+            This value can either be an ``int`` or a string representation of an ``int``.
         store (str or :class:`~geopyspark.geotrellis.catalog.AttributeStore`, optional):
             ``AttributeStore`` instance or URI for layer metadata lookup.
     """
@@ -274,9 +284,13 @@ def write(uri,
                             IndexingMethod(index_strategy).value)
 
     elif tiled_raster_layer.layer_type == LayerType.SPACETIME:
+        if time_resolution:
+            time_resolution = str(time_resolution)
+
         writer.writeTemporal(layer_name,
                              tiled_raster_layer.srdd,
                              TimeUnit(time_unit).value,
+                             time_resolution,
                              IndexingMethod(index_strategy).value)
     else:
         raise ValueError("Cannot write {} layer".format(tiled_raster_layer.layer_type))

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -116,6 +116,7 @@ class TimeUnit(Enum):
     MINUTES = 'minutes'
     HOURS = 'hours'
     DAYS = 'days'
+    WEEKS = 'weeks'
     MONTHS = 'months'
     YEARS = 'years'
 


### PR DESCRIPTION
This PR adds the `temporal_resolution` parameter to the `write` method. This will allow users to save their layers with a more fine-grained resolution than what was previously available.

This PR resolves #538 