### PR TITLE
aws-java-sdk-s3 Version Change

### DIFF
--- a/geopyspark-backend/geotrellis/build.sbt
+++ b/geopyspark-backend/geotrellis/build.sbt
@@ -21,8 +21,6 @@ libraryDependencies ++= Seq(
   "net.sf.py4j"           % "py4j"                         % "0.10.5"
 )
 
-dependencyOverrides += "com.amazonaws" % "aws-java-sdk-s3" % "1.11.105"
-
 assemblyMergeStrategy in assembly := {
   case "reference.conf" => MergeStrategy.concat
   case "application.conf" => MergeStrategy.concat


### PR DESCRIPTION
This PR changes the version of GeoPySpark's `aws-java-sdk-s3` dependency from 1.11.105 to the version used in GeoTrellis. This was originally changed because of issues encountered when reading from S3 #466. At the time, we were unsure of the issue and had decided to come back to it later.

While the exact cause is still not known, I can speculate that the logic in the `S3GeoTiffRDD` was the source. As this was the only thing that changed between now and when the issue first appeared.

This code below could not work before, but now can even with the updated `aws-java-sdk-s3` version:

```
In [1]: import geopyspark as gps
   ...: 
   ...: from pyspark import SparkContext
   ...: # Set up our spark context
   ...: conf = gps.geopyspark_conf(appName="Landsat") \
   ...:           .setMaster("local[*]") \
   ...:           .set(key='spark.ui.enabled', value='true') \
   ...:           .set(key="spark.driver.memory", value="8G")
   ...: sc = SparkContext(conf=conf)
   ...: target_image = "s3://landsat-pds/c1/L8/138/217/LC08_L1GT_138217_20170703_20170703_01_RT/LC08_L1GT_138217_201
   ...: 70703_20170703_01_RT_B5.TIF"
   ...: rdd = gps.geotiff.get(gps.LayerType.SPATIAL, target_image, max_tile_size=512, num_partitions=50)
   ...: tiled_layer = rdd.tile_to_layout(gps.GlobalLayout(), target_crs="EPSG:3857")
   ...: 
Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
17/11/28 13:47:44 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
2017-11-28 13:47:45,613 WARN  - numPartitions option is ignored
17/11/28 13:47:45 WARN S3GeoTiffRDD$: numPartitions option is ignored
                                                                                
In [2]: tiled_layer
Out[2]: TiledRasterLayer(layer_type=LayerType.SPATIAL, zoom_level=13, is_floating_point_layer=False)
```

This PR resolves #485  