### PR TITLE
Documentation for the Vector Pipe Code 2

### DIFF
--- a/docs/docs/geopyspark.vector_pipe.features_collection.rst
+++ b/docs/docs/geopyspark.vector_pipe.features_collection.rst
@@ -1,0 +1,6 @@
+geopyspark.vector_pipe.features_collection module
+==================================================
+
+.. automodule:: geopyspark.vector_pipe.features_collection
+   :members:
+   :inherited-members:

--- a/docs/docs/geopyspark.vector_pipe.osm_reader.rst
+++ b/docs/docs/geopyspark.vector_pipe.osm_reader.rst
@@ -1,0 +1,6 @@
+geopyspark.vector_pipe.osm_reader module
+=========================================
+
+.. automodule:: geopyspark.vector_pipe.osm_reader
+   :members:
+   :inherited-members:

--- a/docs/docs/geopyspark.vector_pipe.rst
+++ b/docs/docs/geopyspark.vector_pipe.rst
@@ -1,0 +1,26 @@
+geopyspark.vector_pipe package
+===============================
+
+.. autoclass:: geopyspark.vector_pipe.Feature
+   :members:
+   :inherited-members:
+   :undoc-members:
+
+.. autoclass:: geopyspark.vector_pipe.Properties
+   :members:
+   :inherited-members:
+   :undoc-members:
+
+.. autoclass:: geopyspark.vector_pipe.CellValue
+   :members:
+   :inherited-members:
+   :undoc-members:
+
+.. toctree::
+  :maxdepth: 2
+  :caption: Modules
+  :glob:
+  :hidden:
+
+  geopyspark.vector_pipe.features_collection
+  geopyspark.vector_pipe.osm_reader

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -136,3 +136,4 @@ a need for it.
 
   docs/geopyspark
   docs/geopyspark.geotrellis
+  docs/geopyspark.vector_pipe

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -127,6 +127,7 @@ a need for it.
 
   tutorials/ingesting-an-image
   tutorials/reading-in-sentinel-data
+  tutorials/reading-and-rasterizing-osm-data
 
 .. toctree::
   :maxdepth: 2

--- a/docs/tutorials/reading-and-rasterizing-osm-data.rst
+++ b/docs/tutorials/reading-and-rasterizing-osm-data.rst
@@ -1,0 +1,110 @@
+Reading and Rasterizing Open Street Map Data
+---------------------------------------------
+
+
+This tutorial shows how to read in Open Street Map (OSM) data, and then
+rasterize it using GeoPySpark.
+
+**Note**: This guide is aimed at users who are already familiar with GeoPySpark.
+
+
+Getting the Data
+=================
+
+To start, let's first grab an `orc file <https://orc.apache.org/>`__,
+which a special file type that is optimized for Hadoop operations.
+The following command will use ``curl`` to download the file from
+``S3`` and move it to the ``/tmp`` directory.
+
+.. code::
+
+  curl -o /tmp/boyertown.orc https://s3.amazonaws.com/geopyspark-test/example-files/boyertown.orc
+
+**A side note**: Files can be retrieved directly from S3. However, this could
+not be done in this instance due to permission requirements needed to access
+the file.
+
+
+Reading in the Data
+====================
+
+Now that we have our data, we can now read it in and begin to work with. We
+will first begin by reading it in.
+
+.. code:: python3
+
+   import geopyspark as gps
+   from pyspark import SparkContext
+
+   conf = gps.geopyspark_conf(appName="osm-rasterize-example", master="local[*]")
+   pysc = SparkContext(conf=conf)
+
+   features = gps.osm_reader.from_orc("/tmp/boyertown.orc")
+
+The above code sets up a ``SparkContext`` and then reads in the
+``boyertown.orc`` file as ``features``, which is an instance
+of ``FeaturesCollection``.
+
+When OSM data is read into GeoPySpark, each OSM Element is turned into either
+a single or multiple different geometries. With each of these geometries
+retaining the metadata of the derived OSM Element. These geometry metadata
+pairs are refered to as a ``Feature``. Internally, these features are
+grouped together by the type of geometry they contain. When accessing
+features from a ``FeaturesCollection``, it is done by geometry.
+
+Selecting the Features We Want
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For this example, we're interested in rasterizing the ``Line``\s and
+``Polygon``\s from the OSM data, so we will select those ``Feature``\s
+from the ``features``. The following code will create a Python ``RDD``
+of ``Feature``\s that contains all ``Line`` geometries (``lines``), and a
+Python ``RDD`` that contains all ``Polygon`` geometries (``polygons``).
+
+.. code:: python3
+
+   lines = features.get_line_features_rdd()
+   polygons = features.get_polygon_features_rdd()
+
+Looking at the Tags of the Features
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When we rasterize the ``Polygon`` ``Feature``\s we would like to have some
+``Polygon``\s with different values than others. In this case, we'd like
+for schools to have a different value than all of the other polygons.
+However, we are unsure if any schools were contained within the original data,
+and we'd like to see if any are there. One method we could use to determine
+if there are schools is to look at the tags of the ``Polygon`` ``Feature``\s.
+The following code will show all of the unique tags for all of the ``Polygon``\s
+in the collection.
+
+.. code:: python3
+
+   features.get_polygon_tags()
+
+Which has the following output:
+
+
+Assigning Values to Geometries
+===============================
+
+Now that we have our geometries setup, it's now time assign them values. The
+reason we need to so is because when vector becomes a raster, its cells need
+to have some kind of value. When rasterizing geometries, each shape will be
+assigned a single value, and all cells that intersect that shape will have
+that value. In addition to value of the actual cells, there's another propertry
+that we will want to give each geometry. That property being ``Z-Index``.
+
+The ``Z-Index`` of a geometry determines what value a cell will be if more than
+one geometry intersects it. With a higher ``Z-Index`` taking priority over
+a lower one. This is important as there may be cases where multiple geometires
+are present at a single cell, but that cell can only contain one value.
+
+For this example, we are going to want to
+
+
+For example, there's a park that's a ``Polygon`` and inside the park are
+benches represented as ``Point``\s. The actual cell values between the park
+and the benches are different, and we'd like to make sure that the values
+of the benches are present in the resulting raster. Therefore, we assign
+the benches a ``Z-Index`` of 2 and the park a ``Z-Index`` of 1.

--- a/docs/tutorials/reading-and-rasterizing-osm-data.rst
+++ b/docs/tutorials/reading-and-rasterizing-osm-data.rst
@@ -1,7 +1,6 @@
 Reading and Rasterizing Open Street Map Data
 ---------------------------------------------
 
-
 This tutorial shows how to read in Open Street Map (OSM) data, and then
 rasterize it using GeoPySpark.
 
@@ -28,8 +27,7 @@ the file.
 Reading in the Data
 ====================
 
-Now that we have our data, we can now read it in and begin to work with. We
-will first begin by reading it in.
+Now that we have our data, we can now read it in and begin to work with.
 
 .. code:: python3
 
@@ -45,38 +43,46 @@ The above code sets up a ``SparkContext`` and then reads in the
 ``boyertown.orc`` file as ``features``, which is an instance
 of ``FeaturesCollection``.
 
-When OSM data is read into GeoPySpark, each OSM Element is turned into either
-a single or multiple different geometries. With each of these geometries
-retaining the metadata of the derived OSM Element. These geometry metadata
-pairs are refered to as a ``Feature``. Internally, these features are
-grouped together by the type of geometry they contain. When accessing
-features from a ``FeaturesCollection``, it is done by geometry.
+When OSM data is read into GeoPySpark, each OSM Element is turned into
+single or multiple different geometries. With each of these geometries
+retaining the metadata from the derived OSM Element. These geometry metadata
+pairs are referred to as a ``Feature``. These features are grouped together by
+the type of geometry they contain. When accessing features from a
+``FeaturesCollection``, it is done by geometry.
+
+There are four different types of geometries in the ``FeaturesCollection``:
+
+  - ``Point``
+  - ``Line``
+  - ``Polygon``
+  - ``MultiPolygon``
+
 
 Selecting the Features We Want
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For this example, we're interested in rasterizing the ``Line``\s and
 ``Polygon``\s from the OSM data, so we will select those ``Feature``\s
-from the ``features``. The following code will create a Python ``RDD``
-of ``Feature``\s that contains all ``Line`` geometries (``lines``), and a
-Python ``RDD`` that contains all ``Polygon`` geometries (``polygons``).
+from the ``FeaturesCollection`` that contain them. The following code will
+create a Python ``RDD`` of ``Feature``\s that contains all ``Line`` geometries
+(``lines``), and a Python ``RDD`` that contains all ``Polygon``
+geometries (``polygons``).
 
 .. code:: python3
 
    lines = features.get_line_features_rdd()
    polygons = features.get_polygon_features_rdd()
 
+
 Looking at the Tags of the Features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When we rasterize the ``Polygon`` ``Feature``\s we would like to have some
-``Polygon``\s with different values than others. In this case, we'd like
-for schools to have a different value than all of the other polygons.
-However, we are unsure if any schools were contained within the original data,
-and we'd like to see if any are there. One method we could use to determine
-if there are schools is to look at the tags of the ``Polygon`` ``Feature``\s.
-The following code will show all of the unique tags for all of the ``Polygon``\s
-in the collection.
+When we rasterize the ``Polygon`` ``Feature``\s, we'd like for schools to have
+a different value than all of the other ``Polygon``\s.  However, we are unsure
+if any schools were contained within the original data, and we'd like to see
+if any are. One method we could use to determine if there are schools is to
+look at the tags of the ``Polygon`` ``Feature``\s.  The following code will show
+all of the unique tags for all of the ``Polygon``\s in the collection.
 
 .. code:: python3
 
@@ -84,27 +90,100 @@ in the collection.
 
 Which has the following output:
 
+.. code::
+
+   {'NHD:ComID': '25964412',
+    'NHD:Elevation': '0.00000000000',
+    'NHD:FCode': '39004',
+    'NHD:FDate': '2001/08/16',
+    'NHD:FTYPE': 'LakePond',
+    'NHD:Permanent_': '25964412',
+    'NHD:ReachCode': '02040203004486',
+    'NHD:Resolution': 'High',
+    'addr:city': 'Gilbertsville',
+    'addr:housenumber': '1100',
+    'addr:postcode': '19525',
+    'addr:state': 'PA',
+    'addr:street': 'E Philadelphia Avenue',
+    'amenity': 'school',
+    'area': 'yes',
+    'building': 'yes',
+    'leisure': 'pitch',
+    'name': 'Boyertown Area Junior High School-West Center',
+    'natural': 'water',
+    'railway': 'platform',
+    'smoking': 'outside',
+    'source': 'Yahoo',
+    'sport': 'baseball',
+    'tourism': 'museum',
+    'wikidata': 'Q8069423',
+    'wikipedia': "en:Zern's Farmer's Market"}
+
+
+So it appears that there are schools in this dataset, and that we can continue
+on.
+
 
 Assigning Values to Geometries
 ===============================
 
-Now that we have our geometries setup, it's now time assign them values. The
-reason we need to so is because when vector becomes a raster, its cells need
-to have some kind of value. When rasterizing geometries, each shape will be
-assigned a single value, and all cells that intersect that shape will have
-that value. In addition to value of the actual cells, there's another propertry
-that we will want to give each geometry. That property being ``Z-Index``.
+Now that we have our ``Feature``\s, it's time to assign them values. The
+reason we need to do so is because when a vector becomes a raster, its cells
+need to have some kind of value. When rasterizing ``Feature``\s, each geometry
+contained within it will be given a single value, and all cells that intersect
+that shape will have that value. In addition to value of the actual cells,
+there's another property that we will want to set for each
+``Feature``, ``Z-Index``.
 
-The ``Z-Index`` of a geometry determines what value a cell will be if more than
-one geometry intersects it. With a higher ``Z-Index`` taking priority over
-a lower one. This is important as there may be cases where multiple geometires
+The ``Z-Index`` of a ``Feature`` determines what value a cell will be if more
+than one geometry intersects it. With a higher ``Z-Index`` taking priority over
+a lower one. This is important as there may be cases where multiple geometries
 are present at a single cell, but that cell can only contain one value.
 
-For this example, we are going to want to
+For this example, we are going to want all ``Polygon``\s to have a higher
+``Z-Index`` than the ``Line``\s. In addition, since we're interested in
+schools, ``Polygon``\s that are labeled as schools will have a greater
+``Z-Index`` than other ``Polygon``\s.
+
+.. code:: python3
+
+   mapped_lines = lines.map(lambda feature: gps.Feature(feautre.geometry, gps.CellValue(value=1, zindex=1)))
+
+   def assign_polygon_feature(feature):
+       tags = feature.properties.tags.values()
+
+       if 'school' in tags.values():
+           return gps.Feature(feature.geometry, gps.CellValue(value=3, zindex=3))
+       else:
+           return gps.Feature(feature.geometry, gps.CellValue(value=2, zindex=2))
+
+   mapped_polygons = polygons.map(assign_polygon_feature)
+
+We create the ``mapped_lines`` variable that contains an ``RDD`` of ``Feature``\s,
+where each ``Feature`` has a ``CellValue`` with a ``value`` and ``zindex`` of 1.
+The ``assign_polygon_feature`` function is then created which will test to see if a
+``Polygon`` is a school or not. If it is, then the resulting ``Feature`` will
+have a ``CellValue`` with a ``value`` and ``zindex`` of 3. Otherwise, those
+two values will be 2.
 
 
-For example, there's a park that's a ``Polygon`` and inside the park are
-benches represented as ``Point``\s. The actual cell values between the park
-and the benches are different, and we'd like to make sure that the values
-of the benches are present in the resulting raster. Therefore, we assign
-the benches a ``Z-Index`` of 2 and the park a ``Z-Index`` of 1.
+Rasterizing the Features
+=========================
+
+Now that the ``Feature``\s have been given ``CellValue``\s, it is now time to
+rasterize them.
+
+.. code:: python3
+
+   unioned_features = pysc.union((mapped_lines, mapped_polygons))
+
+   rasterized_layer = gps.rasterize_features(features=unioned_features, crs=4326, zoom=12)
+
+The ``rasterize_features`` function requires a single ``RDD`` of ``Feature``\s.
+Therefore, we union together ``mapped_lines`` and ``mapped_polygons`` which
+gives us ``unioned_features``. Along with passing in our ``RDD``, we must also
+set the ``crs`` and ``zoom`` of the resulting Layer. In this case, the ``crs``
+is in ``LatLng``, so we set it to be ``4326``. ``zoom`` varies between use cases,
+so it was just chosen arbitrarily for this example. The resulting
+``rasterized_layer`` is a ``TiledRasterLayer`` that we can now analyze and/or
+ingest.

--- a/geopyspark/geotrellis/rasterize.py
+++ b/geopyspark/geotrellis/rasterize.py
@@ -12,7 +12,7 @@ __all__ = ['rasterize', 'rasterize_features']
 
 
 def rasterize(geoms, crs, zoom, fill_value, cell_type=CellType.FLOAT64, options=None, num_partitions=None):
-    """Rasterizes a Shapely geometries.
+    """Rasterizes a collection of Shapely geometries.
 
     Args:
         geoms ([shapely.geometry] or (shapely.geometry) or pyspark.RDD[shapely.geometry]): Either
@@ -73,6 +73,32 @@ def rasterize_features(features,
                        options=None,
                        num_partitions=None,
                        zindex_cell_type=CellType.INT8):
+    """Rasterizes a collection of :class:`~geopyspark.vector_pipe.Feature`\s.
+
+    Args:
+        features (pyspark.RDD[Feature]): A Python ``RDD`` that
+            contains :class:`~geopyspark.vector_pipe.Feature`\s.
+
+            Note:
+                The ``properties`` of each ``Feature`` must be an instance of
+                :class:`~geopyspark.vector_pipe.CellValue`.
+        crs (str or int): The CRS of the input geometry.
+        zoom (int): The zoom level of the output raster.
+
+            Note:
+                Not all rasterized ``Feature``\s may be present in the resulting layer
+                if the ``zoom`` is not high enough.
+        cell_type (str or :class:`~geopyspark.geotrellis.constants.CellType`): Which data type the
+            cells should be when created. Defaults to ``CellType.FLOAT64``.
+        options (:class:`~geopyspark.geotrellis.RasterizerOptions`, optional): Pixel intersection options.
+        num_partitions (int, optional): The number of repartitions Spark will make when the data is
+            repartitioned. If ``None``, then the data will not be repartitioned.
+        zindex_cell_type (str or :class:`~geopyspark.geotrellis.constants.CellType`): Which data type
+            the ``Z-Index`` cells are. Defaults to ``CellType.INT8``.
+
+    Returns:
+        :class:`~geopyspark.geotrellis.layer.TiledRasterLayer`
+    """
 
     if isinstance(crs, int):
         crs = str(crs)

--- a/geopyspark/vector_pipe/__init__.py
+++ b/geopyspark/vector_pipe/__init__.py
@@ -1,11 +1,81 @@
 from collections import namedtuple
 
 
-Feature = namedtuple("Feature", "geometry properties")
+class Feature(namedtuple("Feature", "geometry properties")):
+    """Represents a geometry that is derived from an OSM Element with that Element's associated metadata.
 
-Properties = namedtuple("Properties", "element_id user uid changeset version minor_version timestamp visible tags")
+    Args:
+        geometry (shapely.geometry): The geometry of the feature that is represented as
+            a ``shapely.geometry``. This geometry is derived from an OSM Element.
+        properties (:class:`~geopyspark.vector_pipe.Properties` or :class:`~geopyspark.vector_pipe.CellValue`):
+            The metadata associated with the OSM Element. Can be represented as either an instance
+            of ``Properties`` or a ``CellValue``.
 
-CellValue = namedtuple("CellValue", "value zindex")
+    Attributes:
+        geometry (shapely.geometry): The geometry of the feature that is represented as
+            a ``shapely.geometry``. This geometry is derived from an OSM Element.
+        properties (:class:`~geopyspark.vector_pipe.Properties` or :class:`~geopyspark.vector_pipe.CellValue`):
+            The metadata associated with the OSM Element. Can be represented as either an instance
+            of ``Properties`` or a ``CellValue``.
+    """
+
+    __slots__ = []
+
+
+class Properties(namedtuple("Properties", "element_id user uid changeset version minor_version timestamp visible tags")):
+    """Represents the metadata of an OSM Element.
+
+    This object is one of two types that can be used to represent the ``properties`` of a
+    :class:`~geopyspark.vector_pipe.Feature`.
+
+    Args:
+        element_id (int): The ``id`` of the OSM Element.
+        user (str): The display name of the last user who modified/created the OSM Element.
+        uid (int): The numeric id of the last user who modified the OSM Element.
+        changeset (int): The OSM ``changeset`` number in which the OSM Element was created/modified.
+        version (int): The edit version of the OSM Element.
+        minor_version (int): Represents minor changes between versions of an OSM Element.
+        timestamp (datetime.datetime): The time of the last modification to the OSM Element.
+        visible (bool): Represents whether or not the OSM Element is deleted or not in the database.
+        tags (dict): A ``dict`` of ``str``\s that represents the given features of the OSM Element.
+
+    Attributes:
+        element_id (int): The ``id`` of the OSM Element.
+        user (str): The display name of the last user who modified/created the OSM Element.
+        uid (int): The numeric id of the last user who modified the OSM Element.
+        changeset (int): The OSM ``changeset`` number in which the OSM Element was created/modified.
+        version (int): The edit version of the OSM Element.
+        minor_version (int): Represents minor changes between versions of an OSM Element.
+        timestamp (datetime.datetime): The time of the last modification to the OSM Element.
+        visible (bool): Represents whether or not the OSM Element is deleted or not in the database.
+        tags (dict): A ``dict`` of ``str``\s that represents the given features of the OSM Element.
+    """
+
+    __slots__ = []
+
+
+class CellValue(namedtuple("CellValue", "value zindex")):
+    """Represents the ``value`` and ``zindex`` of a geometry.
+
+    This object is one of two types that can be used to represent the ``properties`` of a
+    :class:`~geopyspark.vector_pipe.Feature`.
+
+    Args:
+        value (int or float): The value of all cells that intersects the associated geometry.
+        zindex (int): The ``Z-Index`` of each cell that intersects the associated geometry.
+            ``Z-Index`` determines which value a cell should be if multiple geometries
+            intersect it. A high ``Z-Index`` will always be in front of a ``Z-Index`` of
+            a lower value.
+
+    Attributes:
+        value (int or float): The value of all cells that intersects the associated geometry.
+        zindex (int): The ``Z-Index`` of each cell that intersects the associated geometry.
+            ``Z-Index`` determines which value a cell should be if multiple geometries
+            intersect it. A high ``Z-Index`` will always be in front of a ``Z-Index`` of
+            a lower value.
+    """
+
+    __slots__ = []
 
 
 __all__ = ['Feature', 'Properties', 'CellValue']

--- a/geopyspark/vector_pipe/features_collection.py
+++ b/geopyspark/vector_pipe/features_collection.py
@@ -5,22 +5,63 @@ from geopyspark.vector_pipe.vector_pipe_protobufcodecs import feature_decoder, f
 
 
 class FeaturesCollection(object):
+    """Represents a collection of features from OSM data. A ``feature`` is
+    a geometry that is derived from an OSM Element with that Element's associated metadata.
+    These ``feature``\s are grouped together by their geometry type.
+
+    There are 4 different types of geometries that a ``feature`` can contain:
+        - ``Point``\s
+        - ``Line``\s
+        - ``Polygon``\s
+        - ``MultiPolygon``\s
+
+    Args:
+        scala_features (py4j.JavaObject): The Scala representation of ``FeaturesCollection``.
+
+    Attributes:
+        scala_features (py4j.JavaObject): The Scala representation of ``FeaturesCollection``.
+    """
+
     def __init__(self, scala_features):
         self.scala_features = scala_features
 
     def get_point_features_rdd(self):
+        """Returns each ``Point`` ``feature`` in the ``FeaturesCollection``
+        as a :class:`~geopyspark.vector_pipe.Feature` in a Python RDD.
+
+        Returns:
+            ``RDD[Feature]``
+        """
 
         return self._get_rdd(self.scala_features.toProtoPoints())
 
     def get_line_features_rdd(self):
+        """Returns each ``Line`` ``feature`` in the ``FeaturesCollection``
+        as a :class:`~geopyspark.vector_pipe.Feature` in a Python RDD.
+
+        Returns:
+            ``RDD[Feature]``
+        """
 
         return self._get_rdd(self.scala_features.toProtoLines())
 
     def get_polygon_features_rdd(self):
+        """Returns each ``Polygon`` ``feature`` in the ``FeaturesCollection``
+        as a :class:`~geopyspark.vector_pipe.Feature` in a Python RDD.
+
+        Returns:
+            ``RDD[Feature]``
+        """
 
         return self._get_rdd(self.scala_features.toProtoPolygons())
 
     def get_multipolygon_features_rdd(self):
+        """Returns each ``MultiPolygon`` ``feature`` in the ``FeaturesCollection``
+        as a :class:`~geopyspark.vector_pipe.Feature` in a Python RDD.
+
+        Returns:
+            ``RDD[Feature]``
+        """
 
         return self._get_rdd(self.scala_features.toProtoMultiPolygons())
 
@@ -30,13 +71,45 @@ class FeaturesCollection(object):
         return create_python_rdd(jrdd, ser)
 
     def get_point_tags(self):
+        """Returns all of the unique tags for all of the ``Point``\s in the
+        ``FeaturesCollection`` as a ``dict``. Both the keys and values of the
+        ``dict`` will be ``str``\s.
+
+        Returns:
+            dict
+        """
+
         return loads(self.scala_features.getPointTags())
 
     def get_line_tags(self):
+        """Returns all of the unique tags for all of the ``Line``\s in the
+        ``FeaturesCollection`` as a ``dict``. Both the keys and values of the
+        ``dict`` will be ``str``\s.
+
+        Returns:
+            dict
+        """
+
         return loads(self.scala_features.getLineTags())
 
     def get_polygon_tags(self):
+        """Returns all of the unique tags for all of the ``Polygon``\s in the
+        ``FeaturesCollection`` as a ``dict``. Both the keys and values of the
+        ``dict`` will be ``str``\s.
+
+        Returns:
+            dict
+        """
+
         return loads(self.scala_features.getPolygonTags())
 
     def get_multipolygon_tags(self):
+        """Returns all of the unique tags for all of the ``MultiPolygon``\s in the
+        ``FeaturesCollection`` as a ``dict``. Both the keys and values of the
+        ``dict`` will be ``str``\s.
+
+        Returns:
+            dict
+        """
+
         return loads(self.scala_features.getMultiPolygonTags())

--- a/geopyspark/vector_pipe/osm_reader.py
+++ b/geopyspark/vector_pipe/osm_reader.py
@@ -11,12 +11,57 @@ __all__ = ['from_orc', 'from_dataframe']
 
 
 def from_orc(source):
+    """Reads in OSM data from an orc file that is located either locally or on S3. The
+    resulting data will be read in as an instance of :class:`~geopyspark.vector_pipe.features_collection.FeaturesCollection`.
+
+    Args:
+        source (str): The path or URI to the orc file to be read. Can either be a local file, or
+            a file on S3.
+
+            Note:
+                Reading a file from S3 requires additional setup depending on the environment
+                and how the file is being read.
+
+                The following describes the parameters that need to be set depending on
+                how the files are to be read in. However, **if reading a file on EMR, then
+                the access key and secret key do not need to be set**.
+
+                If using ``s3a://``, then the following ``SparkConf`` parameters need to be set:
+                    - ``spark.hadoop.fs.s3a.impl``
+                    - ``spark.hadoop.fs.s3a.access.key``
+                    - ``spark.hadoop.fs.s3a.secret.key``
+
+                If using ``s3n://``, then the following ``SparkConf`` parameters need to be set:
+                    - ``spark.hadoop.fs.s3n.access.key``
+                    - ``spark.hadoop.fs.s3n.secret.key``
+
+                An alternative to passing in your S3 credentials to ``SparkConf`` would be
+                to export them as environment variables:
+                    - ``AWS_ACCESS_KEY_ID=YOUR_KEY``
+                    - ``AWS_SECRET_ACCESS_KEY_ID=YOUR_SECRET_KEY``
+
+    Returns:
+        :class:`~geopyspark.vector_pipe.features_collection.FeaturesCollection`
+    """
+
     pysc = get_spark_context()
     session = SparkSession.builder.config(conf=pysc.getConf()).enableHiveSupport().getOrCreate()
     features = pysc._jvm.geopyspark.vectorpipe.io.OSMReader.fromORC(session._jsparkSession, source)
+
     return FeaturesCollection(features)
 
 def from_dataframe(dataframe):
+    """Reads OSM data from a Spark ``DataFrame``. The resulting data will be read
+    in as an instance of :class:`~geopyspark.vector_pipe.features_collection.FeaturesCollection`.
+
+    Args:
+        dataframe (DataFrame): A Spark ``DataFrame`` that contains the OSM data.
+
+    Returns:
+        :class:`~geopyspark.vector_pipe.features_collection.FeaturesCollection`
+    """
+
     pysc = get_spark_context()
     features = pysc._jvm.geopyspark.vectorpipe.io.OSMReader.fromDataFrame(dataframe._jdf)
+
     return FeaturesCollection(features)

--- a/geopyspark/vector_pipe/vector_pipe_protobufcodecs.py
+++ b/geopyspark/vector_pipe/vector_pipe_protobufcodecs.py
@@ -17,12 +17,30 @@ from geopyspark.vector_pipe import Feature, Properties, CellValue
 # Decoders
 
 def from_pb_tags(pb_tags):
+    """Creates a ``dict`` from ``ProtoTags``.
+
+    Args:
+        pb_tags (ProtoTags): The ``ProtoTags`` instance to be converted.
+
+    Returns:
+        dict
+    """
+
     if list(pb_tags.tags):
         return {tags.key: tags.value for tags in pb_tags.tags}
     else:
         return {}
 
 def from_pb_properties(pb_metadata):
+    """Creates ``Properties`` from ``ProtoMetadata``.
+
+    Args:
+        pb_metadata (ProtoMetadata): The ``ProtoMetadata`` instance to be converted.
+
+    Returns:
+        :class:`~geopyspark.vector_pipe.Properties`
+    """
+
     time = parser.parse(pb_metadata.timestamp)
     tags = from_pb_tags(pb_metadata.tags)
 
@@ -38,6 +56,17 @@ def from_pb_properties(pb_metadata):
         tags=tags)
 
 def from_pb_feature_cellvalue(pb_feature_cellvalue):
+    """Creates a ``Feature`` with ``properties`` of ``CellValue``
+    from ``ProtoFeature``.
+
+    Args:
+        pb_feature_cellvalue (ProtoFeatureCellValue): The ``ProtoFeatureCellValue`` instance
+            to be converted.
+
+    Returns:
+        :class:`~geopyspark.vector_pipe.Feature`
+    """
+
     geometry = loads(pb_feature_cellvalue.geom)
     cellvalue = CellValue(pb_feature_cellvalue.cellValue.value,
                           pb_feature_cellvalue.cellValue.zindex)
@@ -45,17 +74,45 @@ def from_pb_feature_cellvalue(pb_feature_cellvalue):
     return Feature(geometry, cellvalue)
 
 def from_pb_feature(pb_feature):
+    """Creates a ``Feature`` with ``properties`` of ``Properties``
+    from ``ProtoFeature``.
+
+    Args:
+        pb_feature (ProtoFeature): The ``ProtoFeature`` instance to be converted.
+
+    Returns:
+        :class:`~geopyspark.vector_pipe.Feature`
+    """
+
     metadata = from_pb_properties(pb_feature.metadata)
     geometry = loads(pb_feature.geom)
 
     return Feature(geometry=geometry, properties=metadata)
 
 def feature_decoder(proto_bytes):
+    """Deserializes the ``ProtoFeature`` bytes into Python.
+
+    Args:
+        proto_bytes (bytes): The ProtoBuf encoded bytes of the ProtoBuf class.
+
+    Returns:
+        :class:`~geopyspark.vector_pipe.Feature`
+    """
+
     pb_feature = ProtoFeature.FromString(proto_bytes)
 
     return from_pb_feature(pb_feature)
 
 def feature_cellvalue_decoder(proto_bytes):
+    """Deserializes the ``ProtoFeatureCellValue`` bytes into Python.
+
+    Args:
+        proto_bytes (bytes): The ProtoBuf encoded bytes of the ProtoBuf class.
+
+    Returns:
+        :class:`~geopyspark.vector_pipe.Feature`
+    """
+
     pb_feature_cellvalue = ProtoFeatureCellValue.FromString(proto_bytes)
 
     return from_pb_feature_cellvalue(pb_feature_cellvalue)
@@ -64,6 +121,15 @@ def feature_cellvalue_decoder(proto_bytes):
 # Encoders
 
 def to_pb_properties(metadata):
+    """Converts an instance of ``Properties`` to ``ProtoMetadata``.
+
+    Args:
+        obj (:class:`~geopyspark.vector_pipe.Properties`): An instance of ``Properties``.
+
+    Returns:
+        ProtoProperties
+    """
+
     pb_tags = ProtoTags(tags=[ProtoTag(key=k, value=v) for k, v in metadata[8].items()])
 
     return ProtoMetadata(
@@ -78,22 +144,74 @@ def to_pb_properties(metadata):
         tags=pb_tags)
 
 def to_pb_cellvalue(cv):
+    """Converts an instance of ``CellValue`` to ``ProtoCellValue``.
+
+    Args:
+        obj (:class:`~geopyspark.vector_pipe.CellValue`): An instance of ``CellValue``.
+
+    Returns:
+        ProtoCellValue
+    """
+
     return ProtoCellValue(value=cv.value, zindex=cv.zindex)
 
 def to_pb_feature(feature):
+    """Converts an instance of ``Feature`` with ``properties`` of ``Properties`` to
+    ``ProtoFeature``.
+
+    Args:
+        feature (:class:`~geopyspark.vector_pipe.Feature`): An instance of ``Feature`` to be
+            encoded.
+
+    Returns:
+       ProtoFeature
+    """
+
     geom_bytes = dumps(feature[0])
     pb_properties = to_pb_properties(feature[1])
 
     return ProtoFeature(geom=geom_bytes, metadata=pb_properties)
 
 def to_pb_feature_cellvalue(feature):
+    """Converts an instance of ``Feature`` with ``properties`` of ``CellValue`` to
+    ``ProtoFeatureCellValue``.
+
+    Args:
+        feature (:class:`~geopyspark.vector_pipe.Feature`): An instance of ``Feature`` to be
+            encoded.
+
+    Returns:
+       ProtoFeatureCellValue
+    """
+
     geom_bytes = dumps(feature[0])
     cellvalue = to_pb_cellvalue(feature[1])
 
     return ProtoFeatureCellValue(geom=geom_bytes, cellValue=cellvalue)
 
 def feature_encoder(feature):
+    """Encodes a ``Feature`` with ``properties`` of ``Properties`` into ``ProtoFeature`` bytes.
+
+    Args:
+        feature (:class:`~geopyspark.vector_pipe.Feature`): An instance of ``Feature`` to be
+            encoded.
+
+    Returns:
+       bytes
+    """
+
     return to_pb_feature(feature).SerializeToString()
 
 def feature_cellvalue_encoder(feature):
+    """Encodes a ``Feature`` with ``properties`` of ``CellValue`` into
+    ``ProtoFeatureCellValue`` bytes.
+
+    Args:
+        feature (:class:`~geopyspark.vector_pipe.Feature`): An instance of ``Feature`` to be
+            encoded.
+
+    Returns:
+       bytes
+    """
+
     return to_pb_feature_cellvalue(feature).SerializeToString()


### PR DESCRIPTION
This PR adds documentation for the code added for the VectorPipe integration. Currently, the only documentation added is docstrings, but examples and guides could be added as well.

This PR is an updated version of #587 