### PR TITLE
[WIP] Allow catalog readers to use COG backends

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerWriterWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/LayerWriterWrapper.scala
@@ -5,6 +5,7 @@ import geopyspark.geotrellis._
 import geotrellis.raster._
 import geotrellis.spark._
 import geotrellis.spark.io._
+import geotrellis.spark.io.cog._
 import geotrellis.spark.io.file._
 import geotrellis.spark.io.hadoop._
 import geotrellis.spark.io.index._
@@ -25,8 +26,12 @@ import java.time.ZonedDateTime
   * Base wrapper class for all backends that provide a
   * LayerWriter[LayerId].
   */
-class LayerWriterWrapper(attributeStore: AttributeStore, uri: String) {
-  val layerWriter: LayerWriter[LayerId] = LayerWriter(attributeStore, uri)
+class LayerWriterWrapper(attributeStore: AttributeStore, uri: String, useCOGs: Boolean = false) {
+  val layerWriter: Either[COGLayerWriter, LayerWriter[LayerId]] =
+    if (useCOGs)
+      Left(COGLayerWriter(attributeStore, uri))
+    else
+      Right(LayerWriter(attributeStore, uri))
 
   private def getSpatialIndexMethod(indexStrategy: String): KeyIndexMethod[SpatialKey] =
     indexStrategy match {
@@ -83,10 +88,19 @@ class LayerWriterWrapper(attributeStore: AttributeStore, uri: String) {
     spatialRDD: TiledRasterLayer[SpatialKey],
     indexStrategy: String
   ): Unit = {
-    val id = getLayerId(layerName, spatialRDD)
     val indexMethod = getSpatialIndexMethod(indexStrategy)
-
-    layerWriter.write(id, spatialRDD.rdd, indexMethod)
+    layerWriter match {
+      case Left(cogWriter) =>
+        val zoom = spatialRDD.zoomLevel.getOrElse(0)
+        cogWriter.write(layerName, spatialRDD.rdd, zoom, indexMethod)
+      case Right(avroWriter) =>
+        val id =
+          spatialRDD.zoomLevel match {
+            case Some(zoom) => LayerId(layerName, zoom)
+            case None => LayerId(layerName, 0)
+          }
+        avroWriter.write(id, spatialRDD.rdd, indexMethod)
+    }
   }
 
   def writeTemporal(
@@ -96,10 +110,19 @@ class LayerWriterWrapper(attributeStore: AttributeStore, uri: String) {
     timeResolution: String,
     indexStrategy: String
   ): Unit = {
-    val id = getLayerId(layerName, temporalRDD)
     val indexMethod = getTemporalIndexMethod(timeString, timeResolution, indexStrategy)
-
-    layerWriter.write(id, temporalRDD.rdd, indexMethod)
+    layerWriter match {
+      case Left(cogWriter) =>
+        val zoom = temporalRDD.zoomLevel.getOrElse(0)
+        cogWriter.write(layerName, temporalRDD.rdd, zoom, indexMethod)
+      case Right(avroWriter) =>
+        val id =
+          temporalRDD.zoomLevel match {
+            case Some(zoom) => LayerId(layerName, zoom)
+            case None => LayerId(layerName, 0)
+          }
+        avroWriter.write(id, temporalRDD.rdd, indexMethod)
+    }
   }
 
   def updateSpatial(

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/ValueReaderWrapper.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/io/ValueReaderWrapper.scala
@@ -6,6 +6,7 @@ import protos.tileMessages._
 import geotrellis.raster._
 import geotrellis.spark._
 import geotrellis.spark.io._
+import geotrellis.spark.io.cog._
 import geotrellis.spark.io.file._
 import geotrellis.spark.io.hadoop._
 import geotrellis.spark.io.s3._
@@ -27,9 +28,13 @@ import geopyspark.util.PythonTranslator
 /**
   * General interface for reading.
   */
-class ValueReaderWrapper(uri: String) {
+class ValueReaderWrapper(uri: String, useCOGs: Boolean = false) {
   val attributeStore = AttributeStore(uri)
-  val valueReader: ValueReader[LayerId] = ValueReader(uri)
+  val valueReader: Either[COGValueReader[LayerId], ValueReader[LayerId]] =
+    if (useCOGs)
+      Left(COGValueReader(uri))
+    else
+      Right(ValueReader(uri))
 
   def getValueClass(id: LayerId): String =
     attributeStore.readHeader[LayerHeader](id).valueClass
@@ -67,22 +72,34 @@ class ValueReaderWrapper(uri: String) {
       (header.keyClass, header.valueClass) match {
         case ("geotrellis.spark.SpatialKey", "geotrellis.raster.Tile") => {
           val spatialKey = SpatialKey(col, row)
-          val result = valueReader.reader[SpatialKey, Tile](id).read(spatialKey)
+          val result = valueReader match {
+            case Left(cogReader) => cogReader.reader[SpatialKey, Tile](id).read(spatialKey)
+            case Right(avroReader) => avroReader.reader[SpatialKey, Tile](id).read(spatialKey)
+          }
           PythonTranslator.toPython[MultibandTile, ProtoMultibandTile](MultibandTile(result))
         }
         case ("geotrellis.spark.SpatialKey", "geotrellis.raster.MultibandTile") => {
           val spatialKey = SpatialKey(col, row)
-          val result = valueReader.reader[SpatialKey, MultibandTile](id).read(spatialKey)
+          val result = valueReader match {
+            case Left(cogReader) => cogReader.reader[SpatialKey, MultibandTile](id).read(spatialKey)
+            case Right(avroReader) => avroReader.reader[SpatialKey, MultibandTile](id).read(spatialKey)
+          }
           PythonTranslator.toPython[MultibandTile, ProtoMultibandTile](result)
         }
         case ("geotrellis.spark.SpaceTimeKey", "geotrellis.raster.Tile") => {
           val spaceKey = SpaceTimeKey(col, row, ZonedDateTime.parse(zdt))
-          val result = valueReader.reader[SpaceTimeKey, Tile](id).read(spaceKey)
+          val result = valueReader match {
+            case Left(cogReader) => cogReader.reader[SpaceTimeKey, Tile](id).read(spaceKey)
+            case Right(avroReader) => avroReader.reader[SpaceTimeKey, Tile](id).read(spaceKey)
+          }
           PythonTranslator.toPython[MultibandTile, ProtoMultibandTile](MultibandTile(result))
         }
         case ("geotrellis.spark.SpaceTimeKey", "geotrellis.raster.MultibandTile") => {
           val spaceKey = SpaceTimeKey(col, row, ZonedDateTime.parse(zdt))
-          val result = valueReader.reader[SpaceTimeKey, MultibandTile](id).read(spaceKey)
+          val result = valueReader match {
+            case Left(cogReader) => cogReader.reader[SpaceTimeKey, MultibandTile](id).read(spaceKey)
+            case Right(avroReader) => avroReader.reader[SpaceTimeKey, MultibandTile](id).read(spaceKey)
+          }
           PythonTranslator.toPython[MultibandTile, ProtoMultibandTile](result)
         }
       }


### PR DESCRIPTION
Geotrellis 2.0 offers the possibility of reading and writing layers as cloud-optimized GeoTiffs (COGs).  This PR intends to allow the `catalog` GPS module to specify the `use_cogs` flag to enable access to this feature. Thus, we allow catalogs to be written in a manner that allows individual files to be read through common GIS tools, as well as through the GPS interface.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>