### PR TITLE
TileReader Will Now Read the Correct Attributes File

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tms/TileReader.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/tms/TileReader.scala
@@ -242,8 +242,8 @@ object TileReaders {
     val valueReader = ValueReader(uri)
     val attributeStore = valueReader.attributeStore
 
-    val ids = attributeStore.layerIds
-    val zoomLevels = for { LayerId(name, zoom) <- ids if name == layerName } yield zoom
+    val ids = attributeStore.layerIds.filter { id => id.name == layerName }
+    val zoomLevels = ids.map { _.zoom }
     val maxZoom = zoomLevels.max
 
     val valueClass = attributeStore.readHeader[LayerHeader](ids.head).valueClass


### PR DESCRIPTION
This PR fixes a bug where `TileReader` would sometimes read the wrong `attributes` file if there existed multiple ones for different layers within the same directory. The cause of this bug was because the reader never filtered out the `LayerId`s by the target layer name so the `attributes` file it would select was sometimes incorrect.

This PR will fail until #636 is merged