### PR TITLE
CellType Representation and Conversion Fixes

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
@@ -276,7 +276,7 @@ abstract class TiledRasterLayer[K: SpatialComponent: JsonFormat: ClassTag: Bound
     withRDD(rdd.mapValues { x => MultibandTile(x.bands.map { y => y.localPowValue(d) }) })
 
   def convertDataType(newType: String): TiledRasterLayer[_] =
-    withRDD(rdd.convert(CellType.fromName(newType)))
+    withContextRDD(rdd.convert(CellType.fromName(newType)).asInstanceOf[ContextRDD[K, MultibandTile, TileLayerMetadata[K]]])
 
   def normalize(oldMin: Double, oldMax: Double, newMin: Double, newMax: Double): TiledRasterLayer[K] =
     withRDD {

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -558,7 +558,7 @@ class RasterLayer(CachableLayer, TileLayer):
 
         new_type = CellType(new_type).value
 
-        if no_data_value:
+        if no_data_value is not None:
             if 'bool' in new_type:
                 raise ValueError("Cannot add user defined types to Bool")
             elif 'raw' in new_type:
@@ -1150,19 +1150,21 @@ class TiledRasterLayer(CachableLayer, TileLayer):
             ValueError: If ``no_data_value`` is set and ``new_type`` is a boolean.
         """
 
-        if no_data_value:
+        new_type = CellType(new_type).value
+
+        if no_data_value is not None:
             if 'bool' in new_type:
                 raise ValueError("Cannot add user defined types to Bool")
             elif 'raw' in new_type:
                 raise ValueError("Cannot add user defined types to raw values")
 
-            no_data_constant = CellType(new_type).value + "ud" + str(no_data_value)
+            no_data_constant = new_type + "ud" + str(no_data_value)
 
             return TiledRasterLayer(self.layer_type,
                                     self.srdd.convertDataType(no_data_constant))
         else:
             return TiledRasterLayer(self.layer_type,
-                                    self.srdd.convertDataType(CellType(new_type).value))
+                                    self.srdd.convertDataType(new_type))
 
     def reproject(self, target_crs, resample_method=ResampleMethod.NEAREST_NEIGHBOR):
         """Reproject rasters to ``target_crs``.


### PR DESCRIPTION
This PR fixes the logic in the `convert_data_type` methods so that the use will be able to pass in a `no_data_value` of 0. In addition, the metadata now reflects the changes in celltype in the resulting `TiledRasterLayer` after conversion

This PR resolves #604 #605 