### PR TITLE
DataBricks Integration for GPS

### DIFF
--- a/geopyspark-backend/geotrellis/build.sbt
+++ b/geopyspark-backend/geotrellis/build.sbt
@@ -16,6 +16,8 @@ assemblyShadeRules in assembly := {
   val shadePackage = "org.locationtech.geopyspark.shaded"
   Seq(
     ShadeRule.rename("org.apache.avro.**" -> s"$shadePackage.org.apache.avro.@1")
+      .inLibrary("org.locationtech.geotrellis" %% "geotrellis-spark" % Version.geotrellis).inAll,
+    ShadeRule.rename("com.typesafe.scalalogging.**" -> s"$shadePackage.com.typesafe.scalalogging.@1")
       .inLibrary("org.locationtech.geotrellis" %% "geotrellis-spark" % Version.geotrellis).inAll
   )
 }


### PR DESCRIPTION
This PR adds a shading rule for the `com.typesafe.scalalogging` so that GPS can be run in DataBricks. The reason why this rule needed to be added is because the version of `scalalogging` that DataBricks is of a different version than what we use.