### PR TITLE
Easy Import for SpaceTimePartitionStrategy

### DIFF
--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -741,7 +741,8 @@ class Metadata(object):
 
 __all__ = ["Tile", "Extent", "ProjectedExtent", "TemporalProjectedExtent", "SpatialKey", "SpaceTimeKey",
            "Metadata", "TileLayout", "GlobalLayout", "LocalLayout", "LayoutDefinition", "Bounds", "RasterizerOptions",
-           "zfactor_lat_lng_calculator", "zfactor_calculator", "HashPartitionStrategy", "SpatialPartitionStrategy"]
+           "zfactor_lat_lng_calculator", "zfactor_calculator", "HashPartitionStrategy", "SpatialPartitionStrategy",
+           "SpaceTimePartitionStrategy"]
 
 from . import catalog
 from . import color

--- a/geopyspark/tests/geotrellis/tiled_layer_tests/histogram_test.py
+++ b/geopyspark/tests/geotrellis/tiled_layer_tests/histogram_test.py
@@ -77,7 +77,7 @@ class HistogramTest(BaseTestClass):
         self.assertEqual(self.hist.values(), [1.0, 2.0, 3.0, 4.0])
 
     def test_item_count(self):
-        self.assertEqual(self.hist.item_count(3.0), 5)
+        self.assertEqual(self.hist.item_count(3.0), 4)
 
     def test_bin_counts(self):
         metadata2 = {'cellType': 'int32ud-500',


### PR DESCRIPTION
This PR is a slight fix for #643 where `SpaceTimePartitionStrategy` can be easily imported.

Example:

```python

# Before easy import, this is how SpaceTimePartitionStrategy had to be imported
from geopyspark.geotrellis impot SpaceTimePartitionStrategy

# After easy import
import geopyspark as gps

```

In addition, the behavior of the GeoTrellis' `Histogram` has changed slightly due to this PR https://github.com/locationtech/geotrellis/pull/2590 Therefore, a tiny fix to one of the unite tests in `histogram_test` has been updated.