### PR TITLE
local_max Opertion for TiledRasterLayers

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
@@ -154,6 +154,21 @@ abstract class TiledRasterLayer[K: SpatialComponent: JsonFormat: ClassTag: Bound
     band: Int
   ): TiledRasterLayer[K]
 
+  def localMax(i: Int): TiledRasterLayer[K] =
+    withRDD(rdd.mapValues { x => MultibandTile(x.bands.map(_.localMax(i))) })
+
+  def localMax(d: Double): TiledRasterLayer[K] =
+    withRDD(rdd.mapValues { x => MultibandTile(x.bands.map(_.localMax(d))) })
+
+  def localMax(other: TiledRasterLayer[K]): TiledRasterLayer[K] =
+    withRDD(rdd.combineValues(other.rdd) {
+      case (x: MultibandTile, y: MultibandTile) => {
+        val tiles: Vector[Tile] =
+          x.bands.zip(y.bands).map { case (b1, b2) => Max(b1, b2) }
+        MultibandTile(tiles)
+      }
+    })
+
   def localAdd(i: Int): TiledRasterLayer[K] =
     withRDD(rdd.mapValues { x => MultibandTile(x.bands.map { y => y + i }) })
 

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -1842,6 +1842,28 @@ class TiledRasterLayer(CachableLayer, TileLayer):
 
         return TiledRasterLayer(self.layer_type, srdd)
 
+    def local_max(self, value):
+        """Determines the maximum value for each cell of each ``Tile`` in the layer.
+
+        This method takes a ``max_constant`` that is compared to each cell in the
+        layer. If ``max_constant`` is larger, then the resulting cell value will
+        be that value. Otherwise, that cell will retain its original value.
+
+        Note:
+            ``NoData`` values are handled such that taking the max between
+            a normal value and ``NoData`` value will always result in ``NoData``.
+
+        Args:
+            value (int or float or :class:`~geopyspark.geotrellis.layer.TiledRasterLayer`): The
+                constant value that will be compared to each cell. If this is a ``TiledRasterLayer``,
+                then ``Tile``\s who share a key will have each of their cell values compared.
+
+        Returns:
+            :class:`~geopyspark.geotrellis.layer.TiledRasterLayer`
+        """
+
+        return self._process_operation(value, self.srdd.localMax)
+
     def __add__(self, value):
         return self._process_operation(value, self.srdd.localAdd)
 

--- a/geopyspark/tests/geotrellis/local_ops_test.py
+++ b/geopyspark/tests/geotrellis/local_ops_test.py
@@ -191,6 +191,31 @@ class LocalOpertaionsTest(BaseTestClass):
 
         self.assertTrue((actual == 4).all())
 
+    def test_max_int(self):
+        arr = np.zeros((1, 4, 4))
+
+        tile = Tile(arr, 'FLOAT', -500)
+        rdd = BaseTestClass.pysc.parallelize([(self.spatial_key, tile)])
+        tiled = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, self.metadata)
+
+        result = tiled.local_max(4)
+        actual = result.to_numpy_rdd().first()[1].cells
+
+        self.assertTrue((actual == 4).all())
+
+    def test_max_layer(self):
+        arr = np.zeros((1, 4, 4))
+
+        tile = Tile(arr, 'FLOAT', -500)
+        rdd = BaseTestClass.pysc.parallelize([(self.spatial_key, tile)])
+        tiled = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, self.metadata)
+
+        result = tiled.local_max(tiled + 1)
+        actual = result.to_numpy_rdd().first()[1].cells
+
+        self.assertTrue((actual == 1).all())
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds the `local_max` method to `TiledRasterLayer`. This will allow the user to perform local max operations using `int`s, `float`, or other `TiledRasterLayer`s as the max constant.

This PR resolves #601 