### PR TITLE
Reading Layers and Values From Accumulo Fix

### DIFF
--- a/docs/guides/catalog.rst
+++ b/docs/guides/catalog.rst
@@ -533,15 +533,3 @@ When writing a workflow that places heavy demand on :class:`~geopyspark.geotrell
           layer_name='spatial-layer',
           tiled_raster_layer=spatial_tiled_layer,
           store=store)
-
-   gps.query(uri="file:///tmp/spatial-catalog-2",
-          layer_name="spatial-layer",
-          layer_zoom=11,
-          store=store)
-
-   gps.read_value(uri="file:///tmp/spatial-catalog-2",
-          layer_name="spatial-layer",
-          layer_zoom=11,
-          col=min_key.col,
-          row=min_key.row,
-          store=store)

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerReaderWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerReaderWrapper.scala
@@ -32,7 +32,6 @@ import scala.collection.mutable
 class LayerReaderWrapper(sc: SparkContext) {
 
   def query(
-    attributeStore: AttributeStore,
     catalogUri: String,
     layerName: String,
     zoom: Int,
@@ -42,10 +41,12 @@ class LayerReaderWrapper(sc: SparkContext) {
     numPartitions: Integer
   ): TiledRasterLayer[_] = {
     val id = LayerId(layerName, zoom)
+    val attributeStore = AttributeStore(catalogUri)
+
     val spatialQuery: Option[Geometry] = Option(queryGeometryBytes).map(WKB.read)
     val queryCRS: Option[CRS] = TileLayer.getCRS(projQuery)
-    val header = attributeStore.readHeader[LayerHeader](id)
-    val layerReader: FilteringLayerReader[LayerId] = LayerReader(attributeStore, catalogUri)(sc)
+    val header: LayerHeader = attributeStore.readHeader[LayerHeader](id)
+    val layerReader: FilteringLayerReader[LayerId] = LayerReader(catalogUri)(sc)
 
     //val pyZoom: Option[Int] = ??? // is this top level zoom or zoom with None ?
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/ValueReaderWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/ValueReaderWrapper.scala
@@ -30,8 +30,9 @@ import geopyspark.util.PythonTranslator
 /**
   * General interface for reading.
   */
-class ValueReaderWrapper(attributeStore: AttributeStore, uri: String) {
-  val valueReader: ValueReader[LayerId] = ValueReader(attributeStore, uri)
+class ValueReaderWrapper(uri: String) {
+  val attributeStore = AttributeStore(uri)
+  val valueReader: ValueReader[LayerId] = ValueReader(uri)
 
   def getValueClass(id: LayerId): String =
     attributeStore.readHeader[LayerHeader](id).valueClass


### PR DESCRIPTION
This PR resolves an the issue where values and layers could not be read from Accumulo. The fix was implemented by creating the `layerReader` and `attributeStore` from the `URI` and not from the passed in `AttributeStore`. Because of that, the `query`, `read_value`, and `ValueReader` no longer take the `store` parameter. The reason why this fix works is not known, and this is something we should look more into in the future.

This PR resolves #618 