### PR TITLE
[WIP] Specifying a Partitioner in Focal Operations

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterLayer.scala
@@ -66,9 +66,9 @@ abstract class RasterLayer[K](implicit ev0: ClassTag[K], ev1: Component[K, Proje
   protected def reproject(targetCRS: String, layoutDefinition: LayoutDefinition, resampleMethod: ResampleMethod): TiledRasterLayer[_]
   protected def withRDD(result: RDD[(K, MultibandTile)]): RasterLayer[K]
 
-  def merge(numPartitions: Integer, partitioner: String): RasterLayer[K] =
-    numPartitions match {
-      case i: Integer => withRDD(rdd.merge(Some(TileLayer.getPartitioner(i, partitioner))))
+  def merge(partitioner: Partitioner): RasterLayer[K] =
+    partitioner match {
+      case p: Partitioner => withRDD(rdd.merge(Some(p)))
       case null => withRDD(rdd.merge())
     }
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
@@ -126,7 +126,9 @@ abstract class TiledRasterLayer[K: SpatialComponent: JsonFormat: ClassTag: Bound
     neighborhood: String,
     param1: Double,
     param2: Double,
-    param3: Double
+    param3: Double,
+    partitioner: String,
+    numPartitions: Int
   ): TiledRasterLayer[K]
 
   def slope(zFactorCalculator: ZFactorCalculator): TiledRasterLayer[K]

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -494,6 +494,53 @@ class Bounds(namedtuple("Bounds", 'minKey maxKey')):
         return {'minKey': min_key_dict, 'maxKey': max_key_dict}
 
 
+class Partitioner(namedtuple("Partitioner", 'partitioner num_partitions')):
+    """Represents the ``Partitioner`` of a layer.
+
+    There are currently two different types of partitioners:
+        - ``HashPartitioner`` which is Spark's ``org.apache.spark.HashPartitioner``
+        - ``SpatialPartitioner`` which partitions data based on they key of each element
+            such that elements that are next to each other will be in the same partition.
+
+    Args:
+        partitioner (str): The name of the ``Partitioner``. Can be either ``HashPartitioner`` or
+            ``SpatialPartitioner``.
+        num_partitions (int): The number of partitions the resulting ``Partitioner`` should have.
+
+    Returns:
+        :class:`~geopyspark.geotrellis.Partitioner`
+    """
+
+    __slots__ = []
+
+    @classmethod
+    def create_hash_partitioner(cls, num_partitions):
+        """Creates a ``Partitioner`` that uses Spark's ``org.apache.spark.HashPartitioner``.
+
+        Args:
+            num_partitions (int): The number of partitions the resulting ``Partitioner`` should have.
+
+        Returns:
+            :class:`~geopyspark.geotrellis.Partitioner`
+        """
+
+        return cls('HashPartitioner', num_partitions)
+
+    @classmethod
+    def create_spatial_partitioner(cls, num_partitions):
+        """Creates a ``Partitioner`` that will partition each ``Tile`` in the layer
+        by its key so that ``Tile``\s that are next to each other will be in the same partition.
+
+        Args:
+            num_partitions (int): The number of partitions the resulting ``Partitioner`` should have.
+
+        Returns:
+            :class:`~geopyspark.geotrellis.Partitioner`
+        """
+
+        return cls('SpatialPartitioner', num_partitions)
+
+
 class Metadata(object):
     """Information of the values within a ``RasterLayer`` or ``TiledRasterLayer``.
     This data pertains to the layout and other attributes of the data within the classes.

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -291,15 +291,3 @@ class Unit(Enum):
 
     METERS = "Meters"
     FEET = "Feet"
-
-
-class Partitioner(Enum):
-    """Partitioners to reparttion a layer.
-
-    There are currently two supported Partitioners:
-        - ``HASH_PARTITIONER`` Spark's HashPartitioner
-        - ``SPATIAL_PARTITIONER`` partitions data based on they key of each element.
-    """
-
-    HASH_PARTITIONER = "HashPartitioner"
-    SPATIAL_PARTITIONER = "SpatialPartitioner"

--- a/geopyspark/geotrellis/converters.py
+++ b/geopyspark/geotrellis/converters.py
@@ -2,7 +2,12 @@
 from py4j.java_gateway import JavaClass
 from py4j.protocol import register_input_converter
 
-from geopyspark.geotrellis import RasterizerOptions, GlobalLayout, LocalLayout, CellType, LayoutDefinition
+from geopyspark.geotrellis import (RasterizerOptions,
+                                   GlobalLayout,
+                                   LocalLayout,
+                                   CellType,
+                                   LayoutDefinition,
+                                   Partitioner)
 from geopyspark.geotrellis.constants import ResampleMethod
 
 
@@ -100,9 +105,22 @@ class LayoutDefinitionConverter:
 
         return ScalaLayoutDefinition(extent, tile_layout)
 
+class PartitionerConverter:
+    def can_convert(self, object):
+        return isinstance(object, Partitioner)
+
+    def convert(self, obj, gateway_client):
+        num_partitions = obj.num_partitions
+        partitioner = obj.partitioner
+
+        TileLayer = JavaClass("geopyspark.geotrellis.TileLayer", gateway_client)
+
+        return TileLayer.getPartitioner(num_partitions, partitioner)
+
 
 register_input_converter(CellTypeConverter(), prepend=True)
 register_input_converter(RasterizerOptionsConverter(), prepend=True)
 register_input_converter(LayoutTypeConverter(), prepend=True)
 register_input_converter(ResampleMethodConverter(), prepend=True)
 register_input_converter(LayoutDefinitionConverter(), prepend=True)
+register_input_converter(PartitionerConverter(), prepend=True)

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -278,6 +278,26 @@ class CachableLayer(object):
 
         return self.srdd.rdd().getNumPartitions()
 
+    def partitioner(self):
+        """Returns the ``Partitioner`` being used by the layer.
+
+        Note:
+            If no ``Partitioner`` has been set then ``None`` will be returned.
+
+        Returns:
+            :class:`~geopyspark.geotrellis.Partitioner` or ``None``
+        """
+
+        partitioner = self.srdd.partitioner()
+
+        if partitioner:
+            if partitioner == "HashPartitioner":
+                return Partitioner.create_hash_partitioner(self.getNumPartitions())
+            else:
+                return Partitioner.create_spatial_partitioner(self.getNumPartitions())
+        else:
+            partitioner
+
     def count(self):
         """Returns how many elements are within the wrapped RDD.
 

--- a/geopyspark/tests/geotrellis/geotiff_raster_rdd_test.py
+++ b/geopyspark/tests/geotrellis/geotiff_raster_rdd_test.py
@@ -4,9 +4,9 @@ import rasterio
 import pytest
 import numpy as np
 
-from geopyspark.geotrellis.constants import LayerType, CellType, Partitioner
+from geopyspark.geotrellis.constants import LayerType, CellType
 from geopyspark.tests.python_test_utils import file_path
-from geopyspark.geotrellis import Extent, ProjectedExtent, Tile
+from geopyspark.geotrellis import Extent, ProjectedExtent, Tile, Partitioner
 from geopyspark.geotrellis.geotiff import get
 from geopyspark.geotrellis.layer import RasterLayer
 from geopyspark.tests.base_test_class import BaseTestClass
@@ -29,7 +29,7 @@ class GeoTiffRasterRDDTest(BaseTestClass):
 
     def test_repartition_with_partitioner(self):
         tiled = self.result.tile_to_layout()
-        repartitioned = tiled.repartition(2, Partitioner.SPATIAL_PARTITIONER)
+        repartitioned = tiled.repartition(Partitioner.create_spatial_partitioner(2))
 
         self.assertEqual(repartitioned.getNumPartitions(), 2)
 

--- a/geopyspark/tests/geotrellis/tiled_layer_tests/partitioner_preservation_test.py
+++ b/geopyspark/tests/geotrellis/tiled_layer_tests/partitioner_preservation_test.py
@@ -1,0 +1,38 @@
+import unittest
+import os
+import pytest
+
+from shapely.geometry import box
+
+from geopyspark.geotrellis import Extent, SpatialKey, GlobalLayout, LocalLayout, Partitioner
+from geopyspark.geotrellis.constants import LayerType, Operation#, Partitioner
+from geopyspark.geotrellis.neighborhood import Square
+from geopyspark.geotrellis.geotiff import get
+from geopyspark.tests.base_test_class import BaseTestClass
+from geopyspark.tests.python_test_utils import file_path
+
+
+class PartitionerPreservationTest(BaseTestClass):
+    rdd = get(LayerType.SPATIAL, file_path("srtm_52_11.tif"), max_tile_size=6001)
+    tiled_layer = rdd.tile_to_layout()
+
+    @pytest.fixture(autouse=True)
+    def tearDown(self):
+        yield
+        BaseTestClass.pysc._gateway.close()
+
+    def test_preservation(self):
+        max_layer = self.tiled_layer.focal(Operation.MAX,
+                                           Square(2),
+                                           partitioner=Partitioner.create_spatial_partitioner(2))
+
+        print(max_layer.partitioner())#, max_layer.getNumPartitions())
+        #self.assertEqual(max_layer.partitioner(), Partitioner.SPATIAL_PARTITIONER)
+
+        #reprojected_layer = max_layer.tile_to_layout(LocalLayout(), 3857)
+
+        #self.assertEqual(reprojected_layer.partitioner(), Partitioner.SPATIAL_PARTITIONER)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR will allow the user to specify the ``Partitioner` to use when performing `focal` operations in GPS. This is beneficially as we are then able to combine the shuffle steps of repartitioning and the `focal` operation into a single step.

Right now, this PR should not be merged and it will fail Travis due to the latest GT `1.2.0-SNAPSHOT` not being available yet.