### PR TITLE
Metadata Creation Fix

### DIFF
--- a/geopyspark-backend/geotrellis/build.sbt
+++ b/geopyspark-backend/geotrellis/build.sbt
@@ -23,6 +23,10 @@ assemblyShadeRules in assembly := {
   )
 }
 
+fork in Test := true
+
+javaOptions ++= Seq("-Xms1024m", "-Xmx6144m")
+
 assemblyMergeStrategy in assembly := {
   case s if s.startsWith("META-INF/services") => MergeStrategy.concat
   case "reference.conf" | "application.conf"  => MergeStrategy.concat

--- a/geopyspark-backend/project/Version.scala
+++ b/geopyspark-backend/project/Version.scala
@@ -1,6 +1,6 @@
 object Version {
   val geopyspark = "0.4.2"
-  val geotrellis = "2.0.0-RC1"
+  val geotrellis = "2.0.0"
   val scala       = "2.11.11"
   val scalaTest   = "2.2.0"
 }

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -674,7 +674,7 @@ class Metadata(object):
 
     def __init__(self, bounds, crs, cell_type, extent, layout_definition):
         self.bounds = bounds
-        self.crs = crs
+        self.crs = crs_to_proj4(crs)
 
         if isinstance(cell_type, CellType):
             self.cell_type = CellType(cell_type).value

--- a/geopyspark/tests/geotrellis/tiled_layer_tests/mask_test.py
+++ b/geopyspark/tests/geotrellis/tiled_layer_tests/mask_test.py
@@ -4,7 +4,7 @@ import pytest
 import rasterio
 import numpy as np
 
-from geopyspark.geotrellis import SpatialKey, Tile, SpatialPartitionStrategy, RasterizerOptions
+from geopyspark.geotrellis import SpatialKey, Tile, SpatialPartitionStrategy, RasterizerOptions, Metadata
 from shapely.geometry import Polygon, box
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis.layer import TiledRasterLayer
@@ -27,7 +27,7 @@ class MaskTest(BaseTestClass):
     layout = {'layoutCols': 2, 'layoutRows': 2, 'tileCols': 2, 'tileRows': 2}
     metadata = {'cellType': 'float32ud-1.0',
                 'extent': extent,
-                'crs': '+proj=longlat +datum=WGS84 +no_defs ',
+                'crs': 4326,
                 'bounds': {
                     'minKey': {'col': 0, 'row': 0},
                     'maxKey': {'col': 1, 'row': 1}},
@@ -36,7 +36,7 @@ class MaskTest(BaseTestClass):
                     'tileLayout': layout}}
 
     geoms = [box(0.0, 0.0, 2.0, 2.0), box(3.0, 3.0, 4.0, 4.0)]
-    raster_rdd = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, metadata)
+    raster_rdd = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, Metadata.from_dict(metadata))
 
     @pytest.fixture(autouse=True)
     def tearDown(self):


### PR DESCRIPTION
This PR fixes a bug that prevented the user from creating `Metadata` from a `dict` when the `crs` was not a proj4 string. Now, an `int` representing an EPSG code can used for the CRS.

In addition to the above fix, this PR also bumps the GeoTrellis version to 2.0.0.