### PR TITLE
python-dateutil Dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setup_args = dict(
         'protobuf>=3.3.0',
         'numpy>=1.8',
         'shapely>=1.6b3',
-        'pytz'
+        'pytz',
+        'python-dateutil>=2.6.1'
     ],
     packages=[
         'geopyspark',


### PR DESCRIPTION
This PR adds the `python-dateutil` library as a required dependency for GPS. This library is used to convert string timestamps to instances of `datetime.datetime` objects in Python.