### PR TITLE
Remove hbase, cassandra, accumulo dependencies

### DIFF
--- a/geopyspark-backend/build.sbt
+++ b/geopyspark-backend/build.sbt
@@ -1,7 +1,6 @@
 lazy val commonSettings = Seq(
   version := Version.geopyspark + scala.util.Properties.envOrElse("GEOPYSPARK_VERSION_SUFFIX", ""),
   scalaVersion := Version.scala,
-  crossScalaVersions := Version.crossScala,
   description := "GeoPySpark",
   organization := "org.locationtech.geotrellis",
   licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
@@ -18,7 +17,15 @@ lazy val commonSettings = Seq(
 
   shellPrompt := { s => Project.extract(s).currentProject.id + " > " },
 
-  resolvers += Resolver.sonatypeRepo("releases"),
+  externalResolvers := Seq(
+    "Geotoolkit Repo" at "http://maven.geotoolkit.org",
+    "OSGeo GeoTools" at "http://download.osgeo.org/webdav/geotools/",
+    "geosolutions" at "http://maven.geo-solutions.it/",
+    "LocationTech Snapshots" at "https://repo.locationtech.org/content/groups/snapshots",
+    "LocationTech Releases" at "https://repo.locationtech.org/content/groups/releases",
+    Resolver.bintrayRepo("azavea", "maven"),
+    DefaultMavenRepository
+  ),
 
   addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.3" cross CrossVersion.binary),
   addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full)
@@ -27,7 +34,7 @@ lazy val commonSettings = Seq(
 lazy val publishSettings =
   Seq(
     bintrayOrganization := Some("azavea"),
-    bintrayRepository := "geopyspark",
+    bintrayRepository := "maven",
     bintrayVcsUrl := Some("https://github.com/locationtech-labs/geopyspark.git"),
     publishMavenStyle := true,
     publishArtifact in Test := false,
@@ -35,12 +42,10 @@ lazy val publishSettings =
     homepage := Some(url("https://github.com/locationtech-labs/geopyspark"))
   )
 
-resolvers ++= Seq(
-  "Location Tech GeoTrellis Snapshots" at "https://repo.locationtech.org/content/repositories/geotrellis-snapshots",
-  Resolver.mavenLocal
-)
+
 
 scalaVersion := Version.scala
+scalaVersion in ThisBuild := Version.scala
 
 lazy val root = Project("root", file("."))
 

--- a/geopyspark-backend/geotools/build.sbt
+++ b/geopyspark-backend/geotools/build.sbt
@@ -1,14 +1,5 @@
 name := "geotools-backend"
 
-resolvers ++= Seq(
-  "osgeo" at "http://download.osgeo.org/webdav/geotools",
-  "geosolutions" at "http://maven.geo-solutions.it/",
-  "Geotoolkit Repo" at "http://maven.geotoolkit.org",
-  "Location Tech GeoTrellis Snapshots" at "https://repo.locationtech.org/content/repositories/geotrellis-snapshots",
-  "Location Tech GeoTrellis resleases" at "https://repo.locationtech.org/content/groups/releases",
-  Resolver.mavenLocal
-)
-
 libraryDependencies ++= Seq(
   "org.apache.spark"            %% "spark-core"            % "2.2.0" % "provided",
   "org.locationtech.geotrellis" %% "geotrellis-s3"         % Version.geotrellis,
@@ -16,8 +7,7 @@ libraryDependencies ++= Seq(
   "org.locationtech.geotrellis" %% "geotrellis-spark"      % Version.geotrellis,
   "org.locationtech.geotrellis" %% "geotrellis-geotools"   % Version.geotrellis,
   "org.locationtech.geotrellis" %% "geotrellis-shapefile"  % Version.geotrellis,
-  "de.javakaffee" % "kryo-serializers" % "0.38" exclude("com.esotericsoftware", "kryo"),
-  "javax.media" % "jai_core" % "1.1.3" % Test from "http://download.osgeo.org/webdav/geotools/javax/media/jai_core/1.1.3/jai_core-1.1.3.jar"
+  "de.javakaffee" % "kryo-serializers" % "0.38" exclude("com.esotericsoftware", "kryo")
 )
 
 assemblyMergeStrategy in assembly := {

--- a/geopyspark-backend/geotrellis/build.sbt
+++ b/geopyspark-backend/geotrellis/build.sbt
@@ -7,17 +7,15 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
+  "org.typelevel"               %% "cats"                  % "0.9.0",
+  "com.typesafe.akka"           %% "akka-http"             % "10.0.10",
+  "com.typesafe.akka"           %% "akka-http-spray-json"  % "10.0.10",
+  "net.sf.py4j"                 %  "py4j"                  % "0.10.5",
   "org.apache.spark"            %% "spark-core"            % "2.2.0" % "provided",
-  "org.locationtech.geotrellis" %% "geotrellis-accumulo"   % Version.geotrellis,
-  "org.locationtech.geotrellis" %% "geotrellis-cassandra"  % Version.geotrellis,
-  "org.locationtech.geotrellis" %% "geotrellis-hbase"      % Version.geotrellis,
+  "org.apache.commons"          % "commons-math3"          % "3.6.1",
   "org.locationtech.geotrellis" %% "geotrellis-s3"         % Version.geotrellis,
   "org.locationtech.geotrellis" %% "geotrellis-s3-testkit" % Version.geotrellis,
-  "org.locationtech.geotrellis" %% "geotrellis-spark"      % Version.geotrellis,
-  "org.typelevel"               %% "cats"                  % "0.9.0",
-  "com.typesafe.akka"     %% "akka-http"                   % "10.0.10",
-  "com.typesafe.akka"     %% "akka-http-spray-json"        % "10.0.10",
-  "net.sf.py4j"           % "py4j"                         % "0.10.5"
+  "org.locationtech.geotrellis" %% "geotrellis-spark"      % Version.geotrellis
 )
 
 assemblyMergeStrategy in assembly := {

--- a/geopyspark-backend/geotrellis/build.sbt
+++ b/geopyspark-backend/geotrellis/build.sbt
@@ -1,11 +1,5 @@
 name := "geotrellis-backend"
 
-resolvers ++= Seq(
-  "Location Tech GeoTrellis Snapshots" at "https://repo.locationtech.org/content/repositories/geotrellis-snapshots",
-  "Location Tech GeoTrellis resleases" at "https://repo.locationtech.org/content/groups/releases",
-  Resolver.mavenLocal
-)
-
 libraryDependencies ++= Seq(
   "org.typelevel"               %% "cats"                  % "0.9.0",
   "com.typesafe.akka"           %% "akka-http"             % "10.0.10",
@@ -17,6 +11,14 @@ libraryDependencies ++= Seq(
   "org.locationtech.geotrellis" %% "geotrellis-s3-testkit" % Version.geotrellis,
   "org.locationtech.geotrellis" %% "geotrellis-spark"      % Version.geotrellis
 )
+
+assemblyShadeRules in assembly := {
+  val shadePackage = "org.locationtech.geopyspark.shaded"
+  Seq(
+    ShadeRule.rename("org.apache.avro.**" -> s"$shadePackage.org.apache.avro.@1")
+      .inLibrary("org.locationtech.geotrellis" %% "geotrellis-spark" % Version.geotrellis).inAll
+  )
+}
 
 assemblyMergeStrategy in assembly := {
   case "reference.conf" => MergeStrategy.concat

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ZFactorCalculator.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/ZFactorCalculator.scala
@@ -5,7 +5,7 @@ import geopyspark.geotrellis.Constants.{METERS, FEET, METERSATEQUATOR, FEETATEQU
 import geotrellis.proj4._
 import geotrellis.vector._
 
-import org.apache.commons.math.analysis.interpolation._
+import org.apache.commons.math3.analysis.interpolation._
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/AttributeStoreWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/AttributeStoreWrapper.scala
@@ -4,18 +4,14 @@ import geopyspark.geotrellis._
 
 import geotrellis.spark._
 import geotrellis.spark.io._
-import geotrellis.spark.io.accumulo._
-import geotrellis.spark.io.cassandra._
 import geotrellis.spark.io.file._
 import geotrellis.spark.io.hadoop._
-import geotrellis.spark.io.hbase._
 import geotrellis.spark.io.json._
 import geotrellis.spark.io.s3._
 
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
-import org.apache.accumulo.core.client.security.tokens.PasswordToken
 import org.apache.spark._
 
 import scala.collection.JavaConverters._

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerReaderWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerReaderWrapper.scala
@@ -9,11 +9,8 @@ import geotrellis.raster._
 import geotrellis.proj4._
 import geotrellis.spark._
 import geotrellis.spark.io._
-import geotrellis.spark.io.accumulo._
-import geotrellis.spark.io.cassandra._
 import geotrellis.spark.io.file._
 import geotrellis.spark.io.hadoop._
-import geotrellis.spark.io.hbase._
 import geotrellis.spark.io.json._
 import geotrellis.spark.io.s3._
 

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerWriterWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerWriterWrapper.scala
@@ -5,11 +5,8 @@ import geopyspark.geotrellis._
 import geotrellis.raster._
 import geotrellis.spark._
 import geotrellis.spark.io._
-import geotrellis.spark.io.accumulo._
-import geotrellis.spark.io.cassandra._
 import geotrellis.spark.io.file._
 import geotrellis.spark.io.hadoop._
-import geotrellis.spark.io.hbase._
 import geotrellis.spark.io.index._
 import geotrellis.spark.io.index.hilbert._
 import geotrellis.spark.io.s3._

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/ValueReaderWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/ValueReaderWrapper.scala
@@ -6,11 +6,8 @@ import protos.tileMessages._
 import geotrellis.raster._
 import geotrellis.spark._
 import geotrellis.spark.io._
-import geotrellis.spark.io.accumulo._
-import geotrellis.spark.io.cassandra._
 import geotrellis.spark.io.file._
 import geotrellis.spark.io.hadoop._
-import geotrellis.spark.io.hbase._
 import geotrellis.spark.io.s3._
 import geotrellis.vector._
 import geotrellis.vector.io.wkt.WKT

--- a/geopyspark-backend/project/Version.scala
+++ b/geopyspark-backend/project/Version.scala
@@ -2,6 +2,5 @@ object Version {
   val geopyspark = "0.3.0"
   val geotrellis = "2.0.0-SNAPSHOT"
   val scala       = "2.11.11"
-  val crossScala  = Seq("2.11.11", "2.10.6")
   val scalaTest   = "2.2.0"
 }

--- a/geopyspark-backend/project/build.properties
+++ b/geopyspark-backend/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.17

--- a/geopyspark-backend/project/plugins.sbt
+++ b/geopyspark-backend/project/plugins.sbt
@@ -3,8 +3,8 @@ resolvers ++= Seq(
   Opts.resolver.sonatypeReleases
 )
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.5")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.2")

--- a/geopyspark-backend/util/build.sbt
+++ b/geopyspark-backend/util/build.sbt
@@ -1,11 +1,5 @@
 name := "util"
 
-resolvers ++= Seq(
-  "Location Tech GeoTrellis Snapshots" at "https://repo.locationtech.org/content/repositories/geotrellis-snapshots",
-  "Location Tech GeoTrellis resleases" at "https://repo.locationtech.org/content/groups/releases",
-  Resolver.mavenLocal
-)
-
 libraryDependencies ++= Seq(
   "org.apache.spark"            %% "spark-core"            % "2.0.0" % "provided",
   "org.locationtech.geotrellis" %% "geotrellis-s3"         % Version.geotrellis,

--- a/geopyspark-backend/vectorpipe/build.sbt
+++ b/geopyspark-backend/vectorpipe/build.sbt
@@ -1,12 +1,5 @@
 name := "vectorpipe"
 
-resolvers ++= Seq(
-  "Location Tech GeoTrellis Snapshots" at "https://repo.locationtech.org/content/repositories/geotrellis-snapshots",
-  "Location Tech GeoTrellis resleases" at "https://repo.locationtech.org/content/groups/releases",
-  Resolver.bintrayRepo("azavea", "maven"),
-  Resolver.mavenLocal
-)
-
 libraryDependencies ++= Seq(
   "org.apache.spark"            %% "spark-hive"            % "2.2.0" % "provided",
   "org.locationtech.geotrellis" %% "geotrellis-s3"         % Version.geotrellis,


### PR DESCRIPTION
GeoPySpark should be able to load these from the class path using the LayerReader SPI.
In the meantime keeping these optional should reduce the number of possible class conflicts and slim down the base uber jar.