### PR TITLE
RasterFrames Methods

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/SpatialTiledRasterLayer.scala
@@ -100,7 +100,7 @@ class SpatialTiledRasterLayer(
       case GlobalLayout(tileSize, zoom, threshold) =>
         val scheme = new ZoomedLayoutScheme(crs, tileSize, threshold)
         val (_, reprojected) = TileRDDReproject(rdd, crs, Right(scheme.levelForZoom(zoom).layout), resampleMethod, partitioner)
-        SpatialTiledRasterLayer(Some(zoom), reprojected)
+        SpatialTiledRasterLayer(zoom, reprojected)
 
       case LocalLayout(tileCols, tileRows) =>
         val (_, reprojected) = rdd.reproject(crs, FloatingLayoutScheme(tileCols, tileRows), resampleMethod, partitioner)
@@ -545,6 +545,15 @@ object SpatialTiledRasterLayer {
 
     SpatialTiledRasterLayer(Some(zoomLevel), tileLayer)
   }
+
+  def apply(
+    zoomLevel: Integer,
+    rdd: RDD[(SpatialKey, MultibandTile)] with Metadata[TileLayerMetadata[SpatialKey]]
+  ): SpatialTiledRasterLayer =
+    zoomLevel match {
+      case i: Integer => apply(Some(i.toInt), rdd)
+      case null => apply(None, rdd)
+    }
 
   def apply(
     zoomLevel: Option[Int],

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TemporalTiledRasterLayer.scala
@@ -222,7 +222,7 @@ class TemporalTiledRasterLayer(
       case GlobalLayout(tileSize, zoom, threshold) =>
         val scheme = new ZoomedLayoutScheme(crs, tileSize, threshold)
         val (_, reprojected) = TileRDDReproject(rdd, crs, Right(scheme.levelForZoom(zoom).layout), resampleMethod, partitioner)
-        TemporalTiledRasterLayer(Some(zoom), reprojected)
+        TemporalTiledRasterLayer(zoom, reprojected)
 
       case LocalLayout(tileCols, tileRows) =>
         val (_, reprojected) = rdd.reproject(crs, FloatingLayoutScheme(tileCols, tileRows), resampleMethod, partitioner)
@@ -644,6 +644,15 @@ object TemporalTiledRasterLayer {
 
     TemporalTiledRasterLayer(Some(zoomLevel), tileLayer)
   }
+
+  def apply(
+    zoomLevel: Integer,
+    rdd: RDD[(SpaceTimeKey, MultibandTile)] with Metadata[TileLayerMetadata[SpaceTimeKey]]
+  ): TemporalTiledRasterLayer =
+    zoomLevel match {
+      case i: Integer => apply(Some(i.toInt), rdd)
+      case null => apply(None, rdd)
+    }
 
   def apply(
     zoomLevel: Option[Int],


### PR DESCRIPTION
This PR adds two methods to `TiledRasterLayer`: `to_rasterframe` and `from_rasterframe`. These methods will convert a `TiledRasterLayer` into a `RasterLayer` and a `RasterLayer` into a `TiledRasterLayer`, respectively.

**Note:** This PR should not be merged until deployment issues with `pyrasterframes` have been resolved.