### PR TITLE
Formatting For API Docs

### DIFF
--- a/docs/docs/geopyspark.geotrellis.catalog.rst
+++ b/docs/docs/geopyspark.geotrellis.catalog.rst
@@ -1,0 +1,6 @@
+geopyspark.geotrellis.catalog module
+=====================================
+
+.. automodule:: geopyspark.geotrellis.catalog
+   :members:
+   :inherited-members:

--- a/docs/docs/geopyspark.geotrellis.color.rst
+++ b/docs/docs/geopyspark.geotrellis.color.rst
@@ -1,0 +1,6 @@
+geopyspark.geotrellis.color module
+=====================================
+
+.. automodule:: geopyspark.geotrellis.color
+   :members:
+   :inherited-members:

--- a/docs/docs/geopyspark.geotrellis.combine_bands.rst
+++ b/docs/docs/geopyspark.geotrellis.combine_bands.rst
@@ -1,0 +1,6 @@
+geopyspark.geotrellis.combine_bands module
+===========================================
+
+.. automodule:: geopyspark.geotrellis.combine_bands
+   :members:
+   :inherited-members:

--- a/docs/docs/geopyspark.geotrellis.constants.rst
+++ b/docs/docs/geopyspark.geotrellis.constants.rst
@@ -1,0 +1,7 @@
+geopyspark.geotrellis.constants module
+=======================================
+
+.. automodule:: geopyspark.geotrellis.constants
+   :members:
+   :undoc-members:
+   :inherited-members:

--- a/docs/docs/geopyspark.geotrellis.cost_distance.rst
+++ b/docs/docs/geopyspark.geotrellis.cost_distance.rst
@@ -1,0 +1,6 @@
+geopyspark.geotrellis.cost_distance module
+===========================================
+
+.. automodule:: geopyspark.geotrellis.cost_distance
+   :members:
+   :inherited-members:

--- a/docs/docs/geopyspark.geotrellis.euclidean_distance.rst
+++ b/docs/docs/geopyspark.geotrellis.euclidean_distance.rst
@@ -1,0 +1,6 @@
+geopyspark.geotrellis.euclidean_distance module
+================================================
+
+.. automodule:: geopyspark.geotrellis.euclidean_distance
+   :members:
+   :inherited-members:

--- a/docs/docs/geopyspark.geotrellis.geotiff.rst
+++ b/docs/docs/geopyspark.geotrellis.geotiff.rst
@@ -1,0 +1,6 @@
+geopyspark.geotrellis.geotiff module
+======================================
+
+.. automodule:: geopyspark.geotrellis.geotiff
+   :members:
+   :inherited-members:

--- a/docs/docs/geopyspark.geotrellis.hillshade.rst
+++ b/docs/docs/geopyspark.geotrellis.hillshade.rst
@@ -1,0 +1,6 @@
+geopyspark.geotrellis.hillshade module
+=======================================
+
+.. automodule:: geopyspark.geotrellis.hillshade
+   :members:
+   :inherited-members:

--- a/docs/docs/geopyspark.geotrellis.histogram.rst
+++ b/docs/docs/geopyspark.geotrellis.histogram.rst
@@ -1,0 +1,6 @@
+geopyspark.geotrellis.histogram module
+===========================================
+
+.. automodule:: geopyspark.geotrellis.histogram
+   :members:
+   :inherited-members:

--- a/docs/docs/geopyspark.geotrellis.layer.rst
+++ b/docs/docs/geopyspark.geotrellis.layer.rst
@@ -1,0 +1,6 @@
+geopyspark.geotrellis.layer module
+====================================
+
+.. automodule:: geopyspark.geotrellis.layer
+   :members:
+   :inherited-members:

--- a/docs/docs/geopyspark.geotrellis.neighborhood.rst
+++ b/docs/docs/geopyspark.geotrellis.neighborhood.rst
@@ -1,0 +1,6 @@
+geopyspark.geotrellis.neighborhood module
+============================================
+
+.. automodule:: geopyspark.geotrellis.neighborhood
+   :members:
+   :inherited-members:

--- a/docs/docs/geopyspark.geotrellis.protobufcodecs.rst
+++ b/docs/docs/geopyspark.geotrellis.protobufcodecs.rst
@@ -1,0 +1,5 @@
+geopyspark.geotrellis.ProtoBufCodecs module
+==============================================
+
+.. autoclass:: geopyspark.geotrellis.protobuf
+   :members:

--- a/docs/docs/geopyspark.geotrellis.protobufserializer.rst
+++ b/docs/docs/geopyspark.geotrellis.protobufserializer.rst
@@ -1,0 +1,5 @@
+geopyspark.geotrellis.ProtoBufSerializer module
+================================================
+
+.. autoclass:: geopyspark.geotrellis.protobufserializer.ProtoBufSerializer
+   :members:

--- a/docs/docs/geopyspark.geotrellis.rasterize.rst
+++ b/docs/docs/geopyspark.geotrellis.rasterize.rst
@@ -1,0 +1,6 @@
+geopyspark.geotrellis.rasterize module
+=======================================
+
+.. automodule:: geopyspark.geotrellis.rasterize
+   :members:
+   :inherited-members:

--- a/docs/docs/geopyspark.geotrellis.rst
+++ b/docs/docs/geopyspark.geotrellis.rst
@@ -1,97 +1,82 @@
 geopyspark.geotrellis package
 =============================
 
-.. automodule:: geopyspark.geotrellis
+.. autoclass:: geopyspark.geotrellis.Tile
    :members:
    :undoc-members:
    :inherited-members:
 
-geopyspark.geotrellis.ProtoBufCodecs module
-----------------------------------------------
-
-.. autoclass:: geopyspark.geotrellis.protobuf
-   :members:
-
-geopyspark.geotrellis.ProtoBufSerializer module
-------------------------------------------------
-
-.. autoclass:: geopyspark.geotrellis.protobufserializer.ProtoBufSerializer
-   :members:
-
-geopyspark.geotrellis.catalog module
--------------------------------------
-
-.. automodule:: geopyspark.geotrellis.catalog
+.. autoclass:: geopyspark.geotrellis.Extent
    :members:
    :inherited-members:
 
-geopyspark.geotrellis.constants module
----------------------------------------
-
-.. automodule:: geopyspark.geotrellis.constants
-   :members:
-   :undoc-members:
-   :inherited-members:
-
-geopyspark.geotrellis.geotiff module
------------------------------------------
-
-.. automodule:: geopyspark.geotrellis.geotiff
+.. autoclass:: geopyspark.geotrellis.ProjectedExtent
    :members:
    :inherited-members:
 
-geopyspark.geotrellis.neighborhood module
---------------------------------------------
-
-.. automodule:: geopyspark.geotrellis.neighborhood
+.. autoclass:: geopyspark.geotrellis.TemporalProjectedExtent
    :members:
    :inherited-members:
 
-geopyspark.geotrellis.layer module
-------------------------------------
-
-.. automodule:: geopyspark.geotrellis.layer
+.. autoclass:: geopyspark.geotrellis.GlobalLayout
    :members:
    :inherited-members:
 
-geopyspark.geotrellis.cost_distance module
--------------------------------------------
-
-.. automodule:: geopyspark.geotrellis.cost_distance
+.. autoclass:: geopyspark.geotrellis.LocalLayout
    :members:
    :inherited-members:
 
-geopyspark.geotrellis.euclidean_distance module
-------------------------------------------------
-
-.. automodule:: geopyspark.geotrellis.euclidean_distance
+.. autoclass:: geopyspark.geotrellis.LocalLayout
    :members:
    :inherited-members:
 
-geopyspark.geotrellis.hillshade module
--------------------------------------------
-
-.. automodule:: geopyspark.geotrellis.hillshade
+.. autoclass:: geopyspark.geotrellis.TileLayout
    :members:
    :inherited-members:
 
-geopyspark.geotrellis.rasterize module
--------------------------------------------
-
-.. automodule:: geopyspark.geotrellis.rasterize
+.. autoclass:: geopyspark.geotrellis.LayoutDefinition
    :members:
    :inherited-members:
 
-geopyspark.geotrellis.tms module
---------------------------------
-
-.. automodule:: geopyspark.geotrellis.tms
+.. autoclass:: geopyspark.geotrellis.SpatialKey
    :members:
    :inherited-members:
-      
-geopyspark.geotrellis.histogram module
--------------------------------------------
 
-.. automodule:: geopyspark.geotrellis.histogram
+.. autoclass:: geopyspark.geotrellis.SpaceTimeKey
    :members:
    :inherited-members:
+
+.. autoclass:: geopyspark.geotrellis.RasterizerOptions
+   :members:
+   :inherited-members:
+
+.. autoclass:: geopyspark.geotrellis.Bounds
+   :members:
+   :inherited-members:
+
+.. autoclass:: geopyspark.geotrellis.Metadata
+   :members:
+   :inherited-members:
+
+.. toctree::
+  :maxdepth: 2
+  :caption: Modules
+  :glob:
+  :hidden:
+
+  geopyspark.geotrellis.catalog
+  geopyspark.geotrellis.color
+  geopyspark.geotrellis.combine_bands
+  geopyspark.geotrellis.constants
+  geopyspark.geotrellis.cost_distance
+  geopyspark.geotrellis.euclidean_distance
+  geopyspark.geotrellis.geotiff
+  geopyspark.geotrellis.hillshade
+  geopyspark.geotrellis.histogram
+  geopyspark.geotrellis.layer
+  geopyspark.geotrellis.neighborhood
+  geopyspark.geotrellis.protobufcodecs
+  geopyspark.geotrellis.protobufserializer
+  geopyspark.geotrellis.rasterize
+  geopyspark.geotrellis.tms
+  geopyspark.geotrellis.union

--- a/docs/docs/geopyspark.geotrellis.tms.rst
+++ b/docs/docs/geopyspark.geotrellis.tms.rst
@@ -1,0 +1,6 @@
+geopyspark.geotrellis.tms module
+================================
+
+.. automodule:: geopyspark.geotrellis.tms
+   :members:
+   :inherited-members:

--- a/docs/docs/geopyspark.geotrellis.union.rst
+++ b/docs/docs/geopyspark.geotrellis.union.rst
@@ -1,0 +1,6 @@
+geopyspark.geotrellis.union module
+====================================
+
+.. automodule:: geopyspark.geotrellis.union
+   :members:
+   :inherited-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -129,8 +129,8 @@ a need for it.
   tutorials/reading-in-sentinel-data
 
 .. toctree::
-  :maxdepth: 4
-  :caption: Docs
+  :maxdepth: 2
+  :caption: API Reference
   :glob:
   :hidden:
 


### PR DESCRIPTION
This PR changes the formatting of the API docs by breaking each module into its own file. This should make it easier to navigate the documentation.