### PR TITLE
get_point_values Will Now Return the Correct Number of Results for Temporal Layers

### DIFF
--- a/docs/guides/layers.rst
+++ b/docs/guides/layers.rst
@@ -643,9 +643,9 @@ Getting the Point Values From a SPACETIME Layer
 '''''''''''''''''''''''''''''''''''''''''''''''
 
 When using ``get_point_values`` on a layer with a ``LayerType`` of
-``SPACETIME``, the results will be paired as ``(shapely.geometry.Point, datetime.datetime, [float])``.
-Where each given ``Point`` will be paired with the values it intersects and those
-values' corresponding timestamps.
+``SPACETIME``, the results will be paired as ``(shapely.geometry.Point, [(datetime.datetime, [float])])``.
+Where each given ``Point`` will be paired with a list of tuples that contain the values it
+intersects and those values' corresponding timestamps.
 
 .. code:: python3
 
@@ -658,7 +658,7 @@ Giving a [shapely.geometry.Point] to get_point_values
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 When ``points`` is given as a ``[shapely.geometry.Point]``,
-then the ouput will be a ``[(shapely.geometry.Point, datetime.datetime, [float])]``.
+then the ouput will be a ``[(shapely.geometry.Point, [(datetime.datetime, [float])])]``.
 
 .. code:: python3
 
@@ -668,7 +668,7 @@ Giving a {k: shapely.geometry.Point} to get_point_values
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 When ``points`` is given as a ``{k: shapely.geometry.Point}``,
-then the ouput will be a ``{k: (shapely.geometry.Point, datetime.datetime, [float])}``.
+then the ouput will be a ``{k: (shapely.geometry.Point, [(datetime.datetime, [float])])}``.
 
 .. code:: python3
 


### PR DESCRIPTION
This PR fixes a bug where `get_point_values` would only return the values for one instant in a temporal layer regardless of how many times were in the layer itself. Now, all times and their values are returned. Because of this, the return type of `get_point_values` for temporal layers is now different.

**Before:**
```python

# return for lists
[(Point, (datetime.datetime, [float]))]

# return for dicts

{k: (Point, (datetime.datetime, [float]))}
```

**After:**
```python

# return for lists
[(Point, [(datetime.datetime, [float])])]

# return for dicts
{k: (Point, [(datetime.datetime, [float])])}
```

This PR resolves #619 