### PR TITLE
Akka Actor Dependency Removal

### DIFF
--- a/geopyspark-backend/geotrellis/build.sbt
+++ b/geopyspark-backend/geotrellis/build.sbt
@@ -15,7 +15,6 @@ libraryDependencies ++= Seq(
   "org.locationtech.geotrellis" %% "geotrellis-s3-testkit" % Version.geotrellis,
   "org.locationtech.geotrellis" %% "geotrellis-spark"      % Version.geotrellis,
   "org.typelevel"               %% "cats"                  % "0.9.0",
-  "com.typesafe.akka"     %% "akka-actor"                  % "2.5.6",
   "com.typesafe.akka"     %% "akka-http"                   % "10.0.10",
   "com.typesafe.akka"     %% "akka-http-spray-json"        % "10.0.10",
   "net.sf.py4j"           % "py4j"                         % "0.10.5"


### PR DESCRIPTION
This PR removes the `akka-actor` dependency from GeoPySpark as it caused conflicts for the dependencies of `akk-http`.

This PR resolves #544 