### PR TITLE
Parameter Type Change For the union Method

### DIFF
--- a/geopyspark/geotrellis/union.py
+++ b/geopyspark/geotrellis/union.py
@@ -6,7 +6,7 @@ from geopyspark.geotrellis.layer import RasterLayer, TiledRasterLayer
 __all__ = ['union']
 
 
-def union(*layers):
+def union(layers):
     """Unions togther two or more ``RasterLayer``\s or ``TiledRasterLayer``\s.
 
     All layers must have the same ``layer_type``. If the layers are ``TiledRasterLayer``\s,
@@ -18,8 +18,8 @@ def union(*layers):
         duplicates of that key. One copy for each instance of the key.
 
     Args:
-        layers (*:class:`~geopyspark.RasterLayer` or *:class:`~geopyspark.TiledRasterLayer`): An
-            arbitrary number (that is more than one) of layers to be unioned together.
+        layers ([:class:`~geopyspark.RasterLayer`] or [:class:`~geopyspark.TiledRasterLayer`] or (:class:`~geopyspark.RasterLayer`) or (:class:`~geopyspark.TiledRasterLayer`)): A
+            colection of two or more ``RasterLayer``\s or ``TiledRasterLayer``\s layers to be unioned together.
 
     Returns:
         :class:`~geopyspark.RasterLayer` or :class:`~geopyspark.TiledRasterLayer`

--- a/geopyspark/tests/union_test.py
+++ b/geopyspark/tests/union_test.py
@@ -41,12 +41,12 @@ class UnionSpatialTest(BaseTestClass):
         BaseTestClass.pysc._gateway.close()
 
     def test_union_of_raster_layers(self):
-        result = union(self.layer_1, self.layer_2)
+        result = union([self.layer_1, self.layer_2])
 
         self.assertTrue(result.srdd.rdd().count(), 2)
 
     def test_union_of_tiled_raster_layers(self):
-        result = union(self.tiled_layer_1, self.tiled_layer_2)
+        result = union([self.tiled_layer_1, self.tiled_layer_2])
 
         bounds_1 = self.tiled_layer_1.layer_metadata.bounds
         bounds_2 = self.tiled_layer_2.layer_metadata.bounds
@@ -88,12 +88,12 @@ class UnionTemporalTest(BaseTestClass):
         BaseTestClass.pysc._gateway.close()
 
     def test_union_of_raster_layers(self):
-        result = union(self.layer_1, self.layer_2)
+        result = union([self.layer_1, self.layer_2])
 
         self.assertTrue(result.srdd.rdd().count(), 2)
 
     def test_union_of_tiled_raster_layers(self):
-        result = union(self.tiled_layer_1, self.tiled_layer_2)
+        result = union([self.tiled_layer_1, self.tiled_layer_2])
 
         bounds_1 = self.tiled_layer_1.layer_metadata.bounds
         bounds_2 = self.tiled_layer_2.layer_metadata.bounds


### PR DESCRIPTION
This PR changes the type of the parameter for the `union` method from an arbitrary number of layers to a collection of layers. The benefit of this is that it'll be easier to pass in layers to the `union` method and it'll match the API for the `combine_bands` method.

**Note**: This PR should be on of the last to be merged before the 0.3 release.