### PR TITLE
Rasterize an RDD of Geometries

### DIFF
--- a/docs/guides/map-algebra.rst
+++ b/docs/guides/map-algebra.rst
@@ -274,10 +274,10 @@ If, for example, one had a set of polygons representing counties in the US, and
 a value for, say, the median income within each county, a raster could be made
 representing these data.
 
-GeoPySpark's ``rasterize`` function takes a list of any number of
-Shapely geometries, converts them to rasters, tiles the rasters to a
-given layout, and then produces a ``TiledRasterLayer`` with these tiled
-values.
+GeoPySpark's ``rasterize`` function can take a ``[shapely.geometry]``,
+``(shapely.geometry)``, or a ``PythonRDD[shapely.geometry]``. These geometries will be
+converted to rasters, then tiled to a given layout, and then be returned as a
+``TiledRasterLayer`` which contains these tiled values.
 
 Rasterize MultiPolygons
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -292,8 +292,18 @@ Rasterize MultiPolygons
 
 .. code:: python3
 
-    # Creates a TiledRasterLayer that contains the MultiPolygon with a CRS of EPSG:3857 at zoom level 5.
+    # Creates a TiledRasterLayer with a CRS of EPSG:4326 at zoom level 5.
     gps.rasterize(geoms=[raster_multi_poly], crs=4326, zoom=5, fill_value=1)
+
+Rasterize a PythonRDD of Polygons
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python3
+
+    poly_rdd = pysc.parallelize([raster_poly_1, raster_poly_2, raster_poly_3])
+
+    # Creates a TiledRasterLayer with a CRS of EPSG:3857 at zoom level 5.
+    gps.rasterize(geoms=poly_rdd, crs=3857, zoom=3, fill_value=10)
 
 Rasterize LineStrings
 ~~~~~~~~~~~~~~~~~~~~~
@@ -314,5 +324,5 @@ Rasterize Polygons and LineStrings
 
 .. code:: python3
 
-    # Creates a TiledRasterLayer with both the LineStrings and the MultiPolygon
+    # Creates a TiledRasterLayer from both LineStrings and MultiPolygons
     gps.rasterize(geoms=[line_1, line_2, line_3, raster_multi_poly], crs=4326, zoom=5, fill_value=2)

--- a/geopyspark/tests/tiled_layer_tests/rasterize_test.py
+++ b/geopyspark/tests/tiled_layer_tests/rasterize_test.py
@@ -5,14 +5,14 @@ import math
 
 import pytest
 
-from geopyspark.geotrellis import Extent
 from shapely.geometry import Polygon
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis import rasterize
 
 
 class RasterizeTest(BaseTestClass):
-    extent = Extent(0.0, 0.0, 11.0, 11.0)
+    polygon = Polygon([(0, 11), (11, 11), (11, 0), (0, 0)])
+    polygon_collection = [polygon]
 
     @pytest.fixture(autouse=True)
     def tearDown(self):
@@ -20,30 +20,51 @@ class RasterizeTest(BaseTestClass):
         BaseTestClass.pysc._gateway.close()
 
     def test_whole_area(self):
-        polygon = Polygon([(0, 11), (11, 11), (11, 0), (0, 0)])
-
-        raster_rdd = rasterize([polygon],
+        raster_rdd = rasterize(self.polygon_collection,
                                "EPSG:3857",
                                11,
                                1)
 
-        cells = raster_rdd.to_numpy_rdd().first()[1].cells
+        cells = raster_rdd.to_numpy_rdd().values().first().cells
+
+        for x in cells.flatten().tolist():
+            self.assertTrue(math.isnan(x))
+
+    def test_whole_area_rdd(self):
+        python_rdd = BaseTestClass.pysc.parallelize(self.polygon_collection)
+        raster_rdd = rasterize(python_rdd,
+                               "EPSG:3857",
+                               11,
+                               1)
+
+        cells = raster_rdd.to_numpy_rdd().values().first().cells
 
         for x in cells.flatten().tolist():
             self.assertTrue(math.isnan(x))
 
     def test_whole_area_integer_crs(self):
-        polygon = Polygon([(0, 11), (11, 11), (11, 0), (0, 0)])
-
-        raster_rdd = rasterize([polygon],
+        raster_rdd = rasterize(self.polygon_collection,
                                3857,
                                11,
                                1)
 
-        cells = raster_rdd.to_numpy_rdd().first()[1].cells
+        cells = raster_rdd.to_numpy_rdd().values().first().cells
 
         for x in cells.flatten().tolist():
             self.assertTrue(math.isnan(x))
+
+    def test_whole_area_integer_crs_rdd(self):
+        python_rdd = BaseTestClass.pysc.parallelize(self.polygon_collection)
+        raster_rdd = rasterize(python_rdd,
+                               3857,
+                               11,
+                               1)
+
+        cells = raster_rdd.to_numpy_rdd().values().first().cells
+
+        for x in cells.flatten().tolist():
+            self.assertTrue(math.isnan(x))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR will allow the user to pass in an `RDD` of `shapely.geometry`s to the `rasterize` method. In addition, it updates the documentation on this method to reflect these changes.

This PR resolves #521 