### PR TITLE
crop Method for TiledRasterLayer

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TiledRasterLayer.scala
@@ -8,6 +8,7 @@ import protos.tupleMessages._
 
 import geotrellis.proj4._
 import geotrellis.raster._
+import geotrellis.raster.crop.Crop.{Options => CropOptions}
 import geotrellis.raster.distance._
 import geotrellis.raster.io.geotiff._
 import geotrellis.raster.io.geotiff.compression._
@@ -16,6 +17,7 @@ import geotrellis.raster.rasterize._
 import geotrellis.raster.render._
 import geotrellis.raster.resample.ResampleMethod
 import geotrellis.spark._
+import geotrellis.spark.crop._
 import geotrellis.spark.costdistance.IterativeCostDistance
 import geotrellis.spark.io._
 import geotrellis.spark.io.json._
@@ -81,6 +83,16 @@ abstract class TiledRasterLayer[K: SpatialComponent: JsonFormat: ClassTag: Bound
   def collectKeys(): java.util.ArrayList[Array[Byte]]
 
   def layerMetadata: String = rdd.metadata.toJson.prettyPrint
+
+  def crop(
+    area: Array[Byte],
+    options: CropOptions
+  ): TiledRasterLayer[K] =
+    withContextRDD(
+      rdd
+        .crop(WKB.read(area).envelope, options)
+        .asInstanceOf[ContextRDD[K, MultibandTile, TileLayerMetadata[K]]]
+      )
 
   def mask(wkbs: java.util.ArrayList[Array[Byte]]): TiledRasterLayer[K] = {
     val geometries: Seq[MultiPolygon] = wkbs

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -503,6 +503,27 @@ class RasterizerOptions(namedtuple("RasterizerOption", 'includePartial sampleTyp
         return super(cls, RasterizerOptions).__new__(cls, includePartial, sampleType)
 
 
+class CropOptions(namedtuple("CropOptions", 'clamp force')):
+    """Represents options available when cropping a ``TiledRasterLayer``.
+
+    Args:
+        clamp (bool, optional): Clamp the given area to the source boundaries. If ``False``,
+            then the resulting value might not be contained within the source layer.
+            (default: ``True``).
+        force (bool, optional): If ``True``, the resulting layer should be created immediately.
+            Otherwise, the result will be lazily computed (default: ``False``).
+
+    Attributes:
+        clamp (bool): Clamp the given area to the source boundaries
+        force (bool): Should the resulting layer be created immediately or lazily.
+    """
+
+    __slots__ = []
+
+    def __new__(cls, clamp=True, force=False):
+        return super(cls, CropOptions).__new__(cls, clamp, force)
+
+
 class Bounds(namedtuple("Bounds", 'minKey maxKey')):
     """
     Represents the grid that covers the area of the rasters in a Layer on a grid.
@@ -788,7 +809,7 @@ class Metadata(object):
 __all__ = ["Tile", "Extent", "ProjectedExtent", "TemporalProjectedExtent", "SpatialKey", "SpaceTimeKey",
            "Metadata", "TileLayout", "GlobalLayout", "LocalLayout", "LayoutDefinition", "Bounds", "RasterizerOptions",
            "zfactor_lat_lng_calculator", "zfactor_calculator", "HashPartitionStrategy", "SpatialPartitionStrategy",
-           "SpaceTimePartitionStrategy"]
+           "SpaceTimePartitionStrategy", "CropOptions"]
 
 from . import catalog
 from . import color

--- a/geopyspark/geotrellis/converters.py
+++ b/geopyspark/geotrellis/converters.py
@@ -9,7 +9,8 @@ from geopyspark.geotrellis import (RasterizerOptions,
                                    LayoutDefinition,
                                    HashPartitionStrategy,
                                    SpatialPartitionStrategy,
-                                   SpaceTimePartitionStrategy)
+                                   SpaceTimePartitionStrategy,
+                                   CropOptions)
 
 
 from geopyspark.geotrellis.constants import ResampleMethod
@@ -147,6 +148,16 @@ class SpaceTimePartitionStrategyConverter:
 
         return ScalaTemporalStrategy.apply(obj.num_partitions, obj.bits, scala_time_unit, scala_time_resolution)
 
+class CropOptionsConverter:
+    def can_convert(self, object):
+        return isinstance(object, CropOptions)
+
+    def convert(self, obj, gateway_client):
+
+        ScalaCropOptions = JavaClass("geotrellis.raster.crop.Crop$Options$", gateway_client)
+
+        return ScalaCropOptions().apply(obj.clamp, obj.force)
+
 
 register_input_converter(CellTypeConverter(), prepend=True)
 register_input_converter(RasterizerOptionsConverter(), prepend=True)
@@ -156,3 +167,4 @@ register_input_converter(LayoutDefinitionConverter(), prepend=True)
 register_input_converter(HashPartitionStrategyConverter(), prepend=True)
 register_input_converter(SpatialPartitionStrategyConverter(), prepend=True)
 register_input_converter(SpaceTimePartitionStrategyConverter(), prepend=True)
+register_input_converter(CropOptionsConverter(), prepend=True)

--- a/geopyspark/tests/geotrellis/tiled_layer_tests/crop_test.py
+++ b/geopyspark/tests/geotrellis/tiled_layer_tests/crop_test.py
@@ -1,0 +1,58 @@
+import os
+import unittest
+import pytest
+import rasterio
+import numpy as np
+
+from geopyspark.geotrellis import SpatialKey, Tile, CropOptions, Extent
+from shapely.geometry import box
+from geopyspark.tests.base_test_class import BaseTestClass
+from geopyspark.geotrellis.layer import TiledRasterLayer
+from geopyspark.geotrellis.constants import LayerType
+
+
+class CropTest(BaseTestClass):
+    pysc = BaseTestClass.pysc
+
+    cells = np.array([[
+        [1.0, 1.0, 1.0, 1.0, 1.0],
+        [2.0, 2.0, 2.0, 2.0, 2.0],
+        [3.0, 3.0, 3.0, 3.0, 3.0],
+        [4.0, 4.0, 4.0, 4.0, 4.0],
+        [5.0, 5.0, 5.0, 5.0, 5.0]]])
+
+    layer = [(SpatialKey(0, 0), Tile(cells, 'FLOAT', -1.0)),
+             (SpatialKey(1, 0), Tile(cells, 'FLOAT', -1.0,)),
+             (SpatialKey(0, 1), Tile(cells, 'FLOAT', -1.0,)),
+             (SpatialKey(1, 1), Tile(cells, 'FLOAT', -1.0,))]
+
+    rdd = pysc.parallelize(layer)
+
+    extent = {'xmin': 0.0, 'ymin': 0.0, 'xmax': 4.0, 'ymax': 4.0}
+    layout = {'layoutCols': 2, 'layoutRows': 2, 'tileCols': 5, 'tileRows': 5}
+    metadata = {'cellType': 'float32ud-1.0',
+                'extent': extent,
+                'crs': '+proj=longlat +datum=WGS84 +no_defs ',
+                'bounds': {
+                    'minKey': {'col': 0, 'row': 0},
+                    'maxKey': {'col': 1, 'row': 1}},
+                'layoutDefinition': {
+                    'extent': extent,
+                    'tileLayout': layout}}
+
+    raster_rdd = TiledRasterLayer.from_numpy_rdd(LayerType.SPATIAL, rdd, metadata)
+
+    @pytest.fixture(autouse=True)
+    def tearDown(self):
+        yield
+        BaseTestClass.pysc._gateway.close()
+
+    def test_crop(self):
+        area_of_interest = box(0.0, 0.0, 2.0, 2.0)
+        actual = self.raster_rdd.crop(area_of_interest).layer_metadata.extent
+
+        self.assertEqual(Extent.from_polygon(area_of_interest), actual)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds the `crop` method to `TiledRasterLayer` which will allow users to crop out areas of interest in their layers.