### PR TITLE
SpaceTimePartitionStrategy

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Constants.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/Constants.scala
@@ -63,4 +63,5 @@ object Constants {
 
   final val HASH = "HashPartitioner"
   final val SPATIAL = "SpatialPartitioner"
+  final val SPACETIME = "SpaceTimePartitioner"
 }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/PartitionStrategy.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/PartitionStrategy.scala
@@ -40,3 +40,30 @@ object SpatialPartitionStrategy {
       case null => new SpatialPartitionStrategy(None, bits)
     }
 }
+
+
+class SpaceTimePartitionStrategy(
+  val numPartitions: Option[Int],
+  val bits: Int,
+  val temporalType: String,
+  val temporalResolution: String
+) extends PartitionStrategy(numPartitions) {
+  def producePartitioner(partitions: Int): Option[Partitioner] =
+    numPartitions match {
+      case None => Some(SpaceTimePartitioner(partitions, bits, temporalType, temporalResolution))
+      case Some(num) => Some(SpaceTimePartitioner(num, bits, temporalType, temporalResolution))
+    }
+}
+
+object SpaceTimePartitionStrategy {
+  def apply(
+    numPartitions: Integer,
+    bits: Int,
+    temporalType: String,
+    temporalResolution: String
+  ): SpaceTimePartitionStrategy =
+    numPartitions match {
+      case i: Integer => new SpaceTimePartitionStrategy(Some(i.toInt), bits, temporalType, temporalResolution)
+      case null => new SpaceTimePartitionStrategy(None, bits, temporalType, temporalResolution)
+    }
+}

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpaceTimePartitioner.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpaceTimePartitioner.scala
@@ -1,0 +1,73 @@
+package geopyspark.geotrellis
+
+import geotrellis.spark._
+import geotrellis.spark.io.index._
+import geotrellis.spark.io.index.zcurve._
+import geotrellis.util._
+
+import org.apache.spark._
+
+import scala.reflect._
+
+
+class SpaceTimePartitioner[K: SpatialComponent](
+  partitions: Int,
+  bits: Int,
+  temporalType: String,
+  temporalResolution: String
+) extends Partitioner {
+  val timeResolution: Long =
+    (temporalType, temporalResolution) match {
+      case ("millis", null) => 1.toLong
+      case ("millis", r) => r.toLong
+      case ("seconds", null) => 1000L
+      case ("seconds", r) => 1000L * r.toLong
+      case ("minutes", null) => 1000L * 60
+      case ("minutes", r) => 1000L * 60 * r.toLong
+      case ("hours", null) =>  1000L * 60 * 60
+      case ("hours", r) =>  1000L * 60 * 60 * r.toLong
+      case ("days", null) =>  1000L * 60 * 60 * 24
+      case ("days", r) =>  1000L * 60 * 60 * 24 * r.toLong
+      case ("weeks", null) =>  1000L * 60 * 60 * 24 * 7
+      case ("weeks", r) =>  1000L * 60 * 60 * 24 * 7 * r.toLong
+      case ("months", null) =>  1000L * 60 * 60 * 24 * 30
+      case ("months", r) =>  1000L * 60 * 60 * 24 * 30 * r.toLong
+      case ("year", null) =>  1000L * 60 * 60 * 24 * 365
+      case ("year", r) =>  1000L * 60 * 60 * 24 * 365 * r.toLong
+    }
+
+  def numPartitions: Int = partitions
+
+  def getBits: Int = bits
+
+  def getTimeResolution =
+    temporalResolution match {
+      case null => null
+      case s: String => s.toInt
+    }
+
+  def getTimeUnit: String = temporalType
+
+  def getPartition(key: Any): Int = {
+    val k = key.asInstanceOf[SpaceTimeKey]
+    val SpatialKey(col, row) = k.getComponent[SpatialKey]
+    ((Z3(col, row, (k.instant / timeResolution).toInt).z >> bits) % partitions).toInt
+  }
+}
+
+object SpaceTimePartitioner {
+  def apply(
+    partitions: Int,
+    bits: Int,
+    temporalType: String,
+    temporalResolution: String
+  ): SpaceTimePartitioner[SpaceTimeKey] =
+    new SpaceTimePartitioner[SpaceTimeKey](partitions, bits, temporalType, temporalResolution)
+
+  def apply(
+    partitions: Int,
+    temporalType: String,
+    temporalResolution: String
+  ): SpaceTimePartitioner[SpaceTimeKey] =
+    new SpaceTimePartitioner[SpaceTimeKey](partitions, 8, temporalType, temporalResolution)
+}

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TileLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TileLayer.scala
@@ -224,6 +224,7 @@ abstract class TileLayer[K: ClassTag] {
         p match {
           case _: HashPartitioner => "HashPartitioner"
           case _: SpatialPartitioner[K] => "SpatialPartitioner"
+          case _: SpaceTimePartitioner[K] => "SpaceTimePartitioner"
           case _ => throw new Exception(s"$p has no partition strategy")
         }
     }
@@ -253,6 +254,12 @@ object TileLayer {
     partitionStrategy match {
       case ps: PartitionStrategy => ps.producePartitioner(defaultNumPartitions)
       case null => None
+    }
+
+  def getPartitioner(partitions: Int, partitioner: String): Partitioner =
+    partitioner match {
+      case HASH => new HashPartitioner(partitions)
+      case SPATIAL => SpatialPartitioner(partitions)
     }
 
   def getCRS(crs: String): Option[CRS] = {
@@ -288,11 +295,6 @@ object TileLayer {
       case NODATACELLS => TargetCell.NoData
     }
 
-  def getPartitioner(partitions: Int, partitioner: String): Partitioner =
-    partitioner match {
-      case HASH => new HashPartitioner(partitions)
-      case SPATIAL => SpatialPartitioner(partitions)
-    }
 
   def combineBands[K: ClassTag, L <: TileLayer[K]: ClassTag](
     sc: SparkContext,

--- a/geopyspark/geotrellis/converters.py
+++ b/geopyspark/geotrellis/converters.py
@@ -8,7 +8,9 @@ from geopyspark.geotrellis import (RasterizerOptions,
                                    CellType,
                                    LayoutDefinition,
                                    HashPartitionStrategy,
-                                   SpatialPartitionStrategy)
+                                   SpatialPartitionStrategy,
+                                   SpaceTimePartitionStrategy)
+
 
 from geopyspark.geotrellis.constants import ResampleMethod
 
@@ -128,6 +130,23 @@ class SpatialPartitionStrategyConverter:
 
         return ScalaSpatialStrategy.apply(obj.num_partitions, obj.bits)
 
+class SpaceTimePartitionStrategyConverter:
+    def can_convert(self, object):
+        return isinstance(object, SpaceTimePartitionStrategy)
+
+    def convert(self, obj, gateway_client):
+
+        ScalaTemporalStrategy = JavaClass("geopyspark.geotrellis.SpaceTimePartitionStrategy", gateway_client)
+
+        scala_time_unit = obj.time_unit.value
+
+        if obj.time_resolution:
+            scala_time_resolution = str(obj.time_resolution)
+        else:
+            scala_time_resolution = None
+
+        return ScalaTemporalStrategy.apply(obj.num_partitions, obj.bits, scala_time_unit, scala_time_resolution)
+
 
 register_input_converter(CellTypeConverter(), prepend=True)
 register_input_converter(RasterizerOptionsConverter(), prepend=True)
@@ -136,3 +155,4 @@ register_input_converter(ResampleMethodConverter(), prepend=True)
 register_input_converter(LayoutDefinitionConverter(), prepend=True)
 register_input_converter(HashPartitionStrategyConverter(), prepend=True)
 register_input_converter(SpatialPartitionStrategyConverter(), prepend=True)
+register_input_converter(SpaceTimePartitionStrategyConverter(), prepend=True)

--- a/geopyspark/tests/geotrellis/spacetime_partition_strategy_test.py
+++ b/geopyspark/tests/geotrellis/spacetime_partition_strategy_test.py
@@ -1,0 +1,96 @@
+import os
+import datetime
+import unittest
+import numpy as np
+
+import pytest
+
+from geopyspark.geotrellis import SpatialKey, Tile, _convert_to_unix_time
+from geopyspark.tests.base_test_class import BaseTestClass
+from geopyspark.geotrellis import Extent, ProjectedExtent, SpaceTimeKey, SpatialKey, TemporalProjectedExtent, SpaceTimePartitionStrategy
+from geopyspark.geotrellis.layer import RasterLayer, TiledRasterLayer
+from geopyspark.geotrellis.constants import LayerType, TimeUnit
+
+
+class SpaceTimePartitionStrategyTest(BaseTestClass):
+    band = np.array([
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0, 1.0]])
+
+    tile = Tile.from_numpy_array(band)
+    time_1 = datetime.datetime.strptime("2016-08-24T09:00:00Z", '%Y-%m-%dT%H:%M:%SZ')
+    time_2 = datetime.datetime.strptime("2017-08-24T09:00:00Z", '%Y-%m-%dT%H:%M:%SZ')
+    time_3 = datetime.datetime.strptime("2017-10-17T09:00:00Z", '%Y-%m-%dT%H:%M:%SZ')
+
+    layer = [(SpaceTimeKey(0, 0, time_1), tile),
+             (SpaceTimeKey(1, 0, time_1), tile),
+             (SpaceTimeKey(0, 1, time_1), tile),
+             (SpaceTimeKey(1, 1, time_1), tile),
+             (SpaceTimeKey(0, 0, time_2), tile),
+             (SpaceTimeKey(1, 0, time_2), tile),
+             (SpaceTimeKey(0, 1, time_2), tile),
+             (SpaceTimeKey(1, 1, time_2), tile),
+             (SpaceTimeKey(0, 0, time_3), tile),
+             (SpaceTimeKey(1, 0, time_3), tile),
+             (SpaceTimeKey(0, 1, time_3), tile),
+             (SpaceTimeKey(1, 1, time_3), tile)
+            ]
+
+    rdd = BaseTestClass.pysc.parallelize(layer)
+
+    extent = {'xmin': 0.0, 'ymin': 0.0, 'xmax': 33.0, 'ymax': 33.0}
+    layout = {'layoutCols': 2, 'layoutRows': 2, 'tileCols': 5, 'tileRows': 5}
+    metadata = {'cellType': 'float32ud-1.0',
+                'extent': extent,
+                'crs': '+proj=longlat +datum=WGS84 +no_defs ',
+                'bounds': {
+                    'minKey': {'col': 0, 'row': 0, 'instant': _convert_to_unix_time(time_1)},
+                    'maxKey': {'col': 1, 'row': 1, 'instant': _convert_to_unix_time(time_3)}},
+                'layoutDefinition': {
+                    'extent': extent,
+                    'tileLayout': {'tileCols': 5, 'tileRows': 5, 'layoutCols': 2, 'layoutRows': 2}}}
+
+    tiled_raster_rdd = TiledRasterLayer.from_numpy_rdd(LayerType.SPACETIME, rdd, metadata)
+
+    layer2 = [(TemporalProjectedExtent(Extent(0, 0, 1, 1), epsg=3857, instant=time_1), tile),
+              (TemporalProjectedExtent(Extent(1, 0, 2, 1), epsg=3857, instant=time_1), tile),
+              (TemporalProjectedExtent(Extent(0, 1, 1, 2), epsg=3857, instant=time_1), tile),
+              (TemporalProjectedExtent(Extent(1, 1, 2, 2), epsg=3857, instant=time_1), tile),
+              (TemporalProjectedExtent(Extent(1, 0, 2, 1), epsg=3857, instant=time_2), tile),
+              (TemporalProjectedExtent(Extent(1, 0, 2, 1), epsg=3857, instant=time_2), tile),
+              (TemporalProjectedExtent(Extent(0, 1, 1, 2), epsg=3857, instant=time_2), tile),
+              (TemporalProjectedExtent(Extent(1, 1, 2, 2), epsg=3857, instant=time_2), tile),
+              (TemporalProjectedExtent(Extent(1, 0, 2, 1), epsg=3857, instant=time_3), tile),
+              (TemporalProjectedExtent(Extent(1, 0, 2, 1), epsg=3857, instant=time_3), tile),
+              (TemporalProjectedExtent(Extent(0, 1, 1, 2), epsg=3857, instant=time_3), tile),
+              (TemporalProjectedExtent(Extent(1, 1, 2, 2), epsg=3857, instant=time_3), tile)]
+
+    rdd2 = BaseTestClass.pysc.parallelize(layer2)
+    raster_rdd = RasterLayer.from_numpy_rdd(LayerType.SPACETIME, rdd2)
+
+    strategy = SpaceTimePartitionStrategy(TimeUnit.MONTHS, num_partitions=8)
+
+    @pytest.fixture(autouse=True)
+    def tearDown(self):
+        yield
+        BaseTestClass.pysc._gateway.close()
+
+    def test_tiled_raster_layer_should_partition_by(self):
+        result = self.tiled_raster_rdd.partitionBy(self.strategy)
+        actual_strategy = result.get_partition_strategy()
+
+        self.assertEqual(self.strategy, actual_strategy)
+
+    def test_raster_layer_tile_to_layout(self):
+        result = self.raster_rdd.tile_to_layout(layout=self.tiled_raster_rdd, partition_strategy=self.strategy)
+        actual_strategy = result.get_partition_strategy()
+
+        self.assertEqual(self.strategy, actual_strategy)
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pylintrc
+++ b/pylintrc
@@ -4,6 +4,6 @@ ignore=tests,command,protobuf,geopyspark.geotrellis.converters
 
 [MESSAGE CONTROL]
 
-disable=R,W,I,missing-docstring,too-many-arguments,too-few-public-members,too-few-public-methods,no-member,line-too-long,protected-access,invalid-name,import-error,anomalous-backslash-in-string,too-many-statements,too-many-public-methods,slots-on-old-class,no-name-in-module,too-many-instance-attributes,too-many-lines,bad-builtin,too-many-locals,redefined-builtin,redefined-variable-type,too-many-branches,superfluous-parens,no-else-return,ungrouped-imports,assigning-non-slot,wrong-import-position
+disable=R,W,I,missing-docstring,too-many-arguments,too-few-public-members,too-few-public-methods,no-member,line-too-long,protected-access,invalid-name,import-error,anomalous-backslash-in-string,too-many-statements,too-many-public-methods,slots-on-old-class,no-name-in-module,too-many-instance-attributes,too-many-lines,bad-builtin,too-many-locals,redefined-builtin,redefined-variable-type,too-many-branches,superfluous-parens,no-else-return,ungrouped-imports,assigning-non-slot,wrong-import-position,unsupported-membership-test
 
 reports=no


### PR DESCRIPTION
This PR adds the `SpaceTimePartitionStrategy` to to the list of `PartitionStrategies`. This will allow for better partitioning of `SPACETIME` layers. The `SpaceTimePartitioner` will try to sort each element of the layer based on its spatial location and its time. Temporal sorting can be controlled both by a unit of time (ie. `DAYS`, `MONTHS`, etc) and by a resolution (ie. 1 day, 3 weeks, etc).

This PR resolves #642 