### PR TITLE
Partition Strategies and Preservation

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/PartitionStrategy.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/PartitionStrategy.scala
@@ -1,0 +1,42 @@
+package geopyspark.geotrellis
+
+import org.apache.spark._
+
+
+abstract class PartitionStrategy(numPartitions: Option[Int]) {
+  def producePartitioner(partitions: Int): Option[Partitioner]
+}
+
+
+class HashPartitionStrategy(val numPartitions: Option[Int]) extends PartitionStrategy(numPartitions) {
+  def producePartitioner(partitions: Int): Option[Partitioner] =
+      numPartitions match {
+      case None => Some(new HashPartitioner(partitions))
+      case Some(num) => Some(new HashPartitioner(num))
+    }
+}
+
+object HashPartitionStrategy {
+  def apply(numPartitions: Integer): HashPartitionStrategy =
+    numPartitions match {
+      case i: Integer => new HashPartitionStrategy(Some(i.toInt))
+      case null => new HashPartitionStrategy(None)
+    }
+}
+
+
+class SpatialPartitionStrategy(val numPartitions: Option[Int], val bits: Int) extends PartitionStrategy(numPartitions) {
+  def producePartitioner(partitions: Int): Option[Partitioner] =
+    numPartitions match {
+      case None => Some(SpatialPartitioner(partitions, bits))
+      case Some(num) => Some(SpatialPartitioner(num, bits))
+    }
+}
+
+object SpatialPartitionStrategy {
+  def apply(numPartitions: Integer, bits: Int): SpatialPartitionStrategy =
+    numPartitions match {
+      case i: Integer => new SpatialPartitionStrategy(Some(i.toInt), bits)
+      case null => new SpatialPartitionStrategy(None, bits)
+    }
+}

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterLayer.scala
@@ -43,6 +43,9 @@ abstract class RasterLayer[K](implicit ev0: ClassTag[K], ev1: Component[K, Proje
 
   def repartition(numPartitions: Int): RasterLayer[K] = withRDD(rdd.repartition(numPartitions))
 
+  def partitionBy(partitionStrategy: PartitionStrategy): RasterLayer[K] =
+    withRDD(rdd.partitionBy(partitionStrategy.producePartitioner(rdd.getNumPartitions).get))
+
   def toProtoRDD(): JavaRDD[Array[Byte]]
 
   def collectKeys(): java.util.ArrayList[Array[Byte]]

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterLayer.scala
@@ -41,6 +41,8 @@ import scala.collection.immutable.HashMap
 abstract class RasterLayer[K](implicit ev0: ClassTag[K], ev1: Component[K, ProjectedExtent]) extends TileLayer[K] with Serializable {
   def rdd: RDD[(K, MultibandTile)]
 
+  def repartition(numPartitions: Int): RasterLayer[K] = withRDD(rdd.repartition(numPartitions))
+
   def toProtoRDD(): JavaRDD[Array[Byte]]
 
   def collectKeys(): java.util.ArrayList[Array[Byte]]
@@ -57,18 +59,45 @@ abstract class RasterLayer[K](implicit ev0: ClassTag[K], ev1: Component[K, Proje
   def convertDataType(newType: String): RasterLayer[_] =
     withRDD(rdd.map { x => (x._1, x._2.convert(CellType.fromName(newType))) })
 
-  protected def tileToLayout(tileLayerMetadata: String, resampleMethod: ResampleMethod): TiledRasterLayer[_]
-  def tileToLayout(layoutType: LayoutType, resampleMethod: ResampleMethod): TiledRasterLayer[_]
-  protected def tileToLayout(layoutDefinition: LayoutDefinition, resampleMethod: ResampleMethod): TiledRasterLayer[_]
+  def tileToLayout(
+    tileLayerMetadata: String,
+    resampleMethod: ResampleMethod,
+    partitionStrategy: PartitionStrategy
+  ): TiledRasterLayer[_]
 
-  protected def reproject(targetCRS: String, resampleMethod: ResampleMethod): RasterLayer[K]
-  protected def reproject(targetCRS: String, layoutType: LayoutType, resampleMethod: ResampleMethod): TiledRasterLayer[_]
-  protected def reproject(targetCRS: String, layoutDefinition: LayoutDefinition, resampleMethod: ResampleMethod): TiledRasterLayer[_]
+  def tileToLayout(
+    layoutType: LayoutType,
+    resampleMethod: ResampleMethod,
+    partitionStrategy: PartitionStrategy
+  ): TiledRasterLayer[_]
+
+  def tileToLayout(
+    layoutDefinition: LayoutDefinition,
+    resampleMethod: ResampleMethod,
+    partitionStrategy: PartitionStrategy
+  ): TiledRasterLayer[_]
+
+  def reproject(targetCRS: String, resampleMethod: ResampleMethod): RasterLayer[K]
+
+  def reproject(
+    targetCRS: String,
+    layoutType: LayoutType,
+    resampleMethod: ResampleMethod,
+    partitionStrategy: PartitionStrategy
+  ): TiledRasterLayer[_]
+
+  def reproject(
+    targetCRS: String,
+    layoutDefinition: LayoutDefinition,
+    resampleMethod: ResampleMethod,
+    partitionStrategy: PartitionStrategy
+  ): TiledRasterLayer[_]
+
   protected def withRDD(result: RDD[(K, MultibandTile)]): RasterLayer[K]
 
-  def merge(numPartitions: Integer, partitioner: String): RasterLayer[K] =
-    numPartitions match {
-      case i: Integer => withRDD(rdd.merge(Some(TileLayer.getPartitioner(i, partitioner))))
+  def merge(partitionStrategy: PartitionStrategy): RasterLayer[K] =
+    partitionStrategy match {
+      case ps: PartitionStrategy => withRDD(rdd.merge(ps.producePartitioner(rdd.getNumPartitions)))
       case null => withRDD(rdd.merge())
     }
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialPartitioner.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialPartitioner.scala
@@ -13,6 +13,8 @@ import scala.reflect._
 class SpatialPartitioner[K: SpatialComponent](partitions: Int, bits: Int) extends Partitioner {
   def numPartitions: Int = partitions
 
+  def getBits: Int = bits
+
   def getPartition(key: Any): Int = {
     val k = key.asInstanceOf[K]
     val SpatialKey(col, row) = k.getComponent[SpatialKey]

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TileLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TileLayer.scala
@@ -202,6 +202,17 @@ abstract class TileLayer[K: ClassTag] {
       case ps: PartitionStrategy => Tiler.Options(resampleMethod, ps.producePartitioner(rdd.getNumPartitions))
       case null => Tiler.Options(resampleMethod, None)
     }
+
+  def getPartitionStrategyName: String =
+    rdd.partitioner match {
+      case None => null
+      case Some(p) =>
+        p match {
+          case _: HashPartitioner => "HashPartitioner"
+          case _: SpatialPartitioner[K] => "SpatialPartitioner"
+          case _ => throw new Exception(s"$p has no partition strategy")
+        }
+    }
 }
 
 object TileLayer {

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TileLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TileLayer.scala
@@ -196,6 +196,12 @@ abstract class TileLayer[K: ClassTag] {
 
   protected def reclassify(reclassifiedRDD: RDD[(K, MultibandTile)]): TileLayer[_]
   protected def reclassifyDouble(reclassifiedRDD: RDD[(K, MultibandTile)]): TileLayer[_]
+
+  def getTilerOptions(resampleMethod: ResampleMethod, partitionStrategy: PartitionStrategy): Tiler.Options =
+    partitionStrategy match {
+      case ps: PartitionStrategy => Tiler.Options(resampleMethod, ps.producePartitioner(rdd.getNumPartitions))
+      case null => Tiler.Options(resampleMethod, None)
+    }
 }
 
 object TileLayer {

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
@@ -60,6 +60,9 @@ abstract class TiledRasterLayer[K: SpatialComponent: JsonFormat: ClassTag: Bound
 
   def repartition(numPartitions: Int): TiledRasterLayer[K] = withRDD(rdd.repartition(numPartitions))
 
+  def partitionBy(partitionStrategy: PartitionStrategy) =
+    withRDD(rdd.partitionBy(partitionStrategy.producePartitioner(rdd.getNumPartitions).get))
+
   def bands(band: Int): TiledRasterLayer[K] =
     withRDD(rdd.mapValues { multibandTile => multibandTile.subsetBands(band) })
 

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -494,6 +494,51 @@ class Bounds(namedtuple("Bounds", 'minKey maxKey')):
         return {'minKey': min_key_dict, 'maxKey': max_key_dict}
 
 
+class HashPartitionStrategy(namedtuple("HashPartitionStrategy", "num_partitions")):
+    """Represents a partitioning strategy for a layer that uses Spark's ``HashPartitioner``
+    with a set number of partitions.
+
+    Args:
+        num_partitions (int, optional): The number of partitions that should be used during
+            partitioning. Default is, ``None``. If ``None`` the resulting layer will have
+            a ``HashPartitioner`` with the number of partitions being either the same
+            as the input layer's, or a number computed by the method.
+
+    Returns:
+        :class:`~geopyspark.geotrellis.HashPartitionStrategy`
+    """
+
+    __slots__ = []
+
+    def __new__(cls, num_partitions=None):
+        return super(HashPartitionStrategy, cls).__new__(cls, num_partitions)
+
+class SpatialPartitionStrategy(namedtuple("SpatialPartitionStrategy", "num_partitions bits")):
+    """Represents a partitioning strategy for a layer that uses GeoPySpark's ``SpatialPartitioner``
+    with a set number of partitions.
+
+    This partitioner will try and group ``Tile``\s together that are spatially near each other in
+    the same partition. In order to do this, each ``Tile`` has their ``Key Index`` calculated
+    using the space filling curve index, ``Z-Curve``.
+
+    Args:
+        num_partitions (int, optional): The number of partitions that should be used during
+            partitioning. Default is, ``None``. If ``None`` the resulting layer will have
+            a ``HashPartitioner`` with the number of partitions being either the same
+            as the input layer's, or a number computed by the method.
+        bits (int, optional): How many bits the resulting ``Key Index`` of a ``Tile`` should
+            be shifted to the right. Default is, ``8``.
+
+    Returns:
+        :class:`~geopyspark.geotrellis.SpatialPartitionStrategy`
+    """
+
+    __slots__ = []
+
+    def __new__(cls, num_partitions=None, bits=8):
+        return super(SpatialPartitionStrategy, cls).__new__(cls, num_partitions, bits)
+
+
 class Metadata(object):
     """Information of the values within a ``RasterLayer`` or ``TiledRasterLayer``.
     This data pertains to the layout and other attributes of the data within the classes.
@@ -640,7 +685,7 @@ class Metadata(object):
 
 __all__ = ["Tile", "Extent", "ProjectedExtent", "TemporalProjectedExtent", "SpatialKey", "SpaceTimeKey",
            "Metadata", "TileLayout", "GlobalLayout", "LocalLayout", "LayoutDefinition", "Bounds", "RasterizerOptions",
-           "zfactor_lat_lng_calculator", "zfactor_calculator"]
+           "zfactor_lat_lng_calculator", "zfactor_calculator", "HashPartitionStrategy", "SpatialPartitionStrategy"]
 
 from . import catalog
 from . import color

--- a/geopyspark/geotrellis/constants.py
+++ b/geopyspark/geotrellis/constants.py
@@ -6,7 +6,7 @@ __all__ = ['NO_DATA_INT', 'LayerType', 'IndexingMethod', 'ResampleMethod', 'Time
            'Operation', 'Neighborhood', 'ClassificationStrategy', 'CellType', 'ColorRamp',
            'DEFAULT_MAX_TILE_SIZE', 'DEFAULT_PARTITION_BYTES', 'DEFAULT_CHUNK_SIZE',
            'DEFAULT_GEOTIFF_TIME_TAG', 'DEFAULT_GEOTIFF_TIME_FORMAT', 'DEFAULT_S3_CLIENT',
-           'StorageMethod', 'ColorSpace', 'Compression', 'Unit', 'Partitioner']
+           'StorageMethod', 'ColorSpace', 'Compression', 'Unit']
 
 
 """The NoData value for ints in GeoTrellis."""
@@ -291,15 +291,3 @@ class Unit(Enum):
 
     METERS = "Meters"
     FEET = "Feet"
-
-
-class Partitioner(Enum):
-    """Partitioners to reparttion a layer.
-
-    There are currently two supported Partitioners:
-        - ``HASH_PARTITIONER`` Spark's HashPartitioner
-        - ``SPATIAL_PARTITIONER`` partitions data based on they key of each element.
-    """
-
-    HASH_PARTITIONER = "HashPartitioner"
-    SPATIAL_PARTITIONER = "SpatialPartitioner"

--- a/geopyspark/geotrellis/converters.py
+++ b/geopyspark/geotrellis/converters.py
@@ -2,7 +2,14 @@
 from py4j.java_gateway import JavaClass
 from py4j.protocol import register_input_converter
 
-from geopyspark.geotrellis import RasterizerOptions, GlobalLayout, LocalLayout, CellType, LayoutDefinition
+from geopyspark.geotrellis import (RasterizerOptions,
+                                   GlobalLayout,
+                                   LocalLayout,
+                                   CellType,
+                                   LayoutDefinition,
+                                   HashPartitionStrategy,
+                                   SpatialPartitionStrategy)
+
 from geopyspark.geotrellis.constants import ResampleMethod
 
 
@@ -100,9 +107,32 @@ class LayoutDefinitionConverter:
 
         return ScalaLayoutDefinition(extent, tile_layout)
 
+class HashPartitionStrategyConverter:
+    def can_convert(self, object):
+        return isinstance(object, HashPartitionStrategy)
+
+    def convert(self, obj, gateway_client):
+
+        ScalaHashStrategy = JavaClass("geopyspark.geotrellis.HashPartitionStrategy", gateway_client)
+
+        return ScalaHashStrategy.apply(obj.num_partitions)
+
+
+class SpatialPartitionStrategyConverter:
+    def can_convert(self, object):
+        return isinstance(object, SpatialPartitionStrategy)
+
+    def convert(self, obj, gateway_client):
+
+        ScalaSpatialStrategy = JavaClass("geopyspark.geotrellis.SpatialPartitionStrategy", gateway_client)
+
+        return ScalaSpatialStrategy.apply(obj.num_partitions, obj.bits)
+
 
 register_input_converter(CellTypeConverter(), prepend=True)
 register_input_converter(RasterizerOptionsConverter(), prepend=True)
 register_input_converter(LayoutTypeConverter(), prepend=True)
 register_input_converter(ResampleMethodConverter(), prepend=True)
 register_input_converter(LayoutDefinitionConverter(), prepend=True)
+register_input_converter(HashPartitionStrategyConverter(), prepend=True)
+register_input_converter(SpatialPartitionStrategyConverter(), prepend=True)

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -477,21 +477,44 @@ class RasterLayer(CachableLayer, TileLayer):
         return RasterLayer(LayerType.SPATIAL, _to_spatial_layer(self, target_time))
 
     def repartition(self, num_partitions=None):
-        """Repartition underlying RDD using the given partitioner.
+        """Repartitions the layer to have a different number of partitions.
 
         Args:
-            num_partitions(int, optional): Desired number of partitions. If ``None``,
-                then the exisiting number of partitions will be used.
-            partitioner (str or :class:`~geopyspark.geotrellis.constants.Partitioner`, optional):
-                The partitioner that should be used to repartition the data. The default is
-                ``Partitioner.HASH_PARTITIONER``.
+            num_partitions(int, optional): Desired number of partitions. Default is, ``None``
+                .If ``None``, then the exisiting number of partitions will be used.
 
         Returns:
-            :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
+            :class:`~geopyspark.RasterLayer`
         """
 
         if num_partitions:
             return RasterLayer(self.layer_type, self.srdd.repartition(num_partitions))
+        else:
+            return self
+
+    def partitionBy(self, partition_strategy=None):
+        """Repartitions the layer using the given partitioning strategy.
+
+        Args:
+            partition_strategy (:class:`~geopyspark.HashPartitionStrategy` or :class:`~geopyspark.SpatialPartitioinStrategy`, optional):
+                Sets the ``Partitioner`` for the resulting layer and how many partitions it has.
+                Default is, ``None``.
+
+                If ``None``, then the output layer will be the same as the source layer.
+
+                If ``partition_strategy`` is set but has no ``num_partitions``, then the resulting layer
+                will have the ``Partioner`` specified in the strategy with the with same number of
+                partitions the source layer had.
+
+                If ``partition_strategy`` is set and has a ``num_partitions``, then the resulting layer
+                will have the ``Partioner`` and number of partitions specified in the strategy.
+
+        Returns:
+            :class:`~geopyspark.RasterLayer`
+        """
+
+        if partition_strategy:
+            return RasterLayer(self.layer_type, self.srdd.partitionBy(partition_strategy))
         else:
             return self
 
@@ -1262,17 +1285,14 @@ class TiledRasterLayer(CachableLayer, TileLayer):
         return TiledRasterLayer(self.layer_type, srdd)
 
     def repartition(self, num_partitions=None):
-        """Repartition underlying RDD using the given partitioner.
+        """Repartitions the layer to have a different number of partitions.
 
         Args:
-            num_partitions(int, optional): Desired number of partitions. If ``None``,
-                then the exisiting number of partitions will be used.
-            partitioner (str or :class:`~geopyspark.geotrellis.constants.Partitioner`, optional):
-                The partitioner that should be used to repartition the data. The default is
-                ``Partitioner.HASH_PARTITIONER``.
+            num_partitions(int, optional): Desired number of partitions. Default is, ``None``
+                .If ``None``, then the exisiting number of partitions will be used.
 
         Returns:
-            :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
+            :class:`~geopyspark.TiledRasterLayer`
         """
 
         if num_partitions:
@@ -1280,8 +1300,25 @@ class TiledRasterLayer(CachableLayer, TileLayer):
         else:
             return self
 
+    def partitionBy(self, partition_strategy=None):
+        """Repartitions the layer using the given partitioning strategy.
+
+        Args:
+            partition_strategy (:class:`~geopyspark.HashPartitionStrategy` or :class:`~geopyspark.SpatialPartitioinStrategy`, optional):
+                Sets the ``Partitioner`` for the resulting layer and how many partitions it has.
+                Default is, ``None``.
+
+                If ``None``, then the output layer will be the same as the source layer.
+
+                If ``partition_strategy`` is set but has no ``num_partitions``, then the resulting layer
+                will have the ``Partioner`` specified in the strategy with the with same number of
+                partitions the source layer had.
+
+                If ``partition_strategy`` is set and has a ``num_partitions``, then the resulting layer
+                will have the ``Partioner`` and number of partitions specified in the strategy.
+
         Returns:
-            :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
+            :class:`~geopyspark.TiledRasterLayer`
         """
 
         if partition_strategy:

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -38,9 +38,7 @@ from geopyspark.geotrellis.constants import (Operation,
                                              StorageMethod,
                                              ColorSpace,
                                              Compression,
-                                             NO_DATA_INT,
-                                             Partitioner
-                                            )
+                                             NO_DATA_INT)
 from geopyspark.geotrellis.neighborhood import Neighborhood
 
 

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -106,17 +106,29 @@ def _to_geotiff_rdd(pysc, srdd, storage_method, rows_per_strip, tile_dimensions,
                                  band_tags or [])
 
 
-def _reproject(target_crs, layout, resample_method, layer):
+def _reproject(target_crs, layout, resample_method, partition_strategy, layer):
+    # The reproject Scala methods for RasterLayer and TiledRasterLayer are different
+    # so we need pick which one we're going to use.
+    def rasterlayer_reproject(source):
+        return layer.srdd.reproject(target_crs, source, resample_method, partition_strategy)
+
+    def tiledrasterlayer_reproject(source):
+        return layer.srdd.reproject(target_crs, source, resample_method)
+
+    if isinstance(layer, RasterLayer):
+        reproject_method = rasterlayer_reproject
+    else:
+        reproject_method = tiledrasterlayer_reproject
 
     if isinstance(layout, (LocalLayout, GlobalLayout, LayoutDefinition)):
-        srdd = layer.srdd.reproject(target_crs, layout, resample_method)
+        srdd = reproject_method(layout)
         return TiledRasterLayer(layer.layer_type, srdd)
 
     elif isinstance(layout, Metadata):
         if layout.crs != target_crs:
             raise ValueError("The layout needs to be in the same CRS as the target_crs")
 
-        srdd = layer.srdd.reproject(target_crs, layout.layout_definition, resample_method)
+        srdd = reproject_method(layout.layout_definition)
         return TiledRasterLayer(layer.layer_type, srdd)
 
     elif isinstance(layout, TiledRasterLayer):
@@ -124,7 +136,7 @@ def _reproject(target_crs, layout, resample_method, layer):
             raise ValueError("The layout needs to be in the same CRS as the target_crs")
 
         metadata = layout.layer_metadata
-        srdd = layer.srdd.reproject(target_crs, layout.layer_metadata.layout_definition, resample_method)
+        srdd = reproject_method(layout.layer_metadata.layout_definition)
         return TiledRasterLayer(layer.layer_type, srdd)
     else:
         raise TypeError("%s can not be used as target layout." % layout)
@@ -464,6 +476,25 @@ class RasterLayer(CachableLayer, TileLayer):
 
         return RasterLayer(LayerType.SPATIAL, _to_spatial_layer(self, target_time))
 
+    def repartition(self, num_partitions=None):
+        """Repartition underlying RDD using the given partitioner.
+
+        Args:
+            num_partitions(int, optional): Desired number of partitions. If ``None``,
+                then the exisiting number of partitions will be used.
+            partitioner (str or :class:`~geopyspark.geotrellis.constants.Partitioner`, optional):
+                The partitioner that should be used to repartition the data. The default is
+                ``Partitioner.HASH_PARTITIONER``.
+
+        Returns:
+            :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
+        """
+
+        if num_partitions:
+            return RasterLayer(self.layer_type, self.srdd.repartition(num_partitions))
+        else:
+            return self
+
     def bands(self, band):
         """Select a subsection of bands from the ``Tile``\s within the layer.
 
@@ -478,7 +509,7 @@ class RasterLayer(CachableLayer, TileLayer):
 
         Args:
             band (int or tuple or list or range): The band(s) to be selected from the ``Tile``\s.
-                Can either be a single int, or a collection of int\s.
+                Can either be a single int, or a collection of ints.
 
         Returns:
             :class:`~geopyspark.geotrellis.layer.RasterLayer` with the selected bands.
@@ -588,7 +619,7 @@ class RasterLayer(CachableLayer, TileLayer):
         else:
             return [temporal_projected_extent_decoder(key) for key in self.srdd.collectKeys()]
 
-    def merge(self, num_partitions=None, partitioner=Partitioner.HASH_PARTITIONER):
+    def merge(self, partition_strategy=None):
         """Merges the ``Tile`` of each ``K`` together to produce a single ``Tile``.
 
         This method will reduce each value by its key within the layer to produce a single
@@ -605,16 +636,25 @@ class RasterLayer(CachableLayer, TileLayer):
             num_partitions (int, optional): The number of partitions that the resulting
                 layer should be partitioned with. If ``None``, then the ``num_partitions``
                 will the number of partitions the layer curretly has.
-            partitioner (str or :class:`~geopyspark.geotrellis.constants.Partitioner`, optional):
-                The partitioner that should be used to repartition the data. The default is
-                ``Partitioner.HASH_PARTITIONER``.
+            partition_strategy (:class:`~geopyspark.HashPartitionStrategy` or :class:`~geopyspark.SpatialPartitioinStrategy`, optional):
+                Sets the ``Partitioner`` for the resulting layer and how many partitions it has.
+                Default is, ``None``.
+
+                If ``None``, then the output layer will be the same ``Partitioner`` and number of
+                partitions as the source layer.
+
+                If ``partition_strategy`` is set but has no ``num_partitions``, then the resulting layer
+                will have the ``Partioner`` specified in the strategy with the with same number of
+                partitions the source layer had.
+
+                If ``partition_strategy`` is set and has a ``num_partitions``, then the resulting layer
+                will have the ``Partioner`` and number of partitions specified in the strategy.
 
         Returns:
             :class:`~geopyspark.geotrellis.layer.RasterLayer`
         """
 
-        partitioner = Partitioner(partitioner).value
-        result = self.srdd.merge(num_partitions, partitioner)
+        result = self.srdd.merge(partition_strategy)
 
         return RasterLayer(self.layer_type, result)
 
@@ -660,21 +700,34 @@ class RasterLayer(CachableLayer, TileLayer):
 
         return RasterLayer(self.layer_type, srdd)
 
-    def tile_to_layout(self, layout=LocalLayout(), target_crs=None, resample_method=ResampleMethod.NEAREST_NEIGHBOR):
+    def tile_to_layout(self,
+                       layout=LocalLayout(),
+                       target_crs=None,
+                       resample_method=ResampleMethod.NEAREST_NEIGHBOR,
+                       partition_strategy=None):
         """Cut tiles to layout and merge overlapping tiles. This will produce unique keys.
 
         Args:
-            layout (:class:`~geopyspark.geotrellis.Metadata` or
-                :class:`~geopyspark.geotrellis.TiledRasterLayer` or
-                :obj:`~geopyspark.geotrellis.LayoutDefinition` or
-                :obj:`~geopyspark.geotrellis.GlobalLayout` or
-                :class:`~geopyspark.geotrellis.LocalLayout`, optional):
-                    Target raster layout for the tiling operation.
+            layout (:class:`~geopyspark.geotrellis.Metadata` or :class:`~geopyspark.geotrellis.TiledRasterLayer` or :obj:`~geopyspark.geotrellis.LayoutDefinition` or :obj:`~geopyspark.geotrellis.GlobalLayout` or :class:`~geopyspark.geotrellis.LocalLayout`):
+                Target raster layout for the tiling operation.
             target_crs (str or int, optional): Target CRS of reprojection. Either EPSG code,
                 well-known name, or a PROJ.4 string. If ``None``, no reproject will be perfomed.
             resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
                 The cell resample method to used during the tiling operation.
                 Default is``ResampleMethods.NEAREST_NEIGHBOR``.
+            partition_strategy (:class:`~geopyspark.HashPartitionStrategy` or :class:`~geopyspark.SpatialPartitioinStrategy`, optional):
+                Sets the ``Partitioner`` for the resulting layer and how many partitions it has.
+                Default is, ``None``.
+
+                If ``None``, then the output layer will be the same ``Partitioner`` and number of
+                partitions as the source layer.
+
+                If ``partition_strategy`` is set but has no ``num_partitions``, then the resulting layer
+                will have the ``Partioner`` specified in the strategy with the with same number of
+                partitions the source layer had.
+
+                If ``partition_strategy`` is set and has a ``num_partitions``, then the resulting layer
+                will have the ``Partioner`` and number of partitions specified in the strategy.
 
         Returns:
             :class:`~geopyspark.geotrellis.layer.TiledRasterLayer`
@@ -684,18 +737,18 @@ class RasterLayer(CachableLayer, TileLayer):
 
         if target_crs:
             target_crs = crs_to_proj4(target_crs)
-            return _reproject(target_crs, layout, resample_method, self)
+            return _reproject(target_crs, layout, resample_method, partition_strategy, self)
 
         if isinstance(layout, Metadata):
             layer_metadata = layout.to_dict()
-            srdd = self.srdd.tileToLayout(json.dumps(layer_metadata), resample_method)
+            srdd = self.srdd.tileToLayout(json.dumps(layer_metadata), resample_method, partition_strategy)
         elif isinstance(layout, TiledRasterLayer):
             layer_metadata = layout.layer_metadata
-            srdd = self.srdd.tileToLayout(json.dumps(layer_metadata.to_dict()), resample_method)
+            srdd = self.srdd.tileToLayout(json.dumps(layer_metadata.to_dict()), resample_method, partition_strategy)
         elif isinstance(layout, LayoutDefinition):
-            srdd = self.srdd.tileToLayout(layout, resample_method)
+            srdd = self.srdd.tileToLayout(layout, resample_method, partition_strategy)
         elif isinstance(layout, (LocalLayout, GlobalLayout)):
-            srdd = self.srdd.tileToLayout(layout, resample_method)
+            srdd = self.srdd.tileToLayout(layout, resample_method, partition_strategy)
         else:
             raise TypeError("%s can not be converted to raster layout." % layout)
 
@@ -937,7 +990,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
         else:
             return [space_time_key_decoder(key) for key in self.srdd.collectKeys()]
 
-    def merge(self, num_partitions=None, partitioner=Partitioner.HASH_PARTITIONER):
+    def merge(self, partition_strategy=None):
         """Merges the ``Tile`` of each ``K`` together to produce a single ``Tile``.
 
         This method will reduce each value by its key within the layer to produce a single
@@ -954,16 +1007,25 @@ class TiledRasterLayer(CachableLayer, TileLayer):
             num_partitions (int, optional): The number of partitions that the resulting
                 layer should be partitioned with. If ``None``, then the ``num_partitions``
                 will the number of partitions the layer curretly has.
-            partitioner (str or :class:`~geopyspark.geotrellis.constants.Partitioner`, optional):
-                The partitioner that should be used to repartition the data. The default is
-                ``Partitioner.HASH_PARTITIONER``.
+            partition_strategy (:class:`~geopyspark.HashPartitionStrategy` or :class:`~geopyspark.SpatialPartitioinStrategy`, optional):
+                Sets the ``Partitioner`` for the resulting layer and how many partitions it has.
+                Default is, ``None``.
+
+                If ``None``, then the output layer will be the same ``Partitioner`` and number of
+                partitions as the source layer.
+
+                If ``partition_strategy`` is set but has no ``num_partitions``, then the resulting layer
+                will have the ``Partioner`` specified in the strategy with the with same number of
+                partitions the source layer had.
+
+                If ``partition_strategy`` is set and has a ``num_partitions``, then the resulting layer
+                will have the ``Partioner`` and number of partitions specified in the strategy.
 
         Returns:
             :class:`~geopyspark.geotrellis.layer.TiledRasterLayer`
         """
 
-        partitioner = Partitioner(partitioner).value
-        result = self.srdd.merge(num_partitions, partitioner)
+        result = self.srdd.merge(partition_strategy)
 
         return TiledRasterLayer(self.layer_type, result)
 
@@ -1199,7 +1261,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
 
         return TiledRasterLayer(self.layer_type, srdd)
 
-    def repartition(self, num_partitions=None, partitioner=Partitioner.HASH_PARTITIONER):
+    def repartition(self, num_partitions=None):
         """Repartition underlying RDD using the given partitioner.
 
         Args:
@@ -1213,10 +1275,19 @@ class TiledRasterLayer(CachableLayer, TileLayer):
             :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
         """
 
-        num_partitions = num_partitions or self.getNumPartitions()
-        partitioner = Partitioner(partitioner).value
+        if num_partitions:
+            return TiledRasterLayer(self.layer_type, self.srdd.repartition(num_partitions))
+        else:
+            return self
 
-        return TiledRasterLayer(self.layer_type, self.srdd.repartition(num_partitions, partitioner))
+        Returns:
+            :class:`~geopyspark.geotrellis.rdd.TiledRasterLayer`
+        """
+
+        if partition_strategy:
+            return TiledRasterLayer(self.layer_type, self.srdd.partitionBy(partition_strategy))
+        else:
+            return self
 
     def lookup(self, col, row):
         """Return the value(s) in the image of a particular ``SpatialKey`` (given by col and row).
@@ -1251,21 +1322,34 @@ class TiledRasterLayer(CachableLayer, TileLayer):
 
         return [multibandtile_decoder(tile) for tile in array_of_tiles]
 
-    def tile_to_layout(self, layout, target_crs=None, resample_method=ResampleMethod.NEAREST_NEIGHBOR):
+    def tile_to_layout(self,
+                       layout,
+                       target_crs=None,
+                       resample_method=ResampleMethod.NEAREST_NEIGHBOR,
+                       partition_strategy=None):
         """Cut tiles to a given layout and merge overlapping tiles. This will produce unique keys.
 
         Args:
-            layout (:obj:`~geopyspark.geotrellis.LayoutDefinition` or
-                :class:`~geopyspark.geotrellis.Metadata` or
-                :class:`~geopyspark.geotrellis.TiledRasterLayer` or
-                :obj:`~geopyspark.geotrellis.GlobalLayout` or
-                :class:`~geopyspark.geotrellis.LocalLayout`):
-                    Target raster layout for the tiling operation.
+            layout (:obj:`~geopyspark.geotrellis.LayoutDefinition` or :class:`~geopyspark.geotrellis.Metadata` or :class:`~geopyspark.geotrellis.TiledRasterLayer` or :obj:`~geopyspark.geotrellis.GlobalLayout` or :class:`~geopyspark.geotrellis.LocalLayout`):
+                Target raster layout for the tiling operation.
             target_crs (str or int, optional): Target CRS of reprojection. Either EPSG code,
                 well-known name, or a PROJ.4 string. If ``None``, no reproject will be perfomed.
             resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
                 The resample method to use for the reprojection. If none is specified, then
                 ``ResampleMethods.NEAREST_NEIGHBOR`` is used.
+            partition_strategy (:class:`~geopyspark.HashPartitionStrategy` or :class:`~geopyspark.SpatialPartitioinStrategy`, optional):
+                Sets the ``Partitioner`` for the resulting layer and how many partitions it has.
+                Default is, ``None``.
+
+                If ``None``, then the output layer will be the same ``Partitioner`` and number of
+                partitions as the source layer.
+
+                If ``partition_strategy`` is set but has no ``num_partitions``, then the resulting layer
+                will have the ``Partioner`` specified in the strategy with the with same number of
+                partitions the source layer had.
+
+                If ``partition_strategy`` is set and has a ``num_partitions``, then the resulting layer
+                will have the ``Partioner`` and number of partitions specified in the strategy.
 
         Returns:
             :class:`~geopyspark.geotrellis.layer.TiledRasterLayer`
@@ -1275,42 +1359,52 @@ class TiledRasterLayer(CachableLayer, TileLayer):
 
         if target_crs:
             target_crs = crs_to_proj4(target_crs)
-            return _reproject(target_crs, layout, resample_method, self)
+            return _reproject(target_crs, layout, resample_method, partition_strategy, self)
 
         if isinstance(layout, LayoutDefinition):
-            srdd = self.srdd.tileToLayout(layout, resample_method)
+            srdd = self.srdd.tileToLayout(layout, resample_method, partition_strategy)
 
         elif isinstance(layout, Metadata):
             if self.layer_metadata.crs != layout.crs:
                 raise ValueError("The layout needs to have the same crs as the TiledRasterLayer")
 
-            srdd = self.srdd.tileToLayout(layout.layout_definition, resample_method)
+            srdd = self.srdd.tileToLayout(layout.layout_definition, resample_method, partition_strategy)
 
         elif isinstance(layout, TiledRasterLayer):
             if self.layer_metadata.crs != layout.layer_metadata.crs:
                 raise ValueError("The layout needs to have the same crs as the TiledRasterLayer")
 
             metadata = layout.layer_metadata
-            srdd = self.srdd.tileToLayout(metadata.layout_definition, resample_method)
+            srdd = self.srdd.tileToLayout(metadata.layout_definition, resample_method, partition_strategy)
 
         elif isinstance(layout, (LocalLayout, GlobalLayout)):
-            srdd = self.srdd.tileToLayout(layout, resample_method)
+            srdd = self.srdd.tileToLayout(layout, resample_method, partition_strategy)
 
         else:
             raise TypeError("Could not retile from the given layout", layout)
 
         return TiledRasterLayer(self.layer_type, srdd)
 
-    def pyramid(self, resample_method=ResampleMethod.NEAREST_NEIGHBOR, partitioner=Partitioner.HASH_PARTITIONER):
+    def pyramid(self, resample_method=ResampleMethod.NEAREST_NEIGHBOR, partition_strategy=None):
         """Creates a layer ``Pyramid`` where the resolution is halved per level.
 
         Args:
             resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
                 The resample method to use when building the pyramid.
                 Default is ``ResampleMethods.NEAREST_NEIGHBOR``.
-            partitioner (str or :class:`~geopyspark.geotrellis.constants.Partitioner`, optional):
-                The partitioner that should be used to repartition the data. The default is
-                ``Partitioner.HASH_PARTITIONER``.
+            partition_strategy (:class:`~geopyspark.HashPartitionStrategy` or :class:`~geopyspark.SpatialPartitioinStrategy`, optional):
+                Sets the ``Partitioner`` for the resulting layer and how many partitions it has.
+                Default is, ``None``.
+
+                If ``None``, then the output layer will be the same ``Partitioner`` and number of
+                partitions as the source layer.
+
+                If ``partition_strategy`` is set but has no ``num_partitions``, then the resulting layer
+                will have the ``Partioner`` specified in the strategy with the with same number of
+                partitions the source layer had.
+
+                If ``partition_strategy`` is set and has a ``num_partitions``, then the resulting layer
+                will have the ``Partioner`` and number of partitions specified in the strategy.
 
         Returns:
             :class:`~geopyspark.geotrellis.layer.Pyramid`.
@@ -1320,11 +1414,16 @@ class TiledRasterLayer(CachableLayer, TileLayer):
         """
 
         resample_method = ResampleMethod(resample_method)
-        partitioner = Partitioner(partitioner).value
-        result = self.srdd.pyramid(resample_method, partitioner)
+        result = self.srdd.pyramid(resample_method, partition_strategy)
         return Pyramid([TiledRasterLayer(self.layer_type, srdd) for srdd in result])
 
-    def focal(self, operation, neighborhood=None, param_1=None, param_2=None, param_3=None):
+    def focal(self,
+              operation,
+              neighborhood=None,
+              param_1=None,
+              param_2=None,
+              param_3=None,
+              partition_strategy=None):
         """Performs the given focal operation on the layers contained in the Layer.
 
         Args:
@@ -1336,6 +1435,19 @@ class TiledRasterLayer(CachableLayer, TileLayer):
             param_1 (int or float, optional): The first argument of ``neighborhood``.
             param_2 (int or float, optional): The second argument of the ``neighborhood``.
             param_3 (int or float, optional): The third argument of the ``neighborhood``.
+            partition_strategy (:class:`~geopyspark.HashPartitionStrategy` or :class:`~geopyspark.SpatialPartitioinStrategy`, optional):
+                Sets the ``Partitioner`` for the resulting layer and how many partitions it has.
+                Default is, ``None``.
+
+                If ``None``, then the output layer will be the same ``Partitioner`` and number of
+                partitions as the source layer.
+
+                If ``partition_strategy`` is set but has no ``num_partitions``, then the resulting layer
+                will have the ``Partioner`` specified in the strategy with the with same number of
+                partitions the source layer had.
+
+                If ``partition_strategy`` is set and has a ``num_partitions``, then the resulting layer
+                will have the ``Partioner`` and number of partitions specified in the strategy.
 
         Note:
             ``param`` only need to be set if ``neighborhood`` is not an instance of
@@ -1360,7 +1472,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
 
         if isinstance(neighborhood, Neighborhood):
             srdd = self.srdd.focal(operation, neighborhood.name, neighborhood.param_1,
-                                   neighborhood.param_2, neighborhood.param_3)
+                                   neighborhood.param_2, neighborhood.param_3, partition_strategy)
 
         elif isinstance(neighborhood, (str, nb)):
             param_1 = param_1 or 0.0
@@ -1368,11 +1480,11 @@ class TiledRasterLayer(CachableLayer, TileLayer):
             param_3 = param_3 or 0.0
 
             srdd = self.srdd.focal(operation, nb(neighborhood).value,
-                                   float(param_1), float(param_2), float(param_3))
+                                   float(param_1), float(param_2), float(param_3), partition_strategy)
 
         elif not neighborhood and operation == Operation.ASPECT.value:
             z_factor = float(param_1 or 1.0)
-            srdd = self.srdd.focal(operation, nb.SQUARE.value, z_factor, 0.0, 0.0)
+            srdd = self.srdd.focal(operation, nb.SQUARE.value, z_factor, 0.0, 0.0, partition_strategy)
 
         else:
             raise ValueError("neighborhood must be set or the operation must be ASPECT")

--- a/geopyspark/geotrellis/rasterize.py
+++ b/geopyspark/geotrellis/rasterize.py
@@ -1,6 +1,6 @@
 from shapely.wkb import dumps
 from geopyspark import get_spark_context
-from geopyspark.geotrellis.constants import LayerType, CellType, Partitioner
+from geopyspark.geotrellis.constants import LayerType, CellType
 from geopyspark.geotrellis.layer import TiledRasterLayer
 from geopyspark.geotrellis.protobufserializer import ProtoBufSerializer
 

--- a/geopyspark/tests/geotrellis/geotiff_raster_rdd_test.py
+++ b/geopyspark/tests/geotrellis/geotiff_raster_rdd_test.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from geopyspark.geotrellis.constants import LayerType, CellType, Partitioner
 from geopyspark.tests.python_test_utils import file_path
-from geopyspark.geotrellis import Extent, ProjectedExtent, Tile
+from geopyspark.geotrellis import Extent, ProjectedExtent, Tile, SpatialPartitionStrategy
 from geopyspark.geotrellis.geotiff import get
 from geopyspark.geotrellis.layer import RasterLayer
 from geopyspark.tests.base_test_class import BaseTestClass
@@ -27,11 +27,13 @@ class GeoTiffRasterRDDTest(BaseTestClass):
         repartitioned = laid_out_rdd.repartition(2)
         self.assertEqual(repartitioned.getNumPartitions(), 2)
 
-    def test_repartition_with_partitioner(self):
+    def test_partitionBy(self):
         tiled = self.result.tile_to_layout()
-        repartitioned = tiled.repartition(2, Partitioner.SPATIAL_PARTITIONER)
 
-        self.assertEqual(repartitioned.getNumPartitions(), 2)
+        strategy = SpatialPartitionStrategy(2)
+        repartitioned = tiled.partitionBy(strategy)
+
+        self.assertEqual(repartitioned.get_partition_strategy(), strategy)
 
     def test_to_numpy_rdd(self, option=None):
         pyrdd = self.result.to_numpy_rdd()
@@ -56,7 +58,7 @@ class GeoTiffRasterRDDTest(BaseTestClass):
         extent = Extent(0.0, 0.0, 10.0, 10.0)
         projected_extent = ProjectedExtent(extent, epsg_code)
 
-        tile = Tile(arr, 'FLOAT',float('nan'))
+        tile = Tile(arr, 'FLOAT', float('nan'))
         rdd = BaseTestClass.pysc.parallelize([(projected_extent, tile)])
         raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
 

--- a/geopyspark/tests/geotrellis/geotiff_raster_rdd_test.py
+++ b/geopyspark/tests/geotrellis/geotiff_raster_rdd_test.py
@@ -4,7 +4,7 @@ import rasterio
 import pytest
 import numpy as np
 
-from geopyspark.geotrellis.constants import LayerType, CellType, Partitioner
+from geopyspark.geotrellis.constants import LayerType, CellType
 from geopyspark.tests.python_test_utils import file_path
 from geopyspark.geotrellis import Extent, ProjectedExtent, Tile, SpatialPartitionStrategy
 from geopyspark.geotrellis.geotiff import get

--- a/geopyspark/tests/geotrellis/raster_layer_test.py
+++ b/geopyspark/tests/geotrellis/raster_layer_test.py
@@ -3,8 +3,16 @@ import unittest
 import numpy as np
 import pytest
 
-from geopyspark.geotrellis import SpatialKey, Tile, ProjectedExtent, Extent, RasterLayer, LocalLayout, TileLayout, \
-    GlobalLayout, LayoutDefinition
+from geopyspark.geotrellis import (SpatialKey,
+                                   Tile,
+                                   ProjectedExtent,
+                                   Extent,
+                                   RasterLayer,
+                                   LocalLayout,
+                                   TileLayout,
+                                   GlobalLayout,
+                                   LayoutDefinition,
+                                   SpatialPartitionStrategy)
 from shapely.geometry import Point
 from geopyspark.geotrellis.layer import TiledRasterLayer
 from geopyspark.tests.base_test_class import BaseTestClass
@@ -29,6 +37,12 @@ class RasterLayerTest(BaseTestClass):
     numpy_rdd = BaseTestClass.pysc.parallelize(layers)
     layer = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, numpy_rdd)
     metadata = layer.collect_metadata(GlobalLayout(5))
+
+    def test_to_to_layout_with_partitioner(self):
+        strategy = SpatialPartitionStrategy(4)
+        tiled = self.layer.tile_to_layout(LocalLayout(5), partition_strategy=strategy)
+
+        self.assertEqual(tiled.get_partition_strategy(), strategy)
 
     def test_tile_to_local_layout(self):
         tiled = self.layer.tile_to_layout(LocalLayout(5))

--- a/geopyspark/tests/geotrellis/tiled_layer_tests/focal_test.py
+++ b/geopyspark/tests/geotrellis/tiled_layer_tests/focal_test.py
@@ -3,7 +3,7 @@ import os
 import pytest
 import unittest
 
-from geopyspark.geotrellis import SpatialKey, Extent, Tile
+from geopyspark.geotrellis import SpatialKey, Extent, Tile, SpatialPartitionStrategy, HashPartitionStrategy
 from geopyspark.geotrellis.layer import TiledRasterLayer
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis.constants import LayerType, Operation, Neighborhood
@@ -49,7 +49,8 @@ class FocalTest(BaseTestClass):
         result = self.raster_rdd.focal(
             operation=Operation.SUM,
             neighborhood=Neighborhood.SQUARE,
-            param_1=1.0)
+            param_1=1.0,
+            partition_strategy=HashPartitionStrategy())
 
         self.assertTrue(result.to_numpy_rdd().first()[1].cells[0][1][0] >= 6)
 
@@ -59,7 +60,8 @@ class FocalTest(BaseTestClass):
 
         result = self.raster_rdd.focal(
             operation=Operation.SUM,
-            neighborhood=neighborhood)
+            neighborhood=neighborhood,
+            partition_strategy=HashPartitionStrategy(2))
 
         self.assertTrue(result.to_numpy_rdd().first()[1].cells[0][1][0] >= 3)
 
@@ -69,7 +71,8 @@ class FocalTest(BaseTestClass):
 
         result = self.raster_rdd.focal(
             operation=Operation.SUM,
-            neighborhood=neighborhood)
+            neighborhood=neighborhood,
+            partition_strategy=SpatialPartitionStrategy(2))
 
         self.assertTrue(result.to_numpy_rdd().first()[1].cells[0][1][0] >= 4)
 
@@ -79,7 +82,8 @@ class FocalTest(BaseTestClass):
 
         result = self.raster_rdd.focal(
             operation=Operation.SUM,
-            neighborhood=neighborhood)
+            neighborhood=neighborhood,
+            partition_strategy=SpatialPartitionStrategy())
 
         self.assertTrue(result.to_numpy_rdd().first()[1].cells[0][1][0] >= 4)
 

--- a/geopyspark/tests/geotrellis/tiled_layer_tests/partition_preservation_test.py
+++ b/geopyspark/tests/geotrellis/tiled_layer_tests/partition_preservation_test.py
@@ -1,0 +1,51 @@
+import unittest
+import pytest
+
+from geopyspark.geotrellis import SpatialPartitionStrategy, LocalLayout
+from geopyspark.geotrellis.constants import LayerType, Operation
+from geopyspark.geotrellis.geotiff import get
+from geopyspark.geotrellis.neighborhood import Square
+from geopyspark.tests.base_test_class import BaseTestClass
+from geopyspark.tests.python_test_utils import file_path
+
+
+class PartitionPreservationTest(BaseTestClass):
+    rdd = get(LayerType.SPATIAL, file_path("srtm_52_11.tif"), max_tile_size=6001)
+
+    @pytest.fixture(autouse=True)
+    def tearDown(self):
+        yield
+        BaseTestClass.pysc._gateway.close()
+
+    def test_partition_preservation(self):
+        partition_states = []
+        strategy = SpatialPartitionStrategy(16)
+
+        tiled = self.rdd.tile_to_layout()
+
+        tiled2 = self.rdd.tile_to_layout(partition_strategy=strategy)
+        partition_states.append(tiled2.get_partition_strategy())
+
+        added_layer = (tiled + tiled2) * 0.75
+        partition_states.append(added_layer.get_partition_strategy())
+
+        local_max_layer = added_layer.local_max(tiled)
+        partition_states.append(local_max_layer.get_partition_strategy())
+
+        focal_layer = local_max_layer.focal(Operation.MAX, Square(1))
+        partition_states.append(focal_layer.get_partition_strategy())
+
+        reprojected_layer = focal_layer.tile_to_layout(
+            layout=LocalLayout(),
+            target_crs=3857,
+            partition_strategy=strategy)
+        partition_states.append(reprojected_layer.get_partition_strategy())
+
+        pyramided = reprojected_layer.pyramid()
+        partition_states.append(pyramided.levels[pyramided.max_zoom].get_partition_strategy())
+
+        self.assertTrue(all(x == partition_states[0] for x in partition_states))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/geopyspark/tests/geotrellis/tiled_layer_tests/rasterize_test.py
+++ b/geopyspark/tests/geotrellis/tiled_layer_tests/rasterize_test.py
@@ -5,10 +5,9 @@ import math
 
 import pytest
 
-from geopyspark.geotrellis.constants import Partitioner
 from shapely.geometry import Polygon
 from geopyspark.tests.base_test_class import BaseTestClass
-from geopyspark.geotrellis import rasterize
+from geopyspark.geotrellis import rasterize, SpatialPartitionStrategy
 
 
 class RasterizeTest(BaseTestClass):
@@ -50,7 +49,7 @@ class RasterizeTest(BaseTestClass):
                                "EPSG:3857",
                                11,
                                1,
-                               partitioner=Partitioner.SPATIAL_PARTITIONER)
+                               partition_strategy=SpatialPartitionStrategy())
 
         cells = raster_rdd.to_numpy_rdd().first()[1].cells
 

--- a/geopyspark/tests/vector_pipe/rasterizer_test.py
+++ b/geopyspark/tests/vector_pipe/rasterizer_test.py
@@ -1,7 +1,7 @@
 import unittest
 import pytest
 
-from geopyspark.geotrellis import CellType, Partitioner, SpatialPartitionStrategy
+from geopyspark.geotrellis import CellType, SpatialPartitionStrategy
 from geopyspark.vector_pipe import osm_reader, Feature, CellValue
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.tests.python_test_utils import file_path

--- a/geopyspark/tests/vector_pipe/rasterizer_test.py
+++ b/geopyspark/tests/vector_pipe/rasterizer_test.py
@@ -1,7 +1,7 @@
 import unittest
 import pytest
 
-from geopyspark.geotrellis import CellType, Partitioner
+from geopyspark.geotrellis import CellType, Partitioner, SpatialPartitionStrategy
 from geopyspark.vector_pipe import osm_reader, Feature, CellValue
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.tests.python_test_utils import file_path
@@ -67,7 +67,7 @@ class RasterizationTest(BaseTestClass):
                                     4326,
                                     12,
                                     cell_type=CellType.INT8,
-                                    partitioner=Partitioner.SPATIAL_PARTITIONER)
+                                    partition_strategy=SpatialPartitionStrategy())
 
         self.assertEqual(result.get_min_max(), (1, 4))
         self.assertEqual(result.count(), 1)


### PR DESCRIPTION
This PR replaces the current `Partition` constant class with `HashPartitionStrategy` and `SpatialPartition`. The reason for this change is because it allows for cleaner API while also allowing the user to have more control over how a layer is partitioned during operations.

In addition to introducing the partition strategies, this PR also adds the `partition_strategy` parameter to various methods to allow for greater control the partitioning of the layer.

This PR supersedes #615 

**Note:** This PR will not pass until https://github.com/locationtech/geotrellis/pull/2553 is merged.