### PR TITLE
EmptyQueryException For LayerReaderWrapper

### DIFF
--- a/docs/guides/catalog.rst
+++ b/docs/guides/catalog.rst
@@ -303,7 +303,7 @@ an :class:`~geopyspark.geotrellis.Extent`.
 
 **Note**: It is important that the given geometry is in the same
 projection as the queried layer. Otherwise, either the wrong area
-will be returned or an exception will be thrown.
+will be returned or an empty layer will be returned.
 
 When the Queried Geometry is in the Same Projection as the Layer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -398,6 +398,26 @@ Querying by Space and Time
               layer_zoom=7,
               query_geom=multi_poly,
               time_intervals=[min_key.instant, max_key.instant])
+
+Non-Intersecting Queries
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In the event that neither the ``query_geom`` nor ``time_intervals`` intersects the layer,
+then an empty ``TiledRasterLayer`` will be returned.
+
+.. code:: python3
+
+    # A non-intersecting geometry that we will use to query our layer.
+    bad_area = box(-100, -100, 0, 0)
+
+    # This will return an empty TiledRasterLayer
+    empty_layer = gps.query(uri="file:///tmp/spatial-catalog",
+                            layer_name="spatial-layer",
+                            layer_zoom=11,
+                            query_geom=bad_area)
+
+    empty_layer.isEmpty()
+
 
 AttributeStore
 --------------

--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -166,6 +166,10 @@ def query(uri,
                 Only layers that were made from spatial, singleband GeoTiffs can query a ``Point``.
                 All other types are restricted to ``Polygon`` and ``MulitPolygon``.
 
+            Note:
+                If the queried region does not intersect the layer, then an empty layer will be
+                returned.
+
             If not specified, then the entire layer will be read.
         time_intervals (``[datetime.datetime]``, optional): A list of the time intervals to query.
             This parameter is only used when querying spatial-temporal data. The default value is,

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -284,6 +284,15 @@ class CachableLayer(object):
 
         return self.srdd.rdd().count()
 
+    def isEmpty(self):
+        """Returns a bool that is True if the layer is empty and False if it is not.
+
+        Returns:
+            bool: Are there elements within the layer
+        """
+
+        return self.srdd.rdd().isEmpty()
+
 
 class RasterLayer(CachableLayer, TileLayer):
     """A wrapper of a RDD that contains GeoTrellis rasters.


### PR DESCRIPTION
This PR will now throw an `EmptyQueryException` when the `layerQuery` does not intersect the chosen layer. Before, the error that was thrown was a `java.lang.UnsupportedOperationException: empty.reduceLeft` which was unhelpful.

This PR resolves #531 