### PR TITLE
Renamed GEOTRELLIS_JAR Back to JAR

### DIFF
--- a/geopyspark/__init__.py
+++ b/geopyspark/__init__.py
@@ -4,7 +4,7 @@ from pkg_resources import resource_filename
 from geopyspark.geopyspark_utils import ensure_pyspark
 ensure_pyspark()
 
-from geopyspark.geopyspark_constants import GEOTRELLIS_JAR
+from geopyspark.geopyspark_constants import JAR
 from pyspark import RDD, SparkConf, SparkContext
 from pyspark.serializers import AutoBatchedSerializer
 from py4j.java_gateway import JavaClass, JavaObject
@@ -99,7 +99,7 @@ def geopyspark_conf(master=None, appName=None, additional_jar_dirs=[]):
                 possible_jars.append(os.path.relpath(config_file.read(), cwd))
 
     module_jars = [
-        os.path.abspath(resource_filename('geopyspark.jars', GEOTRELLIS_JAR))
+        os.path.abspath(resource_filename('geopyspark.jars', JAR))
     ]
 
     jar_dirs = [(jar, os.path.dirname(jar)) for jar in module_jars]

--- a/geopyspark/geopyspark_constants.py
+++ b/geopyspark/geopyspark_constants.py
@@ -5,7 +5,7 @@ from os import path
 VERSION = '0.3.0'
 
 """Backend jar name."""
-GEOTRELLIS_JAR = 'geotrellis-backend-assembly-' + VERSION + '.jar'
+JAR = 'geotrellis-backend-assembly-' + VERSION + '.jar'
 
 """The current location of this file."""
 CWD = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
This PR renames the `GEOTRELLIS_JAR` constant back to its original name, `JAR`.

This PR resolves #624 