### PR TITLE
Expose Partitioners in the API

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Constants.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Constants.scala
@@ -60,4 +60,7 @@ object Constants {
 
   final val METERSATEQUATOR = 11320
   final val FEETATEQUATOR = 365217.6
+
+  final val HASH = "HashPartitioner"
+  final val SPATIAL = "SpatialPartitioner"
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterLayer.scala
@@ -66,9 +66,9 @@ abstract class RasterLayer[K](implicit ev0: ClassTag[K], ev1: Component[K, Proje
   protected def reproject(targetCRS: String, layoutDefinition: LayoutDefinition, resampleMethod: ResampleMethod): TiledRasterLayer[_]
   protected def withRDD(result: RDD[(K, MultibandTile)]): RasterLayer[K]
 
-  def merge(numPartitions: Integer): RasterLayer[K] =
+  def merge(numPartitions: Integer, partitioner: String): RasterLayer[K] =
     numPartitions match {
-      case i: Integer => withRDD(rdd.merge(Some(new HashPartitioner(i))))
+      case i: Integer => withRDD(rdd.merge(Some(TileLayer.getPartitioner(i, partitioner))))
       case null => withRDD(rdd.merge())
     }
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialPartitioner.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialPartitioner.scala
@@ -1,0 +1,29 @@
+package geopyspark.geotrellis
+
+import geotrellis.spark._
+import geotrellis.spark.io.index._
+import geotrellis.spark.io.index.zcurve._
+import geotrellis.util._
+
+import org.apache.spark._
+
+import scala.reflect._
+
+
+class SpatialPartitioner[K: SpatialComponent](partitions: Int, bits: Int) extends Partitioner {
+  def numPartitions: Int = partitions
+
+  def getPartition(key: Any): Int = {
+    val k = key.asInstanceOf[K]
+    val SpatialKey(col, row) = k.getComponent[SpatialKey]
+    ((Z2(col, row).z >> bits) % partitions).toInt
+  }
+}
+
+object SpatialPartitioner {
+  def apply[K: SpatialComponent](partitions: Int, bits: Int): SpatialPartitioner[K] =
+    new SpatialPartitioner[K](partitions, bits)
+
+  def apply[K: SpatialComponent](partitions: Int): SpatialPartitioner[K] =
+    new SpatialPartitioner[K](partitions, 8)
+}

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialTiledRasterLayer.scala
@@ -543,7 +543,8 @@ object SpatialTiledRasterLayer {
     requestedCellType: String,
     options: Rasterizer.Options,
     numPartitions: Integer,
-    zIndexCellType: String
+    zIndexCellType: String,
+    layerPartitioner: String
   ): SpatialTiledRasterLayer = {
     import geotrellis.raster.rasterize.Rasterizer.Options
 
@@ -559,7 +560,8 @@ object SpatialTiledRasterLayer {
     val LayoutLevel(z, ld) = ZoomedLayoutScheme(srcCRS).levelForZoom(requestedZoom)
     val maptrans = ld.mapTransform
     val gb @ GridBounds(cmin, rmin, cmax, rmax) = maptrans(fullEnvelope)
-    val partitioner = new HashPartitioner(Option(numPartitions).map(_.toInt).getOrElse(math.max(gb.size / 512, 1)))
+    val partitions = Option(numPartitions).map(_.toInt).getOrElse(math.max(gb.size / 512, 1))
+    val partitioner = TileLayer.getPartitioner(partitions, layerPartitioner)
 
     val tiles =
       RasterizeRDD.fromFeatureWithZIndex(

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
@@ -224,9 +224,9 @@ class TemporalTiledRasterLayer(
     TemporalTiledRasterLayer(zoom, tileLayer)
   }
 
-  def pyramid(resampleMethod: ResampleMethod): Array[TiledRasterLayer[SpaceTimeKey]] = {
+  def pyramid(resampleMethod: ResampleMethod, partitioner: String): Array[TiledRasterLayer[SpaceTimeKey]] = {
     require(! rdd.metadata.bounds.isEmpty, "Can not pyramid an empty RDD")
-    val part = rdd.partitioner.getOrElse(new HashPartitioner(rdd.partitions.length))
+    val part = TileLayer.getPartitioner(rdd.partitions.length, partitioner)
     val (baseZoom, scheme) =
       zoomLevel match {
         case Some(zoom) =>

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TileLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TileLayer.scala
@@ -251,6 +251,12 @@ object TileLayer {
       case NODATACELLS => TargetCell.NoData
     }
 
+  def getPartitioner(partitions: Int, partitioner: String): Partitioner =
+    partitioner match {
+      case HASH => new HashPartitioner(partitions)
+      case SPATIAL => SpatialPartitioner(partitions)
+    }
+
   def combineBands[K: ClassTag, L <: TileLayer[K]: ClassTag](
     sc: SparkContext,
     layers: ArrayList[L]

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -6,7 +6,7 @@ __all__ = ['NO_DATA_INT', 'LayerType', 'IndexingMethod', 'ResampleMethod', 'Time
            'Operation', 'Neighborhood', 'ClassificationStrategy', 'CellType', 'ColorRamp',
            'DEFAULT_MAX_TILE_SIZE', 'DEFAULT_PARTITION_BYTES', 'DEFAULT_CHUNK_SIZE',
            'DEFAULT_GEOTIFF_TIME_TAG', 'DEFAULT_GEOTIFF_TIME_FORMAT', 'DEFAULT_S3_CLIENT',
-           'StorageMethod', 'ColorSpace', 'Compression', 'Unit']
+           'StorageMethod', 'ColorSpace', 'Compression', 'Unit', 'Partitioner']
 
 
 """The NoData value for ints in GeoTrellis."""
@@ -285,8 +285,21 @@ class Compression(Enum):
     NO_COMPRESSION = "NoCompression"
     DEFLATE_COMPRESSION = "DeflateCompression"
 
+
 class Unit(Enum):
     """Represents the units of elevation."""
 
     METERS = "Meters"
     FEET = "Feet"
+
+
+class Partitioner(Enum):
+    """Partitioners to reparttion a layer.
+
+    There are currently two supported Partitioners:
+        - ``HASH_PARTITIONER`` Spark's HashPartitioner
+        - ``SPATIAL_PARTITIONER`` partitions data based on they key of each element.
+    """
+
+    HASH_PARTITIONER = "HashPartitioner"
+    SPATIAL_PARTITIONER = "SpatialPartitioner"

--- a/geopyspark/geotrellis/rasterize.py
+++ b/geopyspark/geotrellis/rasterize.py
@@ -84,7 +84,8 @@ def rasterize_features(features,
                        cell_type=CellType.FLOAT64,
                        options=None,
                        num_partitions=None,
-                       zindex_cell_type=CellType.INT8):
+                       zindex_cell_type=CellType.INT8,
+                       partitioner=Partitioner.HASH_PARTITIONER):
     """Rasterizes a collection of :class:`~geopyspark.vector_pipe.Feature`\s.
 
     Args:
@@ -107,6 +108,9 @@ def rasterize_features(features,
             repartitioned. If ``None``, then the data will not be repartitioned.
         zindex_cell_type (str or :class:`~geopyspark.geotrellis.constants.CellType`): Which data type
             the ``Z-Index`` cells are. Defaults to ``CellType.INT8``.
+        partitioner (str or :class:`~geopyspark.geotrellis.constants.Partitioner, optional): The partitioner
+            that will be used to partition the resulting layer. Defaults to ``Partitioner.HASH_PARTITIONER``.
+
 
     Returns:
         :class:`~geopyspark.geotrellis.layer.TiledRasterLayer`
@@ -114,6 +118,8 @@ def rasterize_features(features,
 
     if isinstance(crs, int):
         crs = str(crs)
+
+    partitioner = Partitioner(partitioner).value
 
     pysc = get_spark_context()
     rasterizer = pysc._gateway.jvm.geopyspark.geotrellis.SpatialTiledRasterLayer.rasterizeFeaturesWithZIndex
@@ -127,6 +133,7 @@ def rasterize_features(features,
                       CellType(cell_type).value,
                       options,
                       num_partitions,
-                      CellType(zindex_cell_type).value)
+                      CellType(zindex_cell_type).value,
+                      partitioner)
 
     return TiledRasterLayer(LayerType.SPATIAL, srdd)

--- a/geopyspark/geotrellis/rasterize.py
+++ b/geopyspark/geotrellis/rasterize.py
@@ -1,6 +1,6 @@
 from shapely.wkb import dumps
 from geopyspark import get_spark_context
-from geopyspark.geotrellis.constants import LayerType, CellType
+from geopyspark.geotrellis.constants import LayerType, CellType, Partitioner
 from geopyspark.geotrellis.layer import TiledRasterLayer
 from geopyspark.geotrellis.protobufserializer import ProtoBufSerializer
 
@@ -11,8 +11,15 @@ from geopyspark.vector_pipe.vector_pipe_protobufcodecs import (feature_cellvalue
 __all__ = ['rasterize', 'rasterize_features']
 
 
-def rasterize(geoms, crs, zoom, fill_value, cell_type=CellType.FLOAT64, options=None, num_partitions=None):
-    """Rasterizes a collection of Shapely geometries.
+def rasterize(geoms,
+              crs,
+              zoom,
+              fill_value,
+              cell_type=CellType.FLOAT64,
+              options=None,
+              num_partitions=None,
+              partitioner=Partitioner.HASH_PARTITIONER):
+    """Rasterizes a Shapely geometries.
 
     Args:
         geoms ([shapely.geometry] or (shapely.geometry) or pyspark.RDD[shapely.geometry]): Either
@@ -25,6 +32,8 @@ def rasterize(geoms, crs, zoom, fill_value, cell_type=CellType.FLOAT64, options=
         options (:class:`~geopyspark.geotrellis.RasterizerOptions`, optional): Pixel intersection options.
         num_partitions (int, optional): The number of repartitions Spark will make when the data is
             repartitioned. If ``None``, then the data will not be repartitioned.
+        partitioner (str or :class:`~geopyspark.geotrellis.constants.Partitioner, optional): The partitioner
+            that will be used to partition the resulting layer. Defaults to ``Partitioner.HASH_PARTITIONER``.
 
     Returns:
         :class:`~geopyspark.geotrellis.layer.TiledRasterLayer`
@@ -35,6 +44,7 @@ def rasterize(geoms, crs, zoom, fill_value, cell_type=CellType.FLOAT64, options=
 
     pysc = get_spark_context()
     rasterizer = pysc._gateway.jvm.geopyspark.geotrellis.SpatialTiledRasterLayer.rasterizeGeometry
+    partitioner = Partitioner(partitioner).value
 
     if isinstance(geoms, (list, tuple)):
         wkb_geoms = [dumps(g) for g in geoms]
@@ -46,7 +56,8 @@ def rasterize(geoms, crs, zoom, fill_value, cell_type=CellType.FLOAT64, options=
                           float(fill_value),
                           CellType(cell_type).value,
                           options,
-                          num_partitions)
+                          num_partitions,
+                          partitioner)
 
     else:
         wkb_rdd = geoms.map(lambda geom: dumps(geom))
@@ -61,7 +72,8 @@ def rasterize(geoms, crs, zoom, fill_value, cell_type=CellType.FLOAT64, options=
                           float(fill_value),
                           CellType(cell_type).value,
                           options,
-                          num_partitions)
+                          num_partitions,
+                          partitioner)
 
     return TiledRasterLayer(LayerType.SPATIAL, srdd)
 

--- a/geopyspark/tests/geotrellis/geotiff_raster_rdd_test.py
+++ b/geopyspark/tests/geotrellis/geotiff_raster_rdd_test.py
@@ -4,22 +4,44 @@ import rasterio
 import pytest
 import numpy as np
 
+<<<<<<< ce5e03f7210966d893129311d1dd5b3945075bf7:geopyspark/tests/geotrellis/geotiff_raster_rdd_test.py
 from geopyspark.geotrellis.constants import LayerType, CellType
 from geopyspark.tests.python_test_utils import file_path
+=======
+from geopyspark.geotrellis.constants import LayerType, CellType, Partitioner
+from geopyspark.tests.python_test_utils import geotiff_test_path
+>>>>>>> Exposed Partitioner options in the API:geopyspark/tests/geotiff_raster_rdd_test.py
 from geopyspark.geotrellis import Extent, ProjectedExtent, Tile
 from geopyspark.geotrellis.geotiff import get
 from geopyspark.geotrellis.layer import RasterLayer
 from geopyspark.tests.base_test_class import BaseTestClass
 
 
+<<<<<<< ce5e03f7210966d893129311d1dd5b3945075bf7:geopyspark/tests/geotrellis/geotiff_raster_rdd_test.py
 class Multiband(BaseTestClass):
     dir_path = file_path("all-ones.tif")
+=======
+class GeoTiffRasterRDDTest(BaseTestClass):
+    dir_path = geotiff_test_path("all-ones.tif")
+>>>>>>> Exposed Partitioner options in the API:geopyspark/tests/geotiff_raster_rdd_test.py
     result = get(LayerType.SPATIAL, dir_path, max_tile_size=256)
 
     @pytest.fixture(autouse=True)
     def tearDown(self):
         yield
         BaseTestClass.pysc._gateway.close()
+
+    def test_repartition(self):
+        md = self.result.collect_metadata()
+        laid_out_rdd = BaseTestClass.rdd.tile_to_layout(md)
+        repartitioned = laid_out_rdd.repartition(2)
+        self.assertEqual(repartitioned.getNumPartitions(), 2)
+
+    def test_repartition_with_partitioner(self):
+        tiled = self.result.tile_to_layout()
+        repartitioned = tiled.repartition(2, Partitioner.SPATIAL_PARTITIONER)
+
+        self.assertEqual(repartitioned.getNumPartitions(), 2)
 
     def test_to_numpy_rdd(self, option=None):
         pyrdd = self.result.to_numpy_rdd()

--- a/geopyspark/tests/geotrellis/geotiff_raster_rdd_test.py
+++ b/geopyspark/tests/geotrellis/geotiff_raster_rdd_test.py
@@ -4,26 +4,16 @@ import rasterio
 import pytest
 import numpy as np
 
-<<<<<<< ce5e03f7210966d893129311d1dd5b3945075bf7:geopyspark/tests/geotrellis/geotiff_raster_rdd_test.py
-from geopyspark.geotrellis.constants import LayerType, CellType
-from geopyspark.tests.python_test_utils import file_path
-=======
 from geopyspark.geotrellis.constants import LayerType, CellType, Partitioner
-from geopyspark.tests.python_test_utils import geotiff_test_path
->>>>>>> Exposed Partitioner options in the API:geopyspark/tests/geotiff_raster_rdd_test.py
+from geopyspark.tests.python_test_utils import file_path
 from geopyspark.geotrellis import Extent, ProjectedExtent, Tile
 from geopyspark.geotrellis.geotiff import get
 from geopyspark.geotrellis.layer import RasterLayer
 from geopyspark.tests.base_test_class import BaseTestClass
 
 
-<<<<<<< ce5e03f7210966d893129311d1dd5b3945075bf7:geopyspark/tests/geotrellis/geotiff_raster_rdd_test.py
-class Multiband(BaseTestClass):
-    dir_path = file_path("all-ones.tif")
-=======
 class GeoTiffRasterRDDTest(BaseTestClass):
-    dir_path = geotiff_test_path("all-ones.tif")
->>>>>>> Exposed Partitioner options in the API:geopyspark/tests/geotiff_raster_rdd_test.py
+    dir_path = file_path("all-ones.tif")
     result = get(LayerType.SPATIAL, dir_path, max_tile_size=256)
 
     @pytest.fixture(autouse=True)

--- a/geopyspark/tests/geotrellis/reproject_test.py
+++ b/geopyspark/tests/geotrellis/reproject_test.py
@@ -18,10 +18,6 @@ class ReprojectTest(BaseTestClass):
         yield
         BaseTestClass.pysc._gateway.close()
 
-    def test_repartition(self):
-        laid_out_rdd = BaseTestClass.rdd.tile_to_layout(self.metadata)
-        result = laid_out_rdd.repartition(2)
-        self.assertEqual(result.getNumPartitions(), 2)
 
     def test_same_crs_layout(self):
         result = BaseTestClass.rdd.tile_to_layout(layout=self.layout_def, target_crs="EPSG:4326")

--- a/geopyspark/tests/geotrellis/tiled_layer_tests/rasterize_test.py
+++ b/geopyspark/tests/geotrellis/tiled_layer_tests/rasterize_test.py
@@ -5,6 +5,7 @@ import math
 
 import pytest
 
+from geopyspark.geotrellis.constants import Partitioner
 from shapely.geometry import Polygon
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis import rasterize
@@ -38,6 +39,20 @@ class RasterizeTest(BaseTestClass):
                                1)
 
         cells = raster_rdd.to_numpy_rdd().values().first().cells
+
+        for x in cells.flatten().tolist():
+            self.assertTrue(math.isnan(x))
+
+    def test_whole_area_with_spatial_partitioner(self):
+        polygon = Polygon([(0, 11), (11, 11), (11, 0), (0, 0)])
+
+        raster_rdd = rasterize([polygon],
+                               "EPSG:3857",
+                               11,
+                               1,
+                               partitioner=Partitioner.SPATIAL_PARTITIONER)
+
+        cells = raster_rdd.to_numpy_rdd().first()[1].cells
 
         for x in cells.flatten().tolist():
             self.assertTrue(math.isnan(x))

--- a/geopyspark/tests/vector_pipe/rasterizer_test.py
+++ b/geopyspark/tests/vector_pipe/rasterizer_test.py
@@ -1,7 +1,7 @@
 import unittest
 import pytest
 
-from geopyspark.geotrellis import CellType
+from geopyspark.geotrellis import CellType, Partitioner
 from geopyspark.vector_pipe import osm_reader, Feature, CellValue
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.tests.python_test_utils import file_path
@@ -38,6 +38,36 @@ class RasterizationTest(BaseTestClass):
 
         unioned = BaseTestClass.pysc.union((mapped_lines, mapped_polys))
         result = rasterize_features(unioned, 4326, 12, cell_type=CellType.INT8)
+
+        self.assertEqual(result.get_min_max(), (1, 4))
+        self.assertEqual(result.count(), 1)
+
+    def test_rasterization_with_partitioner(self):
+        features = osm_reader.from_orc(file_path("zerns.orc"))
+
+        lines = features.get_line_features_rdd()
+        polys = features.get_polygon_features_rdd()
+
+        mapped_lines = lines.map(lambda feature: Feature(feature.geometry, CellValue(1, 1)))
+
+        def assign_cellvalues(feature):
+            tags = feature.properties.tags.values()
+
+            if 'water' in tags:
+                return Feature(feature.geometry, CellValue(4, 4))
+            elif "en:Zern's Farmer's Market" in tags:
+                return Feature(feature.geometry, CellValue(3, 3))
+            else:
+                return Feature(feature.geometry, CellValue(2, 2))
+
+        mapped_polys = polys.map(lambda feature: assign_cellvalues(feature))
+
+        unioned = BaseTestClass.pysc.union((mapped_lines, mapped_polys))
+        result = rasterize_features(unioned,
+                                    4326,
+                                    12,
+                                    cell_type=CellType.INT8,
+                                    partitioner=Partitioner.SPATIAL_PARTITIONER)
 
         self.assertEqual(result.get_min_max(), (1, 4))
         self.assertEqual(result.count(), 1)


### PR DESCRIPTION
This PR exposes a choice of a `Partitioner` when performing operations in GPS. The two that have been added are: `HashPartitioner` and `SpatialPartitioner`, which was created by @echeipesh. As of this PR, the methods where the `Partitioner`s are exposed in are: `repartition`, `merge`, `pyramid`, and `rasterize`.

**Note**: The way to add custom `Partitioner`s in PySpark is by passing in `partitionFunc` as a parameter instead of a `Partition` instance (see [this](https://github.com/apache/spark/blob/7d039e0c0af0931a1696d89e76f455ae4adf277d/python/pyspark/rdd.py#L1736) as an example). Because of this, there might not be a way in which we can preserve the same partitioning strategy a user set when working with the layer in Scala.