### PR TITLE
tobler Method for TiledRasterLayer

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Constants.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Constants.scala
@@ -50,4 +50,8 @@ object Constants {
 
   final val INTKEYS = Array("max_tile_size", "num_partitions", "chunk_size")
   final val STRINGKEYS = Array("crs", "time_tag", "time_format", "delimiter", "s3_client")
+
+  final val NODATACELLS = "NoData"
+  final val DATACELLS = "Data"
+  final val ALLCELLS = "All"
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TileLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TileLayer.scala
@@ -4,6 +4,7 @@ import Constants._
 import geopyspark.geotrellis.GeoTrellisUtils._
 import geotrellis.proj4._
 import geotrellis.raster._
+import geotrellis.raster.mapalgebra.focal._
 import geotrellis.raster.render._
 import geotrellis.raster.histogram._
 import geotrellis.raster.io.geotiff._
@@ -241,6 +242,13 @@ object TileLayer {
     compressionType match {
       case NOCOMPRESSION => NoCompression
       case DEFLATECOMPRESSION => DeflateCompression
+    }
+
+  def getTarget(target: String): TargetCell =
+    target match {
+      case ALLCELLS => TargetCell.All
+      case DATACELLS => TargetCell.Data
+      case NODATACELLS => TargetCell.NoData
     }
 
   def combineBands[K: ClassTag, L <: TileLayer[K]: ClassTag](

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Tobler.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Tobler.scala
@@ -1,0 +1,20 @@
+package geopyspark.geotrellis
+
+import geotrellis.raster._
+import geotrellis.raster.mapalgebra.local._
+import geotrellis.raster.mapalgebra.focal._
+
+
+object Tobler {
+  def apply(
+    r: Tile,
+    n: Neighborhood,
+    bounds: Option[GridBounds],
+    cs: CellSize,
+    z: Double,
+    target: TargetCell = TargetCell.All
+  ): Tile = {
+    val slope = Slope(r, n, bounds, cs ,z, target)
+    6 *: (math.E **: (((slope * math.Pi / 180.0).localTan + 0.05).localAbs * (-3.5)))
+  }
+}

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -6,7 +6,7 @@ __all__ = ['NO_DATA_INT', 'LayerType', 'IndexingMethod', 'ResampleMethod', 'Time
            'Operation', 'Neighborhood', 'ClassificationStrategy', 'CellType', 'ColorRamp',
            'DEFAULT_MAX_TILE_SIZE', 'DEFAULT_PARTITION_BYTES', 'DEFAULT_CHUNK_SIZE',
            'DEFAULT_GEOTIFF_TIME_TAG', 'DEFAULT_GEOTIFF_TIME_FORMAT', 'DEFAULT_S3_CLIENT',
-           'StorageMethod', 'ColorSpace', 'Compression']
+           'StorageMethod', 'ColorSpace', 'Compression', 'TargetCell']
 
 
 """The NoData value for ints in GeoTrellis."""
@@ -285,3 +285,11 @@ class Compression(Enum):
 
     NO_COMPRESSION = "NoCompression"
     DEFLATE_COMPRESSION = "DeflateCompression"
+
+
+class TargetCell(Enum):
+    """Determines which cells in the layer should be used when running a computation."""
+
+    ALL = "All"
+    DATA = "Data"
+    NODATA = "NoData"

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -36,7 +36,8 @@ from geopyspark.geotrellis.constants import (Operation,
                                              StorageMethod,
                                              ColorSpace,
                                              Compression,
-                                             NO_DATA_INT
+                                             NO_DATA_INT,
+                                             TargetCell
                                             )
 from geopyspark.geotrellis.neighborhood import Neighborhood
 
@@ -1783,6 +1784,31 @@ class TiledRasterLayer(CachableLayer, TileLayer):
         """
 
         return self._process_polygonal_summary(geometry, self.srdd.polygonalMean)
+
+    def tobler(self, z_factor=1.0, target_cell=TargetCell.ALL):
+        """Generates a Tobler walking speed layer from an elevation layer.
+
+        Note:
+            This method has a known issue where the Tobler calculation is
+            direction agnostic. Thus, all slopes are assumed to be uphill.
+            This can result it incorrect results. A fix is currently being
+            worked on.
+
+        z_factor (float, optional): How many x and y units in a single z unit.
+            This is a conversion factor between map and elevation units. Defaults
+            to 1.0.
+        target_cell (str or :class:`~geopyspark.geotrellis.constants.TargetCell`, optional):
+            Which cells should be used in the calculation of the Tobler walk speed layer.
+            Defaults to ``TargetCell.ALL``.
+
+        Returns:
+            :class:`~geopyspark.geotrellis.layer.TiledRasterLayer`
+        """
+
+        target_cell = TargetCell(target_cell)
+        result = self.srdd.tobler(z_factor, target_cell.value)
+
+        return TiledRasterLayer(self.layer_type, result)
 
     def _process_operation(self, value, operation):
         if isinstance(value, int) or isinstance(value, float):

--- a/geopyspark/tests/tiled_layer_tests/focal_test.py
+++ b/geopyspark/tests/tiled_layer_tests/focal_test.py
@@ -111,7 +111,7 @@ class FocalTest(BaseTestClass):
 
         self.assertTrue(result.to_numpy_rdd().first()[1].cells[0][1][0] >= 6)
 
-    def test_focal_sum_square(self):
+    def test_focal_sum_square_with_square(self):
         square = Square(extent=1.0)
         result = self.raster_rdd.focal(
             operation=Operation.SUM,
@@ -136,6 +136,9 @@ class FocalTest(BaseTestClass):
                                        param_1=2, param_2=1)
 
         self.assertEqual(result.to_numpy_rdd().first()[1].cells[0][0][0], -1)
+
+    def test_tobler(self):
+        result = self.raster_rdd.tobler()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds the `tobler` method to `TiledRasterLayer`. The logic used create the tobler was taken from this PR: https://github.com/locationtech/geotrellis/pull/2432

**Note**: As mentioned in the linked PR, the `tobler` method assumes all sloped are up hill, and thus, this can result incorrect results. This will be fixed in a future update.