### PR TITLE
tileToLayout Moved to the Abstract Class

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialTiledRasterLayer.scala
@@ -114,16 +114,6 @@ class SpatialTiledRasterLayer(
     SpatialTiledRasterLayer(zoom, tileLayer)
   }
 
-  def tileToLayout(
-    layoutType: LayoutType,
-    resampleMethod: ResampleMethod
-  ): TiledRasterLayer[SpatialKey] = {
-    val (layoutDefinition, zoom) =
-      layoutType.layoutDefinitionWithZoom(rdd.metadata.crs, rdd.metadata.extent, rdd.metadata.cellSize)
-
-    tileToLayout(layoutDefinition, zoom, resampleMethod)
-  }
-
   def pyramid(resampleMethod: ResampleMethod): Array[TiledRasterLayer[SpatialKey]] = {
     require(! rdd.metadata.bounds.isEmpty, "Can not pyramid an empty RDD")
     val part = rdd.partitioner.getOrElse(new HashPartitioner(rdd.partitions.length))

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
@@ -220,16 +220,6 @@ class TemporalTiledRasterLayer(
     TemporalTiledRasterLayer(zoom, tileLayer)
   }
 
-  def tileToLayout(
-    layoutType: LayoutType,
-    resampleMethod: ResampleMethod
-  ): TiledRasterLayer[SpaceTimeKey] = {
-    val (layoutDefinition, zoom) =
-      layoutType.layoutDefinitionWithZoom(rdd.metadata.crs, rdd.metadata.extent, rdd.metadata.cellSize)
-
-    tileToLayout(layoutDefinition, zoom, resampleMethod)
-  }
-
   def pyramid(resampleMethod: ResampleMethod): Array[TiledRasterLayer[SpaceTimeKey]] = {
     require(! rdd.metadata.bounds.isEmpty, "Can not pyramid an empty RDD")
     val part = rdd.partitioner.getOrElse(new HashPartitioner(rdd.partitions.length))

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
@@ -106,7 +106,12 @@ abstract class TiledRasterLayer[K: SpatialComponent: JsonFormat: ClassTag: Bound
   def tileToLayout(
     layoutType: LayoutType,
     resampleMethod: ResampleMethod
-  ): TiledRasterLayer[K]
+  ): TiledRasterLayer[K] = {
+    val (layoutDefinition, zoom) =
+      layoutType.layoutDefinitionWithZoom(rdd.metadata.crs, rdd.metadata.extent, rdd.metadata.cellSize)
+
+    tileToLayout(layoutDefinition, zoom, resampleMethod)
+  }
 
   def tileToLayout(
     layOutDefinition: LayoutDefinition,


### PR DESCRIPTION
This PR moves one of the `tileToLayout` overloads from `SpatialTiledRasterLayer` and `TemporalTiledRasterLayer` to `TiledRasterLayer`.

This PR resolves #535 