### PR TITLE
to_geotiff_rdd Will Now Produce GeoTiffs that Can Be Used as COGs

### DIFF
--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TileLayer.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/TileLayer.scala
@@ -43,6 +43,8 @@ abstract class TileLayer[K: ClassTag] {
 
   def toGeoTiffRDD(
     storageMethod: StorageMethod,
+    resampleString: String,
+    decimations: java.util.ArrayList[Int],
     compression: String,
     colorSpace: Int,
     headTags: java.util.Map[String, String],
@@ -52,20 +54,29 @@ abstract class TileLayer[K: ClassTag] {
       if (headTags.isEmpty || bandTags.isEmpty)
         Tags.empty
       else
-        Tags(headTags.asScala.toMap,
-          bandTags.toArray.map(_.asInstanceOf[scala.collection.immutable.Map[String, String]]).toList)
+        Tags(
+          headTags.asScala.toMap,
+          bandTags
+            .toArray
+            .map(_.asInstanceOf[scala.collection.immutable.Map[String, String]])
+            .toList
+          )
 
-    val options = GeoTiffOptions(
-      storageMethod,
-      TileLayer.getCompression(compression),
-      colorSpace,
-      None)
+    val options =
+      GeoTiffOptions(
+        storageMethod,
+        TileLayer.getCompression(compression),
+        colorSpace,
+        None
+      )
 
-    toGeoTiffRDD(tags, options)
+    toGeoTiffRDD(tags, TileLayer.getResampleMethod(resampleString), decimations.asScala.toList, options)
   }
 
   def toGeoTiffRDD(
     storageMethod: StorageMethod,
+    resampleString: String,
+    decimations: java.util.ArrayList[Int],
     compression: String,
     colorSpace: Int,
     colorMap: ColorMap,
@@ -76,19 +87,31 @@ abstract class TileLayer[K: ClassTag] {
       if (headTags.isEmpty || bandTags.isEmpty)
         Tags.empty
       else
-        Tags(headTags.asScala.toMap,
-          bandTags.toArray.map(_.asInstanceOf[scala.collection.immutable.Map[String, String]]).toList)
+        Tags(
+          headTags.asScala.toMap,
+          bandTags
+            .toArray
+            .map(_.asInstanceOf[scala.collection.immutable.Map[String, String]])
+            .toList
+          )
 
-    val options = GeoTiffOptions(
-      storageMethod,
-      TileLayer.getCompression(compression),
-      colorSpace,
-      Some(IndexedColorMap.fromColorMap(colorMap)))
+    val options =
+      GeoTiffOptions(
+        storageMethod,
+        TileLayer.getCompression(compression),
+        colorSpace,
+        Some(IndexedColorMap.fromColorMap(colorMap))
+      )
 
-    toGeoTiffRDD(tags, options)
+    toGeoTiffRDD(tags, TileLayer.getResampleMethod(resampleString), decimations.asScala.toList, options)
   }
 
-  def toGeoTiffRDD(tags: Tags, geotiffOptions: GeoTiffOptions): JavaRDD[Array[Byte]]
+  def toGeoTiffRDD(
+    tags: Tags,
+    resampleMethod: ResampleMethod,
+    decimations: List[Int],
+    geoTiffOptions: GeoTiffOptions
+  ): JavaRDD[Array[Byte]]
 
   def reclassify(
     intMap: java.util.Map[Int, Int],


### PR DESCRIPTION
This PR improves the `to_geotiff_rdd` method so that the GeoTiffs produced can be used as COGs. In order to achieve this, two changes were made. The first was to change the default `storage_method` from `STRIPED` to `TILED`. The other change was the addition of two new parameters to `to_geotiff_rdd`: `resample_method` and `decimations`. These two parameters are used to create the internal overviews of the outputted GeoTiffs.

*Note:* This PR may break any preexisting code that uses the `to_geotiff_rdd` method, as it changes the order of the arguments to that method.