### PR TITLE
time_intervals Will Now Enumerate Correctly in catalog.query

### DIFF
--- a/geopyspark/geotrellis/catalog.py
+++ b/geopyspark/geotrellis/catalog.py
@@ -209,8 +209,7 @@ def query(uri,
         query_proj = str(query_proj)
 
     if time_intervals:
-        for x in enumerate(time_intervals):
-            time = time_intervals[x]
+        for x, time in enumerate(time_intervals):
             if time.tzinfo:
                 time_intervals[x] = time.astimezone(pytz.utc).isoformat()
             else:


### PR DESCRIPTION
This PR fixes a bug where the `time_intervals` would not be enumerated correctly in the `catalog.query` method. Which, in turn, would cause an error to be thrown.

This PR resolves #622 