### PR TITLE
Minor Fixes for VP Backend

### DIFF
--- a/geopyspark-backend/vectorpipe/build.sbt
+++ b/geopyspark-backend/vectorpipe/build.sbt
@@ -8,7 +8,6 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "org.apache.spark"            %% "spark-core"            % "2.0.0" % "provided",
   "org.apache.spark"            %% "spark-hive"            % "2.2.0" % "provided",
   "org.locationtech.geotrellis" %% "geotrellis-s3"         % Version.geotrellis,
   "org.locationtech.geotrellis" %% "geotrellis-s3-testkit" % Version.geotrellis,

--- a/geopyspark-backend/vectorpipe/src/main/scala/geopyspark/vectorpipe/io/OSMReader.scala
+++ b/geopyspark-backend/vectorpipe/src/main/scala/geopyspark/vectorpipe/io/OSMReader.scala
@@ -18,7 +18,7 @@ object OSMReader {
     source: String
   ): FeaturesCollection =
     osm.fromORC(source)(ss) match {
-      case Failure(e) => null
+      case Failure(e) => throw new Exception(e)
       case S((ns, ws, rs)) => FeaturesCollection(osm.features(ns, ws, rs))
     }
 }


### PR DESCRIPTION
This PR changes two this in the VP backend. The first is the removal of the `org.apache.spark` dependency. The second is that now `OSMReader.read` will now throw an error if it failed to read a file instead of silently failing.