### PR TITLE
Abs Local Operation

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
@@ -229,6 +229,9 @@ abstract class TiledRasterLayer[K: SpatialComponent: JsonFormat: ClassTag: Bound
       }
     })
 
+  def localAbs(): TiledRasterLayer[K] =
+    withRDD(rdd.mapValues { x => MultibandTile(x.bands.map { y => y.localAbs() }) })
+
   def convertDataType(newType: String): TiledRasterLayer[_] =
     withRDD(rdd.convert(CellType.fromName(newType)))
 

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -1817,6 +1817,12 @@ class TiledRasterLayer(CachableLayer, TileLayer):
     def __rtruediv__(self, value):
         return self._process_operation(value, self.srdd.reverseLocalDivide)
 
+    def __abs__(self):
+        srdd = self.srdd.localAbs()
+
+        return TiledRasterLayer(self.layer_type, srdd)
+
+
     def __str__(self):
         return "TiledRasterLayer(layer_type={}, zoom_level={}, is_floating_point_layer={})".format(
             self.layer_type, self.zoom_level, self.is_floating_point_layer)

--- a/geopyspark/tests/local_ops_test.py
+++ b/geopyspark/tests/local_ops_test.py
@@ -121,6 +121,27 @@ class LocalOpertaionsTest(BaseTestClass):
 
         self.assertTrue((actual == arr).all())
 
+    def test_abs_operations(self):
+        arr = np.array([[[-10, -10, -10, 10],
+                         [-20, -20, -20, 20],
+                         [-10, -10, 10, 10],
+                         [-20, -20, 20, 20]]], dtype=int)
+
+        expected = np.array([[[10, 10, 10, 10],
+                              [20, 20, 20, 20],
+                              [10, 10, 10, 10],
+                              [20, 20, 20, 20]]], dtype=int)
+
+        tile = Tile(arr, 'INT', -500)
+        rdd = BaseTestClass.pysc.parallelize([(self.spatial_key, tile)])
+
+        tiled = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, self.metadata)
+
+        result = abs(tiled)
+        actual = result.to_numpy_rdd().first()[1].cells
+
+        self.assertTrue((actual == expected).all())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds the ability for `TiledRasterLayer`s to perform the `abs()` operation. This is how the new feature can be used:

```python
abs(tiled_layer)
```

This PR resolves #512 