### PR TITLE
Jar Names With Shas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,6 @@ script:
 
 before_deploy:
   - export GEOPYSPARK_VERSION_SUFFIX="-${TRAVIS_COMMIT:0:7}"
-  - aws s3 rm s3://geopyspark-dependency-jars/geotrellis-backend-assembly-0.4.2.jar
 
 deploy:
   - provider: script

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-aws s3 cp geopyspark/jars/geotrellis-backend-assembly-*.jar s3://geopyspark-dependency-jars/ \
+aws s3 cp geopyspark/jars/geotrellis-backend-assembly-*.jar s3://geopyspark-dependency-jars/ --acl public-read \
   && cd geopyspark-backend \
   && ./sbt -Dbintray.user=$BINTRAY_USER -Dbintray.pass=$BINTRAY_PASS "project geotrellis-backend" publish \
   && ./sbt -Dbintray.user=$BINTRAY_USER -Dbintray.pass=$BINTRAY_PASS "project vectorpipe" publish \

--- a/geopyspark-backend/build.sbt
+++ b/geopyspark-backend/build.sbt
@@ -1,6 +1,5 @@
-
 lazy val commonSettings = Seq(
-  version := Version.geopyspark + scala.util.Properties.envOrElse("GEOPYSPARK_VERSION_SUFFIX", ""),
+  version := Version.geopyspark,
   scalaVersion := Version.scala,
   description := "GeoPySpark",
   organization := "org.locationtech.geotrellis",

--- a/geopyspark-backend/project/Environment.scala
+++ b/geopyspark-backend/project/Environment.scala
@@ -1,0 +1,5 @@
+import scala.util.Properties
+
+object Environment {
+  lazy val sha: Option[String] = Properties.envOrNone("GEOPYSPARK_VERSION_SUFFIX")
+}

--- a/geopyspark-backend/project/Version.scala
+++ b/geopyspark-backend/project/Version.scala
@@ -1,6 +1,6 @@
 object Version {
-  val geopyspark = "0.4.2"
+  val geopyspark = Environment.sha.getOrElse("0.4.2")
   val geotrellis = "2.1.0"
-  val scala       = "2.11.11"
-  val scalaTest   = "2.2.0"
+  val scala      = "2.11.11"
+  val scalaTest  = "2.2.0"
 }


### PR DESCRIPTION
This PR changes the naming of the jars uploaded to S3 via Travis. Now, the sha of last commit will be included in the jar name unless it's a tagged release. In that case, the version number will be used instead.