### PR TITLE
Removed Error Handeling in TMS.bind

### DIFF
--- a/geopyspark/geotrellis/tms.py
+++ b/geopyspark/geotrellis/tms.py
@@ -149,13 +149,10 @@ class TMS(object):
         if not host:
             host = "localhost"
 
-        try:
-            if requested_port:
-                self.server.bind(host, requested_port)
-            else:
-                self.server.bind(host)
-        except:
-            raise RuntimeError("Problem binding TMS server")
+        if requested_port:
+            self.server.bind(host, requested_port)
+        else:
+            self.server.bind(host)
 
         self.bound = True
         self._port = self.server.port()


### PR DESCRIPTION
This PR removes the try/catch block in the `TMS.bind` method as the error that it returns was unhelpful. With it gone, it'll be easier to debug the TMS server when something goes wrong.