### PR TITLE
to_dict Method for Histogram

### DIFF
--- a/geopyspark/geotrellis/histogram.py
+++ b/geopyspark/geotrellis/histogram.py
@@ -28,11 +28,29 @@ class Histogram(object):
 
     @classmethod
     def from_dict(cls, value):
-        """Encodes histogram as a dictionary"""
+        """Encodes histogram from a ``dict``.
+
+        Returns:
+            :class:`~geopyspark.geotrellis.histogram.Histogram`
+        """
+
         pysc = get_spark_context()
         histogram_json = json.dumps(value)
         scala_histogram = pysc._gateway.jvm.geopyspark.geotrellis.Json.readHistogram(histogram_json)
+
         return cls(scala_histogram)
+
+    def to_dict(self):
+        """Converts this ``Histogram`` instance into a ``dict``.
+
+        Returns:
+            dict
+        """
+
+        pysc = get_spark_context()
+        histogram_json = pysc._gateway.jvm.geopyspark.geotrellis.Json.writeHistogram(self.scala_histogram)
+
+        return json.loads(histogram_json)
 
     def min(self):
         """The smallest value of the histogram.

--- a/geopyspark/tests/geotrellis/tiled_layer_tests/histogram_test.py
+++ b/geopyspark/tests/geotrellis/tiled_layer_tests/histogram_test.py
@@ -33,6 +33,14 @@ class HistogramTest(BaseTestClass):
     tiled = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, metadata)
     hist = tiled.get_histogram()
 
+    def test_dict(self):
+        dict_hist = self.hist.to_dict()
+        encoded_hist = Histogram.from_dict(dict_hist)
+
+        self.assertEqual(encoded_hist.min_max(), self.hist.min_max())
+        self.assertEqual(encoded_hist.mean(), self.hist.mean())
+        self.assertEqual(encoded_hist.bucket_count(), self.hist.bucket_count())
+
     def test_min(self):
         self.assertEqual(self.hist.min(), 1.0)
 


### PR DESCRIPTION
This PR adds the `to_dict` method to the `Histogram` class. The reason for adding this method is because there is currently no easy way to convert a `Histogram` instance into a `dict`. This is needed though if the user wishes to save the `Histogram` as an `Attribute` as `Attributes` can only write values that are `dict`s.