### PR TITLE
Documentation And Examples For The Missing Methods/Functions

### DIFF
--- a/docs/guides/visualization.rst
+++ b/docs/guides/visualization.rst
@@ -133,6 +133,8 @@ resulting ``Pyramid`` will only have as many levels as the source
     result = pyramided + small_pyramid
     result.levels
 
+.. _cmap:
+
 ColorMap
 --------
 


### PR DESCRIPTION
This PR adds documentation and examples for the following methods/functions: `aggregate_by_cell`, `get_point_values`, `merge`, `to_png_rdd`, `to_geotiff_rdd`, `collect_keys`, `filter_by_times`, `union`, `combine_bands`.

PRs #556 and #557 should be merged before this one.