### PR TITLE
Fixed Version Naming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ script:
     fi
 
 before_deploy:
-  - export GEOPYSPARK_VERSION_SUFFIX="-${TRAVIS_COMMIT:0:7}"
+  - export GEOPYSPARK_VERSION_SUFFIX="${TRAVIS_COMMIT:0:7}"
 
 deploy:
   - provider: script


### PR DESCRIPTION
This PR removes the extra `-` from the version name before it gets deployed. This is required as keeping it in prevents the release from happening https://travis-ci.org/locationtech-labs/geopyspark/jobs/449363550#L6391