### PR TITLE
GeoTrellis Types Representation

### DIFF
--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -341,28 +341,39 @@ class TemporalProjectedExtent(namedtuple("TemporalProjectedExtent", 'extent inst
                     'proj4': self.proj4}
 
 
-GlobalLayout = namedtuple("GlobalLayout", 'tile_size zoom threshold')
-"""TileLayout type that spans global CRS extent.
+class GlobalLayout(namedtuple("GlobalLayout", 'tile_size zoom threshold')):
+    """TileLayout type that spans global CRS extent.
 
-When passed in place of LayoutDefinition it signifies that a LayoutDefinition instance should be
-constructed such that it fits the global CRS extent. The cell resolution of resulting layout will
-be one of resolutions implied by power of 2 pyramid for that CRS. Tiling to this layout will
-likely result in either up-sampling or down-sampling the source raster.
+    When passed in place of LayoutDefinition it signifies that a LayoutDefinition instance should be
+    constructed such that it fits the global CRS extent. The cell resolution of resulting layout will
+    be one of resolutions implied by power of 2 pyramid for that CRS. Tiling to this layout will
+    likely result in either up-sampling or down-sampling the source raster.
 
-Args:
-    tile_size (int): The number of columns and row pixels in each tile.
-    zoom (int, optional): Override the zoom level in power of 2 pyramid.
-    threshold(float, optional): The percentage difference between a cell size and a zoom level and
-        the resolution difference between that zoom level and the next that is tolerated to snap to
-        the lower-resolution zoom level. For example, if this paramter is 0.1, that means we're
-        willing to downsample rasters with a higher resolution in order to fit them to some zoom
-        level Z, if the difference is resolution is less than or equal to 10% the difference between
-        the resolutions of zoom level Z and zoom level Z+1.
+    Args:
+        tile_size (int): The number of columns and row pixels in each tile.
+        zoom (int, optional): Override the zoom level in power of 2 pyramid.
+        threshold(float, optional): The percentage difference between a cell size and a zoom level and
+            the resolution difference between that zoom level and the next that is tolerated to snap to
+            the lower-resolution zoom level. For example, if this paramter is 0.1, that means we're
+            willing to downsample rasters with a higher resolution in order to fit them to some zoom
+            level Z, if the difference is resolution is less than or equal to 10% the difference between
+            the resolutions of zoom level Z and zoom level Z+1.
 
-Returns:
-    :obj:`~geopyspark.geotrellis.GlobalLayout`
-"""
-GlobalLayout.__new__.__defaults__ = (256, None, 0.1)
+    Attributes:
+        tile_size (int): The number of columns and row pixels in each tile.
+        zoom (int): The desired zoom level of the layout.
+        threshold(float, optional): The percentage difference between a cell size and a zoom level and
+            the resolution difference between that zoom level and the next that is tolerated to snap to
+            the lower-resolution zoom level.
+    """
+
+    __slots__ = []
+
+    def __new__(cls, tile_size=None, zoom=None, threshold=None):
+        tile_size = tile_size or 256
+        threshold = threshold or 0.1
+
+        return super(cls, GlobalLayout).__new__(cls, tile_size, zoom, threshold)
 
 
 class LocalLayout(namedtuple("LocalLayout", 'tile_cols tile_rows')):
@@ -399,72 +410,97 @@ class LocalLayout(namedtuple("LocalLayout", 'tile_cols tile_rows')):
         return super(cls, LocalLayout).__new__(cls, tile_cols, tile_rows)
 
 
-TileLayout = namedtuple("TileLayout", 'layoutCols layoutRows tileCols tileRows')
-"""
-Describes the grid in which the rasters within a Layer should be laid out.
+class TileLayout(namedtuple("TileLayout", 'layoutCols layoutRows tileCols tileRows')):
+    """
+    Describes the grid in which the rasters within a Layer should be laid out.
 
-Args:
-    layoutCols (int): The number of columns of rasters that runs east to west.
-    layoutRows (int): The number of rows of rasters that runs north to south.
-    tileCols (int): The number of columns of pixels in each raster that runs east to west.
-    tileRows (int): The number of rows of pixels in each raster that runs north to south.
+    Args:
+        layoutCols (int): The number of columns of rasters that runs east to west.
+        layoutRows (int): The number of rows of rasters that runs north to south.
+        tileCols (int): The number of columns of pixels in each raster that runs east to west.
+        tileRows (int): The number of rows of pixels in each raster that runs north to south.
 
-Returns:
-    :obj:`~geopyspark.geotrellis.TileLayout`
-"""
+    Attributes:
+        layoutCols (int): The number of columns of rasters that runs east to west.
+        layoutRows (int): The number of rows of rasters that runs north to south.
+        tileCols (int): The number of columns of pixels in each raster that runs east to west.
+        tileRows (int): The number of rows of pixels in each raster that runs north to south.
+    """
 
-
-LayoutDefinition = namedtuple("LayoutDefinition", 'extent tileLayout')
-"""
-Describes the layout of the rasters within a Layer and how they are projected.
-
-Args:
-    extent (:class:`~geopyspark.geotrellis.Extent`): The ``Extent`` of the layout.
-    tileLayout (:obj:`~geopyspark.geotrellis.TileLayout`): The ``TileLayout`` of
-        how the rasters within the Layer.
-
-Returns:
-    :obj:`~geopyspark.geotrellis.LayoutDefinition`
-"""
+    __slots__ = []
 
 
-SpatialKey = namedtuple("SpatialKey", 'col row')
-"""
-Represents the position of a raster within a grid.
-This grid is a 2D plane where raster positions are represented by a pair of coordinates.
+class LayoutDefinition(namedtuple("LayoutDefinition", 'extent tileLayout')):
+    """
+    Describes the layout of the rasters within a Layer and how they are projected.
 
-Args:
-    col (int): The column of the grid, the numbers run east to west.
-    row (int): The row of the grid, the numbers run north to south.
+    Args:
+        extent (:class:`~geopyspark.geotrellis.Extent`): The ``Extent`` of the layout.
+        tileLayout (:class:`~geopyspark.geotrellis.TileLayout`): The ``TileLayout`` of
+            how the rasters within the Layer.
 
-Returns:
-    :obj:`~geopyspark.geotrellis.SpatialKey`
-"""
+    Attributes:
+        extent (:class:`~geopyspark.geotrellis.Extent`): The ``Extent`` of the layout.
+        tileLayout (:class:`~geopyspark.geotrellis.TileLayout`): The ``TileLayout`` of
+            how the rasters within the Layer.
+    """
+
+    __slots__ = []
 
 
-SpaceTimeKey = namedtuple("SpaceTimeKey", 'col row instant')
-"""
-Represents the position of a raster within a grid.
-This grid is a 3D plane where raster positions are represented by a pair of coordinates as well
-as a z value that represents time.
+class SpatialKey(namedtuple("SpatialKey", 'col row')):
+    """
+    Represents the position of a raster within a grid.
+    This grid is a 2D plane where raster positions are represented by a pair of coordinates.
 
-Args:
-    col (int): The column of the grid, the numbers run east to west.
-    row (int): The row of the grid, the numbers run north to south.
-    instant (``datetime.datetime``): The time stamp of the raster.
+    Args:
+        col (int): The column of the grid, the numbers run east to west.
+        row (int): The row of the grid, the numbers run north to south.
 
-Returns:
-    :obj:`~geopyspark.geotrellis.SpaceTimeKey`
-"""
+    Attributes:
+        col (int): The column of the grid, the numbers run east to west.
+        row (int): The row of the grid, the numbers run north to south.
+    """
 
-RasterizerOptions = namedtuple("RasterizeOption", 'includePartial sampleType')
-"""Represents options available to geometry rasterizer
+    __slots__ = []
 
-Args:
-    includePartial (bool): Include partial pixel intersection (default: True)
-    sampleType (str): 'PixelIsArea' or 'PixelIsPoint' (default: 'PixelIsPoint')
-"""
-RasterizerOptions.__new__.__defaults__ = (True, 'PixelIsPoint')
+
+class SpaceTimeKey(namedtuple("SpaceTimeKey", 'col row instant')):
+    """
+    Represents the position of a raster within a grid.
+    This grid is a 3D plane where raster positions are represented by a pair of coordinates as well
+    as a z value that represents time.
+
+    Args:
+        col (int): The column of the grid, the numbers run east to west.
+        row (int): The row of the grid, the numbers run north to south.
+        instant (``datetime.datetime``): The time stamp of the raster.
+
+    Attributes:
+        col (int): The column of the grid, the numbers run east to west.
+        row (int): The row of the grid, the numbers run north to south.
+        instant (``datetime.datetime``): The time stamp of the raster.
+    """
+
+    __slots__ = []
+
+
+class RasterizerOptions(namedtuple("RasterizerOption", 'includePartial sampleType')):
+    """Represents options available to geometry rasterizer
+
+    Args:
+        includePartial (bool, optional): Include partial pixel intersection (default: True)
+        sampleType (str, optional): 'PixelIsArea' or 'PixelIsPoint' (default: 'PixelIsPoint')
+
+    Attributes:
+        includePartial (bool): Include partial pixel intersection.
+        sampleType (str): How the sampling should be performed during rasterization.
+    """
+
+    __slots__ = []
+
+    def __new__(cls, includePartial=True, sampleType='PixelIsPoint'):
+        return super(cls, RasterizerOptions).__new__(cls, includePartial, sampleType)
 
 
 class Bounds(namedtuple("Bounds", 'minKey maxKey')):
@@ -472,13 +508,16 @@ class Bounds(namedtuple("Bounds", 'minKey maxKey')):
     Represents the grid that covers the area of the rasters in a Layer on a grid.
 
     Args:
-        minKey (:obj:`~geopyspark.geotrellis.SpatialKey` or :obj:`~geopyspark.geotrellis.SpaceTimeKey`):
+        minKey (:class:`~geopyspark.geotrellis.SpatialKey` or :class:`~geopyspark.geotrellis.SpaceTimeKey`):
             The smallest ``SpatialKey`` or ``SpaceTimeKey``.
-        minKey (:obj:`~geopyspark.geotrellis.SpatialKey` or :obj:`~geopyspark.geotrellis.SpaceTimeKey`):
+        minKey (:class:`~geopyspark.geotrellis.SpatialKey` or :class:`~geopyspark.geotrellis.SpaceTimeKey`):
             The largest ``SpatialKey`` or ``SpaceTimeKey``.
 
-    Returns:
-        :class:`~geopyspark.geotrellis.Bounds`
+    Attributes:
+        minKey (:class:`~geopyspark.geotrellis.SpatialKey` or :class:`~geopyspark.geotrellis.SpaceTimeKey`):
+            The smallest ``SpatialKey`` or ``SpaceTimeKey``.
+        minKey (:class:`~geopyspark.geotrellis.SpatialKey` or :class:`~geopyspark.geotrellis.SpaceTimeKey`):
+            The largest ``SpatialKey`` or ``SpaceTimeKey``.
     """
 
     __slots__ = []
@@ -503,15 +542,13 @@ class HashPartitionStrategy(namedtuple("HashPartitionStrategy", "num_partitions"
             partitioning. Default is, ``None``. If ``None`` the resulting layer will have
             a ``HashPartitioner`` with the number of partitions being either the same
             as the input layer's, or a number computed by the method.
-
-    Returns:
-        :class:`~geopyspark.geotrellis.HashPartitionStrategy`
     """
 
     __slots__ = []
 
     def __new__(cls, num_partitions=None):
         return super(cls, HashPartitionStrategy).__new__(cls, num_partitions)
+
 
 class SpatialPartitionStrategy(namedtuple("SpatialPartitionStrategy", "num_partitions bits")):
     """Represents a partitioning strategy for a layer that uses GeoPySpark's ``SpatialPartitioner``
@@ -536,8 +573,10 @@ class SpatialPartitionStrategy(namedtuple("SpatialPartitionStrategy", "num_parti
             Therefore, as the number of bits shifted to the right increases, so then too does the
             group sizes.
 
-    Returns:
-        :class:`~geopyspark.geotrellis.SpatialPartitionStrategy`
+    Attributes:
+        num_partitions (int): The number of partitions that should be used during
+            partitioning.
+        bits (int): Determine how much data should be placed in each partition.
     """
 
     __slots__ = []
@@ -585,8 +624,15 @@ class SpaceTimePartitionStrategy(namedtuple("SpaceTimePartitionStrategy", "time_
 
             This value can either be an ``int`` or a string representation of an ``int``.
 
-    Returns:
-        :class:`~geopyspark.geotrellis.SpaceTimePartitionStrategy`
+    Attributes:
+        time_unit (str or :class:`~geopyspark.geotrellis.constants.TimeUnit`): Which time
+            unit should be used when saving spatial-temporal data.
+        num_partitions (int): The number of partitions that should be used during
+            partitioning.
+        bits (int): Helps determine how much data should be placed in each
+            partition.
+        time_resolution (str or int): Determines how data for each ``time_unit`` should be
+            grouped together.
     """
 
     __slots__ = []
@@ -600,7 +646,7 @@ class Metadata(object):
     This data pertains to the layout and other attributes of the data within the classes.
 
     Args:
-        bounds (:obj:`~geopyspark.geotrellis.Bounds`): The ``Bounds`` of the
+        bounds (:class:`~geopyspark.geotrellis.Bounds`): The ``Bounds`` of the
             values in the class.
         crs (str or int): The ``CRS`` of the data. Can either be the EPSG code, well-known name, or
             a PROJ.4 projection string.
@@ -608,11 +654,11 @@ class Metadata(object):
             cells of the rasters.
         extent (:class:`~geopyspark.geotrellis.Extent`): The ``Extent`` that covers
             the all of the rasters.
-        layout_definition (:obj:`~geopyspark.geotrellis.LayoutDefinition`): The
+        layout_definition (:class:`~geopyspark.geotrellis.LayoutDefinition`): The
             ``LayoutDefinition`` of all rasters.
 
     Attributes:
-        bounds (:obj:`~geopyspark.geotrellis.Bounds`): The ``Bounds`` of the values in the class.
+        bounds (:class:`~geopyspark.geotrellis.Bounds`): The ``Bounds`` of the values in the class.
         crs (str or int): The CRS of the data. Can either be the EPSG code, well-known name, or
             a PROJ.4 projection string.
         cell_type (str): The data type of the cells of the rasters.
@@ -620,9 +666,9 @@ class Metadata(object):
             This can either be ``None``, an ``int``, or a ``float`` depending on the ``cell_type``.
         extent (:class:`~geopyspark.geotrellis.Extent`): The ``Extent`` that covers
             the all of the rasters.
-        tile_layout (:obj:`~geopyspark.geotrellis.TileLayout`): The ``TileLayout``
+        tile_layout (:class:`~geopyspark.geotrellis.TileLayout`): The ``TileLayout``
             that describes how the rasters are orginized.
-        layout_definition (:obj:`~geopyspark.geotrellis.LayoutDefinition`): The
+        layout_definition (:class:`~geopyspark.geotrellis.LayoutDefinition`): The
             ``LayoutDefinition`` of all rasters.
     """
 

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -700,7 +700,7 @@ class RasterLayer(CachableLayer, TileLayer):
             number could cause memory issues.
 
         Returns:
-            ``[:obj:`~geopyspark.geotrellis.SpatialKey`]`` or
+            ``[:class:`~geopyspark.geotrellis.SpatialKey`]`` or
             ``[:ob:`~geopyspark.geotrellis.SpaceTimeKey`]``
         """
 
@@ -754,8 +754,8 @@ class RasterLayer(CachableLayer, TileLayer):
         rasters.
 
         Args:
-            layout (:obj:`~geopyspark.geotrellis.LayoutDefinition` or
-                :obj:`~geopyspark.geotrellis.GlobalLayout` or
+            layout (:class:`~geopyspark.geotrellis.LayoutDefinition` or
+                :class:`~geopyspark.geotrellis.GlobalLayout` or
                 :class:`~geopyspark.geotrellis.LocalLayout`, optional):
                     Target raster layout for the tiling operation.
 
@@ -799,7 +799,7 @@ class RasterLayer(CachableLayer, TileLayer):
         """Cut tiles to layout and merge overlapping tiles. This will produce unique keys.
 
         Args:
-            layout (:class:`~geopyspark.geotrellis.Metadata` or :class:`~geopyspark.geotrellis.TiledRasterLayer` or :obj:`~geopyspark.geotrellis.LayoutDefinition` or :obj:`~geopyspark.geotrellis.GlobalLayout` or :class:`~geopyspark.geotrellis.LocalLayout`):
+            layout (:class:`~geopyspark.geotrellis.Metadata` or :class:`~geopyspark.geotrellis.TiledRasterLayer` or :class:`~geopyspark.geotrellis.LayoutDefinition` or :class:`~geopyspark.geotrellis.GlobalLayout` or :class:`~geopyspark.geotrellis.LocalLayout`):
                 Target raster layout for the tiling operation.
             target_crs (str or int, optional): Target CRS of reprojection. Either EPSG code,
                 well-known name, or a PROJ.4 string. If ``None``, no reproject will be perfomed.
@@ -936,7 +936,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
     """Wraps a RDD of tiled, GeoTrellis rasters.
 
     Represents a RDD that contains ``(K, V)``. Where ``K`` is either
-    :class:`~geopyspark.geotrellis.SpatialKey` or :obj:`~geopyspark.geotrellis.SpaceTimeKey`
+    :class:`~geopyspark.geotrellis.SpatialKey` or :class:`~geopyspark.geotrellis.SpaceTimeKey`
     depending on the ``layer_type`` of the RDD, and ``V`` being a
     :class:`~geopyspark.geotrellis.Tile`.
 
@@ -985,7 +985,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
                 a string.
             numpy_rdd (pyspark.RDD): A PySpark RDD that contains tuples of either
                 :class:`~geopyspark.geotrellis.SpatialKey` or
-                :obj:`~geopyspark.geotrellis.SpaceTimeKey` and rasters that are represented by a
+                :class:`~geopyspark.geotrellis.SpaceTimeKey` and rasters that are represented by a
                 numpy array.
             metadata (:class:`~geopyspark.geotrellis.Metadata`): The ``Metadata`` of
                 the ``TiledRasterLayer`` instance.
@@ -1476,7 +1476,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
         """Cut tiles to a given layout and merge overlapping tiles. This will produce unique keys.
 
         Args:
-            layout (:obj:`~geopyspark.geotrellis.LayoutDefinition` or :class:`~geopyspark.geotrellis.Metadata` or :class:`~geopyspark.geotrellis.TiledRasterLayer` or :obj:`~geopyspark.geotrellis.GlobalLayout` or :class:`~geopyspark.geotrellis.LocalLayout`):
+            layout (:class:`~geopyspark.geotrellis.LayoutDefinition` or :class:`~geopyspark.geotrellis.Metadata` or :class:`~geopyspark.geotrellis.TiledRasterLayer` or :class:`~geopyspark.geotrellis.GlobalLayout` or :class:`~geopyspark.geotrellis.LocalLayout`):
                 Target raster layout for the tiling operation.
             target_crs (str or int, optional): Target CRS of reprojection. Either EPSG code,
                 well-known name, or a PROJ.4 string. If ``None``, no reproject will be perfomed.

--- a/geopyspark/geotrellis/protobufcodecs.py
+++ b/geopyspark/geotrellis/protobufcodecs.py
@@ -209,7 +209,7 @@ def from_pb_spatial_key(pb_spatial_key):
         pb_spatial_key (ProtoSpatialKey): An instance of ``ProtoSpatialKey``.
 
     Returns:
-        :obj:`~geopyspark.geotrellis.SpatialKey`
+        :class:`~geopyspark.geotrellis.SpatialKey`
     """
 
     return SpatialKey(col=pb_spatial_key.col, row=pb_spatial_key.row)
@@ -221,7 +221,7 @@ def spatial_key_decoder(proto_bytes):
         proto_bytes (bytes): The ProtoBuf encoded bytes of the ProtoBuf class.
 
     Returns:
-        :obj:`~geopyspark.geotrellis.SpatialKey`
+        :class:`~geopyspark.geotrellis.SpatialKey`
     """
 
     pb_spatial_key = keyMessages_pb2.ProtoSpatialKey.FromString(proto_bytes)
@@ -234,7 +234,7 @@ def from_pb_space_time_key(pb_space_time_key):
         pb_space_time_key (ProtoSpaceTimeKey): An instance of ``ProtoSpaceTimeKey``.
 
     Returns:
-        :obj:`~geopyspark.geotrellis.SpaceTimeKey`
+        :class:`~geopyspark.geotrellis.SpaceTimeKey`
     """
 
     return SpaceTimeKey(col=pb_space_time_key.col, row=pb_space_time_key.row,
@@ -247,7 +247,7 @@ def space_time_key_decoder(proto_bytes):
         proto_bytes (bytes): The ProtoBuf encoded bytes of the ProtoBuf class.
 
     Returns:
-        :obj:`~geopyspark.geotrellis.SpaceTimeKey`
+        :class:`~geopyspark.geotrellis.SpaceTimeKey`
     """
 
     pb_space_time_key = keyMessages_pb2.ProtoSpaceTimeKey.FromString(proto_bytes)
@@ -571,7 +571,7 @@ def to_pb_spatial_key(obj):
     """Converts an instance of ``SpatialKey`` to ``ProtoSpatialKey``.
 
     Args:
-        obj (:obj:`~geopyspark.geotrellis.SpatialKey`): An instance of ``SpatialKey``.
+        obj (:class:`~geopyspark.geotrellis.SpatialKey`): An instance of ``SpatialKey``.
 
     Returns:
         ProtoSpatialKey
@@ -588,7 +588,7 @@ def spatial_key_encoder(obj):
     """Encodes a ``SpatialKey`` into ``ProtoSpatialKey`` bytes.
 
     Args:
-        obj (:obj:`~geopyspark.geotrellis.SpatialKey`): An instance of ``SpatialKey``.
+        obj (:class:`~geopyspark.geotrellis.SpatialKey`): An instance of ``SpatialKey``.
 
     Returns:
         bytes
@@ -600,7 +600,7 @@ def to_pb_space_time_key(obj):
     """Converts an instance of ``SpaceTimeKey`` to ``ProtoSpaceTimeKey``.
 
     Args:
-        obj (:obj:`~geopyspark.geotrellis.SpaceTimeKey`): An instance of ``SpaceTimeKey``.
+        obj (:class:`~geopyspark.geotrellis.SpaceTimeKey`): An instance of ``SpaceTimeKey``.
 
     Returns:
         ProtoSpaceTimeKey
@@ -618,7 +618,7 @@ def space_time_key_encoder(obj):
     """Encodes a ``SpaceTimeKey`` into ``ProtoSpaceTimeKey`` bytes.
 
     Args:
-        obj (:obj:`~geopyspark.geotrellis.SpaceTimeKey`): An instance of ``SpaceTimeKey``.
+        obj (:class:`~geopyspark.geotrellis.SpaceTimeKey`): An instance of ``SpaceTimeKey``.
 
     Returns:
         bytes


### PR DESCRIPTION
This PR changes some of the GeoTrellis types from `namedtuple`s to sub-classes of `namedtuple`s. The reason for this is because of how they're represented in the documentation. For example, the `GlobalLayout` section of the API docs does not have any of the type's docstrings https://geopyspark.readthedocs.io/en/latest/docs/geopyspark.geotrellis.html#geopyspark.geotrellis.GlobalLayout because Sphinx don't know how to include docstrings to a `namedtuple`. Whereas `LocalLayout` is a sub-class of `namedtuple`, and its docstrings are visible in the docs https://geopyspark.readthedocs.io/en/latest/docs/geopyspark.geotrellis.html#geopyspark.geotrellis.LocalLayout