### PR TITLE
Pow Local Operation

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
@@ -237,6 +237,27 @@ abstract class TiledRasterLayer[K: SpatialComponent: JsonFormat: ClassTag: Bound
   def localAbs(): TiledRasterLayer[K] =
     withRDD(rdd.mapValues { x => MultibandTile(x.bands.map { y => y.localAbs() }) })
 
+  def localPow(i: Int): TiledRasterLayer[K] =
+    withRDD(rdd.mapValues { x => MultibandTile(x.bands.map { y => y ** i }) })
+
+  def localPow(d: Double): TiledRasterLayer[K] =
+    withRDD(rdd.mapValues { x => MultibandTile(x.bands.map { y => y ** d }) })
+
+  def localPow(other: TiledRasterLayer[K]): TiledRasterLayer[K] =
+    withRDD(rdd.combineValues(other.rdd) {
+      case (x: MultibandTile, y: MultibandTile) => {
+        val tiles: Vector[Tile] =
+          x.bands.zip(y.bands).map(tup => tup._1 ** tup._2)
+        MultibandTile(tiles)
+      }
+    })
+
+  def reverseLocalPow(i: Int): TiledRasterLayer[K] =
+    withRDD(rdd.mapValues { x => MultibandTile(x.bands.map { y => y.localPowValue(i) }) })
+
+  def reverseLocalPow(d: Double): TiledRasterLayer[K] =
+    withRDD(rdd.mapValues { x => MultibandTile(x.bands.map { y => y.localPowValue(d) }) })
+
   def convertDataType(newType: String): TiledRasterLayer[_] =
     withRDD(rdd.convert(CellType.fromName(newType)))
 

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -1831,6 +1831,11 @@ class TiledRasterLayer(CachableLayer, TileLayer):
 
         return TiledRasterLayer(self.layer_type, srdd)
 
+    def __pow__(self, value):
+        return self._process_operation(value, self.srdd.localPow)
+
+    def __rpow__(self, value):
+        return self._process_operation(value, self.srdd.reverseLocalPow)
 
     def __str__(self):
         return "TiledRasterLayer(layer_type={}, zoom_level={}, is_floating_point_layer={})".format(

--- a/geopyspark/tests/local_ops_test.py
+++ b/geopyspark/tests/local_ops_test.py
@@ -142,6 +142,55 @@ class LocalOpertaionsTest(BaseTestClass):
 
         self.assertTrue((actual == expected).all())
 
+    def test_pow_int(self):
+        arr = np.zeros((1, 4, 4))
+
+        tile = Tile(arr, 'FLOAT', -500)
+        rdd = BaseTestClass.pysc.parallelize([(self.spatial_key, tile)])
+        tiled = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, self.metadata)
+
+        result = tiled ** 5
+        actual = result.to_numpy_rdd().first()[1].cells
+
+        self.assertTrue((actual == 0).all())
+
+    def test_rpow_int(self):
+        arr = np.full((1, 4, 4), 2, dtype='int16')
+
+        tile = Tile(arr, 'int16', -500)
+        rdd = BaseTestClass.pysc.parallelize([(self.spatial_key, tile)])
+        tiled = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, self.metadata)
+
+        result = 3 ** tiled
+        actual = result.to_numpy_rdd().first()[1].cells
+
+        self.assertTrue((actual == 9).all())
+
+    def test_rpow_double(self):
+        arr = np.full((1, 4, 4), 3.0, dtype='int64')
+
+        tile = Tile(arr, 'FLOAT', -500)
+        rdd = BaseTestClass.pysc.parallelize([(self.spatial_key, tile)])
+        tiled = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, self.metadata)
+
+        result = 0.0 ** tiled
+        actual = result.to_numpy_rdd().first()[1].cells
+
+        self.assertTrue((actual == 0.0).all())
+
+    def test_pow_layer(self):
+        arr = np.zeros((1, 4, 4))
+        twos = arr + 2
+
+        tile = Tile(twos, 'FLOAT', -500)
+        rdd = BaseTestClass.pysc.parallelize([(self.spatial_key, tile)])
+        tiled = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, self.metadata)
+
+        result = tiled ** tiled
+        actual = result.to_numpy_rdd().first()[1].cells
+
+        self.assertTrue((actual == 4).all())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds the `pow` operation to `TiledRasterLayer`s.

```python
tiled_layer ** 0
tiled_layer ** 5.0
tiled_layer ** tiled_layer
```

**Note**: The original issue had `int`s being raised by a `TiledRasterLayer` this feature was not included in this PR.

This PR resolves #511 