### PR TITLE
withNoData Method

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/RasterLayer.scala
@@ -59,8 +59,11 @@ abstract class RasterLayer[K](implicit ev0: ClassTag[K], ev1: Component[K, Proje
   def collectMetadata(layoutType: LayoutType): String
   def collectMetadata(layoutDefinition: LayoutDefinition): String
 
-  def convertDataType(newType: String): RasterLayer[_] =
-    withRDD(rdd.map { x => (x._1, x._2.convert(CellType.fromName(newType))) })
+  def convertDataType(newType: String): RasterLayer[K] =
+    withRDD(rdd.mapValues { _.convert(CellType.fromName(newType)) })
+
+  def withNoData(newNoData: Double): RasterLayer[K] =
+    withRDD(rdd.mapValues { _.withNoData(Some(newNoData)) })
 
   def tileToLayout(
     tileLayerMetadata: String,

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
@@ -310,7 +310,7 @@ abstract class TiledRasterLayer[K: SpatialComponent: JsonFormat: ClassTag: Bound
   def reverseLocalPow(d: Double): TiledRasterLayer[K] =
     withRDD(rdd.mapValues { x => MultibandTile(x.bands.map { y => y.localPowValue(d) }) })
 
-  def convertDataType(newType: String): TiledRasterLayer[_] =
+  def convertDataType(newType: String): TiledRasterLayer[K] =
     withContextRDD(rdd.convert(CellType.fromName(newType)).asInstanceOf[ContextRDD[K, MultibandTile, TileLayerMetadata[K]]])
 
   def normalize(oldMin: Double, oldMax: Double, newMin: Double, newMax: Double): TiledRasterLayer[K] =

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
@@ -313,6 +313,12 @@ abstract class TiledRasterLayer[K: SpatialComponent: JsonFormat: ClassTag: Bound
   def convertDataType(newType: String): TiledRasterLayer[K] =
     withContextRDD(rdd.convert(CellType.fromName(newType)).asInstanceOf[ContextRDD[K, MultibandTile, TileLayerMetadata[K]]])
 
+  def withNoData(newNoData: Double): TiledRasterLayer[K] =
+    withContextRDD(
+      rdd.convert(rdd.metadata.cellType.withNoData(Some(newNoData)))
+        .asInstanceOf[ContextRDD[K, MultibandTile, TileLayerMetadata[K]]]
+      )
+
   def normalize(oldMin: Double, oldMax: Double, newMin: Double, newMax: Double): TiledRasterLayer[K] =
     withRDD {
       rdd.mapValues { tile =>

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -647,6 +647,30 @@ class RasterLayer(CachableLayer, TileLayer):
         else:
             return RasterLayer(self.layer_type, self.srdd.convertDataType(new_type))
 
+    def with_no_data(self, no_data_value):
+        """Changes the ``NoData`` value of the layer with the new given value.
+
+        It is possible to specify a ``NoData`` value for layers with raw values.
+        The resulting layer will be of the same ``CellType`` but with a user
+        defined ``NoData`` value. For example, if a layer has a ``CellType``
+        of ``float32raw`` and a ``no_data_value`` of ``-10`` is given,
+        then the produced layer will have a ``CellType`` of ``float32ud-10.0``.
+
+        If the target layer has a ``bool`` ``CellType``, then the ``no_data_value``
+        will be ignored and the result layer will be the same as the origin. In
+        order to assign a ``NoData`` value to a ``bool`` layer, the
+        :meth:`~geopyspark.geotrellis.layer.RasterLayer.convert_data_type` method
+        must be used.
+
+        Args:
+            no_data_value (int or float): The new ``NoData`` value of the layer.
+
+        Returns:
+            :class:`~geopyspark.geotrellis.layer.RasterLayer`
+        """
+
+        return RasterLayer(self.layer_type, self.srdd.withNoData(float(no_data_value)))
+
     def collect_keys(self):
         """Returns a list of all of the keys in the layer.
 
@@ -1281,6 +1305,30 @@ class TiledRasterLayer(CachableLayer, TileLayer):
         else:
             return TiledRasterLayer(self.layer_type,
                                     self.srdd.convertDataType(new_type))
+
+    def with_no_data(self, no_data_value):
+        """Changes the ``NoData`` value of the layer with the new given value.
+
+        It is possible to specify a ``NoData`` value for layers with raw values.
+        The resulting layer will be of the same ``CellType`` but with a user
+        defined ``NoData`` value. For example, if a layer has a ``CellType``
+        of ``float32raw`` and a ``no_data_value`` of ``-10`` is given,
+        then the produced layer will have a ``CellType`` of ``float32ud-10.0``.
+
+        If the target layer has a ``bool`` ``CellType``, then the ``no_data_value``
+        will be ignored and the result layer will be the same as the origin. In
+        order to assign a ``NoData`` value to a ``bool`` layer, the
+        :meth:`~geopyspark.geotrellis.layer.TiledRasterLayer.convert_data_type` method
+        must be used.
+
+        Args:
+            no_data_value (int or float): The new ``NoData`` value of the layer.
+
+        Returns:
+            :class:`~geopyspark.geotrellis.layer.TiledRasterLayer`
+        """
+
+        return TiledRasterLayer(self.layer_type, self.srdd.withNoData(float(no_data_value)))
 
     def reproject(self, target_crs, resample_method=ResampleMethod.NEAREST_NEIGHBOR):
         """Reproject rasters to ``target_crs``.

--- a/geopyspark/tests/geotrellis/with_no_data_test.py
+++ b/geopyspark/tests/geotrellis/with_no_data_test.py
@@ -1,0 +1,54 @@
+import unittest
+import datetime
+import pytest
+import numpy as np
+
+from geopyspark.tests.base_test_class import BaseTestClass
+from geopyspark.geotrellis import ProjectedExtent, Extent, Tile
+from geopyspark.geotrellis.layer import RasterLayer
+from geopyspark.geotrellis.constants import LayerType
+
+
+class WithNoDataTest(BaseTestClass):
+    epsg_code = 3857
+    extent = Extent(0.0, 0.0, 10.0, 10.0)
+    projected_extent = ProjectedExtent(extent, epsg_code)
+
+    arr = np.zeros((1, 16, 16))
+    tile = Tile(arr, 'FLOAT', -500.0)
+
+    rdd = BaseTestClass.pysc.parallelize([(projected_extent, tile)])
+
+    layer = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd)
+    tiled_layer = layer.tile_to_layout()
+
+    @pytest.fixture(autouse=True)
+    def tearDown(self):
+        yield
+        BaseTestClass.pysc._gateway.close()
+
+    def test_with_no_data_raster_layers(self):
+        no_data_layer = self.layer.with_no_data(-10)
+        tile = no_data_layer.to_numpy_rdd().first()[1]
+
+        self.assertEqual(tile.no_data_value, -10)
+
+        metadata = no_data_layer.collect_metadata()
+
+        self.assertEqual(metadata.cell_type, "float32ud-10.0")
+        self.assertEqual(metadata.no_data_value, -10)
+
+    def test_with_no_data_tiled_raster_layers(self):
+        no_data_layer = self.tiled_layer.with_no_data(18)
+        tile = no_data_layer.to_numpy_rdd().first()[1]
+
+        self.assertEqual(tile.no_data_value, 18)
+
+        metadata = no_data_layer.layer_metadata
+
+        self.assertEqual(metadata.cell_type, "float32ud18.0")
+        self.assertEqual(metadata.no_data_value, 18)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds the `with_no_data` method to the `RasterLayer` and `TiledRasterLayer` classes. This was needed as the only way to change the `NoData` value of a layer before was to use the `convert_data_type` method. With this new method, it'll now be easier and more straightforward to change just the `NoData` value of a layer.

In addition to the added method, the `convertDataType` Scala methods were also cleaned up and the `RasterLayer`'s version of that method has become more performant.