### PR TITLE
TiledRasterLayer reproject Bug Fix

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialTiledRasterLayer.scala
@@ -65,7 +65,8 @@ class SpatialTiledRasterLayer(
 
   def reproject(targetCRS: String, resampleMethod: ResampleMethod): SpatialTiledRasterLayer = {
     val crs = TileLayer.getCRS(targetCRS).get
-    val (zoom, reprojected) = rdd.reproject(crs, rdd.metadata.layout, resampleMethod)
+    val targetLayout = FloatingLayoutScheme(rdd.metadata.layout.tileCols, rdd.metadata.layout.tileRows)
+    val (zoom, reprojected) = rdd.reproject(crs, targetLayout, resampleMethod)
     new SpatialTiledRasterLayer(Some(zoom), reprojected)
   }
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
@@ -163,7 +163,8 @@ class TemporalTiledRasterLayer(
 
   def reproject(targetCRS: String, resampleMethod: ResampleMethod): TemporalTiledRasterLayer = {
     val crs = TileLayer.getCRS(targetCRS).get
-    val (zoom, reprojected) = rdd.reproject(crs, rdd.metadata.layout, resampleMethod)
+    val targetLayout = FloatingLayoutScheme(rdd.metadata.layout.tileCols, rdd.metadata.layout.tileRows)
+    val (zoom, reprojected) = rdd.reproject(crs, targetLayout, resampleMethod)
     TemporalTiledRasterLayer(Some(zoom), reprojected)
   }
 


### PR DESCRIPTION
This PR fixes a bug in the `TiledRasterLayer`'s `reproject` method where the layers were being reprojected to the wrong layout.

This PR resolves #580