### PR TITLE
Read Multiplex Band Support

### DIFF
--- a/docs/guides/core-concepts.rst
+++ b/docs/guides/core-concepts.rst
@@ -301,3 +301,58 @@ intersects it. The higher the ``zindex``, the more priority it has.
 
   # Will always be selected
   feature3 = gps.Feature(geometry=geom3, properties=cell_value3)
+
+SourceInfo
+-----------
+
+:class:`~geopyspark.geotrellis.SourceInfo` represents a data source and the
+information on how that data should be read in.
+
+Reading from Singleband Data Sources
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For example, suppose that one wants to calculate NDVI for an area, and the bands that
+represent the red and near infrared (NIR) values are in two seperate files: ``red_band.tiff``
+and ``nir_band.tiff``, respectively. To read in these files as a single ``Tile`` (ie. a
+``Tile`` with two bands), we can specify our ``SourceInfo``\s as:
+
+.. code:: python3
+
+  source_1 = gps.SourceInfo("/tmp/red_band.tiff", {0: 0})
+  source_2 = gps.SourceInfo("/tmp/nir_band.tiff" {0: 1})
+
+
+``source_1`` states that ``Tile``\s created from ``red_band.tiff`` will use the
+data from band ``0`` of the source for its band ``0``. Whereas ``Tile``\s created
+from ``source_2`` will have the band ``0`` of the source be band ``1`` of the
+``Tile``. Thus, when ``red_band.tiff`` and ``nir_band.tiff`` intersect the
+same area, the resulting ``Tile``\(s) will have two bands: ``0`` from ``red_band.tiff``
+and ``1`` from ``nir_band.tiff``.
+
+Reading from Multiband Data Sources
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is also possible to read in individual bands from a multiband data source.
+Continuing the example above, suppose one wants to calculate NDVI using
+Landsat 8 data where each file contains all eleven bands. In this case,
+only the red band (band ``3``) and the NIR band (band ``4``) are of interest.
+We can read in just those bands by doing:
+
+.. code:: python3
+
+  source = gps.SourceInfo("/tmp/all-landsat-bands.tiff", {3: 0, 4: 1})
+
+The above source will have just bands ``3`` and ``4`` read in, and the resulting
+``Tile``\s will just have two bands: the first from ``3`` and the second from
+``4``, respectively.
+
+A Note on Missing Data
+~~~~~~~~~~~~~~~~~~~~~~~
+
+In the event that data of a specified band does not exist in a region, the
+resulting ``Tile``\(s) of that area will have that band be composed of ``NoData``
+values.
+
+So if the ``nir_band.tiff`` covers a smaller area than the ``red_band.tiff``,
+the ``Tile``\(s) of those uncovered regions will have their band ``1`` be
+just ``NoData`` values.

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/vlm/RasterSource.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/vlm/RasterSource.scala
@@ -234,10 +234,10 @@ object RasterSource {
 
     val LayoutLevel(zoom, layout) =
       layoutType match {
-        case global: GlobalLayout =>
+        case global: GPSGlobalLayout =>
           val scheme = ZoomedLayoutScheme(rasterSummary.crs, global.tileSize)
           scheme.levelForZoom(global.zoom)
-        case local: LocalLayout =>
+        case local: GPSLocalLayout =>
           val scheme = FloatingLayoutScheme(local.tileCols, local.tileRows)
           rasterSummary.levelFor(scheme)
       }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/vlm/RasterSource.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/vlm/RasterSource.scala
@@ -48,7 +48,6 @@ object RasterSource {
     rdd: RDD[String],
     targetCRS: String,
     resampleMethod: ResampleMethod,
-    partitionStrategy: PartitionStrategy,
     readMethod: String
   ): ProjectedRasterLayer = {
     val rasterSourceRDD: RDD[RasterSource] =
@@ -84,7 +83,6 @@ object RasterSource {
     paths: java.util.ArrayList[java.util.HashMap[String, String]],
     targetCRS: String,
     resampleMethod: ResampleMethod,
-    partitionStrategy: PartitionStrategy,
     readMethod: String
   ): ProjectedRasterLayer = {
     val scalaPaths: Seq[Seq[(String, String)]] = paths.asScala.toSeq.map { _.asScala.toSeq }
@@ -95,7 +93,6 @@ object RasterSource {
       sc.parallelize(scalaPaths, scalaPaths.size),
       targetCRS,
       resampleMethod,
-      partitionStrategy,
       readMethod
     )
   }
@@ -106,7 +103,6 @@ object RasterSource {
     rdd: RDD[Seq[(String, String)]],
     targetCRS: String,
     resampleMethod: ResampleMethod,
-    partitionStrategy: PartitionStrategy,
     readMethod: String
   ): ProjectedRasterLayer = {
     val rasterSourcesRDD: RDD[Seq[(String, RasterSource)]] =
@@ -167,7 +163,7 @@ object RasterSource {
     sc: SparkContext,
     layerType: String,
     paths: java.util.ArrayList[java.util.HashMap[String, String]],
-    layoutType: LayoutType,
+    layoutType: GPSLayoutType,
     targetCRS: String,
     resampleMethod: ResampleMethod,
     readMethod: String
@@ -181,7 +177,6 @@ object RasterSource {
       layoutType,
       targetCRS,
       resampleMethod,
-      partitionStrategy,
       readMethod
     )
   }
@@ -193,7 +188,6 @@ object RasterSource {
     layoutType: LayoutType,
     targetCRS: String,
     resampleMethod: ResampleMethod,
-    partitionStrategy: PartitionStrategy,
     readMethod: String
   ): SpatialTiledRasterLayer = {
     val rasterSourcesRDD: RDD[Seq[(String, RasterSource)]] =
@@ -269,7 +263,7 @@ object RasterSource {
 
         val groupedTiles: Map[SpatialKey, MultibandTile] =
           groupedValues.map { case (k, vs) =>
-            (k, MultibandTile(vs.map { _._2.band(0) }))
+            (k, MultibandTile(vs.flatMap { _._2.bands }))
           }
 
         groupedTiles.toSeq

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/vlm/RasterSource.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/vlm/RasterSource.scala
@@ -34,6 +34,8 @@ object RasterSource {
     resampleMethod: ResampleMethod,
     readMethod: String
   ): ProjectedRasterLayer = {
+    val scalaPaths: Seq[Seq[(String, String)]] = paths.asScala.toSeq.map { _.asScala.toSeq }
+
     val partitions =
       numPartitions match {
         case i: Integer => Some(i.toInt)
@@ -43,7 +45,7 @@ object RasterSource {
     read(
       sc,
       layerType,
-      sc.parallelize(paths.asScala, partitions.getOrElse(sc.defaultParallelism)),
+      sc.parallelize(scalaPaths, partitions.getOrElse(scalaPaths.size)),
       targetCRS,
       resampleMethod,
       readMethod
@@ -198,6 +200,8 @@ object RasterSource {
     resampleMethod: ResampleMethod,
     readMethod: String
   ): SpatialTiledRasterLayer = {
+    val scalaPaths: Seq[Seq[(String, String)]] = paths.asScala.toSeq.map { _.asScala.toSeq }
+
     val partitions =
       numPartitions match {
         case i: Integer => Some(i.toInt)
@@ -207,7 +211,7 @@ object RasterSource {
     readToLayout(
       sc,
       layerType,
-      sc.parallelize(paths.asScala, partitions.getOrElse(sc.defaultParallelism)),
+      sc.parallelize(scalaPaths, partitions.getOrElse(scalaPaths.size)),
       layoutType,
       targetCRS,
       resampleMethod,

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/vlm/RasterSource.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/vlm/RasterSource.scala
@@ -81,7 +81,7 @@ object RasterSource {
   def readOrdered(
     sc: SparkContext,
     layerType: String,
-    paths: java.util.ArrayList[java.util.Map[String, String]],
+    paths: java.util.ArrayList[java.util.HashMap[String, String]],
     targetCRS: String,
     resampleMethod: ResampleMethod,
     partitionStrategy: PartitionStrategy,
@@ -166,7 +166,7 @@ object RasterSource {
   def readOrderedToLayout(
     sc: SparkContext,
     layerType: String,
-    paths: java.util.ArrayList[java.util.Map[String, String]],
+    paths: java.util.ArrayList[java.util.HashMap[String, String]],
     layoutType: LayoutType,
     targetCRS: String,
     resampleMethod: ResampleMethod,

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/vlm/RasterSource.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/vlm/RasterSource.scala
@@ -21,7 +21,6 @@ import org.apache.spark.{SparkContext, Partitioner}
 import org.apache.spark.rdd.RDD
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable.ArrayBuffer
 
 
 object RasterSource {
@@ -85,110 +84,6 @@ object RasterSource {
     rasterSourceRDD.unpersist()
 
     ProjectedRasterLayer(projectedRasterRDD)
-  }
-
-  def readOrdered(
-    sc: SparkContext,
-    layerType: String,
-    paths: java.util.ArrayList[String],
-    maxTileSize: Int,
-    targetCRS: String,
-    numPartitions: Integer,
-    resampleMethod: ResampleMethod,
-    readMethod: String
-  ): ProjectedRasterLayer = {
-    val scalaPaths: Seq[Seq[(String, String)]] = ??? ///paths.asScala.toSeq.map { ReadingInfo( }
-
-    val partitions =
-      numPartitions match {
-        case i: Integer => Some(i.toInt)
-        case null => None
-      }
-
-    readOrdered(
-      sc,
-      layerType,
-      sc.parallelize(scalaPaths, partitions.getOrElse(scalaPaths.size)),
-      targetCRS,
-      partitions,
-      resampleMethod,
-      readMethod
-    )
-  }
-
-  def readOrdered(
-    sc: SparkContext,
-    layerType: String,
-    rdd: RDD[Seq[(String, String)]],
-    targetCRS: String,
-    numPartitions: Option[Int],
-    resampleMethod: ResampleMethod,
-    readMethod: String
-  ): ProjectedRasterLayer = {
-    val rasterSourcesRDD: RDD[Seq[(String, RasterSource)]] =
-      (readMethod match {
-        case GEOTRELLIS =>
-          rdd.mapPartitions { iter =>
-            iter.map { files: Seq[(String, String)] =>
-              files.map { case (k, v) => (k, new GeoTiffRasterSource(v): RasterSource)
-              }
-            }
-          }
-        case GDAL =>
-          rdd.mapPartitions { iter =>
-            iter.map { files: Seq[(String, String)] =>
-              files.map { case (k, v) => (k, GDALRasterSource(v): RasterSource)
-              }
-            }
-          }
-      }).cache()
-
-    val reprojectedSourcesRDD: RDD[(String, RasterSource)] =
-      targetCRS match {
-        case crs: String =>
-          rasterSourcesRDD.flatMap { case sources =>
-            sources.map { case (index, source) =>
-              (index, source.reproject(CRS.fromString(crs), resampleMethod))
-            }
-          }
-        case null => rasterSourcesRDD.flatMap { sources => sources }
-      }
-
-    val rasterSummary: RasterSummary =
-      reprojectedSourcesRDD
-        .map { case (_, source) =>
-            val ProjectedExtent(extent, crs) = source.getComponent[ProjectedExtent]
-            val cellSize = CellSize(extent, source.cols, source.rows)
-            RasterSummary(crs, source.cellType, cellSize, extent, source.size, 1)
-          }.reduce { _ combine _ }
-
-    val keyedSourcesRDD: RDD[(Extent, (String, RasterSource))] =
-      reprojectedSourcesRDD.map { case (index, source) =>
-        (source.extent, (index, source))
-      }
-
-    val groupedSourcesRDD: RDD[(Extent, Iterable[(String, RasterSource)])] =
-      keyedSourcesRDD.groupByKey(numPartitions.getOrElse(rasterSummary.estimatePartitionsNumber))
-
-    val projectedRDD: RDD[(ProjectedExtent, MultibandTile)] =
-      groupedSourcesRDD.map { case (ex, iter) =>
-        val sorted = iter.toSeq.sortBy { _._1 }
-        val crs = sorted.head._2.crs
-
-        val tiles: Seq[MultibandTile] =
-          sorted.flatMap { case (_, source) =>
-            source.read(source.extent) match {
-              case Some(raster) => Some(raster.tile)
-              case None => None
-            }
-          }
-
-        (ProjectedExtent(ex, crs), MultibandTile(tiles.map { _.band(0) }))
-      }
-
-    rasterSourcesRDD.unpersist()
-
-    ProjectedRasterLayer(projectedRDD)
   }
 
   def readToLayout(

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/vlm/RasterSource.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/vlm/RasterSource.scala
@@ -90,13 +90,14 @@ object RasterSource {
   def readOrdered(
     sc: SparkContext,
     layerType: String,
-    paths: java.util.ArrayList[java.util.HashMap[String, String]],
+    paths: java.util.ArrayList[String],
+    maxTileSize: Int,
     targetCRS: String,
     numPartitions: Integer,
     resampleMethod: ResampleMethod,
     readMethod: String
   ): ProjectedRasterLayer = {
-    val scalaPaths: Seq[Seq[(String, String)]] = paths.asScala.toSeq.map { _.asScala.toSeq }
+    val scalaPaths: Seq[Seq[(String, String)]] = ??? ///paths.asScala.toSeq.map { ReadingInfo( }
 
     val partitions =
       numPartitions match {

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/vlm/RasterSource.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/vlm/RasterSource.scala
@@ -249,7 +249,7 @@ object RasterSource {
         source.copy(source = resampledSource)
       }
 
-    val result = RasterSourceRDD.readFromRDD(resampledSourcesRDD, layout, partitioner)(sc)
+    val result = RasterSourceRDD.read(resampledSourcesRDD, layout, partitioner)(sc)
 
     SpatialTiledRasterLayer(zoom, result)
   }

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/vlm/RasterSource.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/vlm/RasterSource.scala
@@ -1,7 +1,7 @@
 package geopyspark.geotrellis.vlm
 
-import geopyspark.geotrellis.{PartitionStrategy, ProjectedRasterLayer, SpatialTiledRasterLayer}
-import geopyspark.geotrellis.{LayoutType => GPSLayoutType, LocalLayout => GPSLocalLayout, GlobalLayout => GPSGlobalLayout, SpatialTiledRasterLayer}
+import geopyspark.geotrellis.{PartitionStrategy, ProjectedRasterLayer, SpatialTiledRasterLayer, SpatialPartitioner}
+import geopyspark.geotrellis.{LayoutType => GPSLayoutType, LocalLayout => GPSLocalLayout, GlobalLayout => GPSGlobalLayout}
 
 import geopyspark.geotrellis.Constants.{GEOTRELLIS, GDAL}
 
@@ -262,22 +262,15 @@ object RasterSource {
     paths: java.util.ArrayList[java.util.HashMap[String, String]],
     layoutType: GPSLayoutType,
     targetCRS: String,
-    numPartitions: Integer,
     resampleMethod: ResampleMethod,
     readMethod: String
   ): SpatialTiledRasterLayer = {
     val scalaPaths: Seq[Seq[(String, String)]] = paths.asScala.toSeq.map { _.asScala.toSeq }
 
-    val partitions =
-      numPartitions match {
-        case i: Integer => Some(i.toInt)
-        case null => None
-      }
-
     readOrderedToLayout(
       sc,
       layerType,
-      sc.parallelize(scalaPaths, partitions.getOrElse(sc.defaultParallelism)),
+      sc.parallelize(scalaPaths, scalaPaths.size),
       layoutType,
       targetCRS,
       resampleMethod,
@@ -312,32 +305,24 @@ object RasterSource {
           }
       }).cache()
 
-    val orderedRasterSourcesRDD: RDD[Seq[RasterSource]] =
-      rasterSourcesRDD.map { keyedSource: Seq[(String, RasterSource)] =>
-        keyedSource.sortBy { _._1 }.map { case (_, source) => source }
-      }
-
-    val reprojectedSourcesRDD: RDD[Seq[RasterSource]] =
+    val reprojectedSourcesRDD: RDD[(String, RasterSource)] =
       targetCRS match {
         case crs: String =>
-          orderedRasterSourcesRDD.map {
-            _.map { _.reproject(CRS.fromString(crs), resampleMethod) }
+          rasterSourcesRDD.flatMap { case sources =>
+            sources.map { case (index, source) =>
+              (index, source.reproject(CRS.fromString(crs), resampleMethod))
+            }
           }
-        case null =>
-          orderedRasterSourcesRDD
+        case null => rasterSourcesRDD.flatMap { sources => sources }
       }
 
     val rasterSummary: RasterSummary =
       reprojectedSourcesRDD
-        .map { sources: Seq[RasterSource] =>
-          sources
-            .map { source =>
-              val ProjectedExtent(extent, crs) = source.getComponent[ProjectedExtent]
-              val cellSize = CellSize(extent, source.cols, source.rows)
-              RasterSummary(crs, source.cellType, cellSize, extent, source.size, 1)
-            }.reduce { _ combine _ }
-        }
-        .reduce { _ combine _ }
+        .map { case (_, source) =>
+            val ProjectedExtent(extent, crs) = source.getComponent[ProjectedExtent]
+            val cellSize = CellSize(extent, source.cols, source.rows)
+            RasterSummary(crs, source.cellType, cellSize, extent, source.size, 1)
+          }.reduce { _ combine _ }
 
     val LayoutLevel(zoom, layout) =
       layoutType match {
@@ -352,25 +337,24 @@ object RasterSource {
     val tileLayerMetadata: TileLayerMetadata[SpatialKey] =
       rasterSummary.toTileLayerMetadata(layout, zoom)._1
 
-    val layoutsRDD: RDD[Seq[LayoutTileSource]] =
-      reprojectedSourcesRDD.map { _.map { _.tileToLayout(layout, resampleMethod) } }
+    val layoutsRDD: RDD[(String, LayoutTileSource)] =
+      reprojectedSourcesRDD.mapValues { _.tileToLayout(layout, resampleMethod) }
 
-    val readInSourcesRDD: RDD[Seq[(SpatialKey, MultibandTile)]] =
-      layoutsRDD.map { layouts: Seq[LayoutTileSource] =>
-        layouts.flatMap { _.readAll() }
+    val rasterRegionRDD: RDD[(SpatialKey, (String, RasterRegion))] =
+      layoutsRDD.flatMap { case (index, source) =>
+        source.keyedRasterRegions().map { case (key, region) =>
+          (key, (index, region))
+        }
       }
 
+    val groupedRDD: RDD[(SpatialKey, Iterable[(String, RasterRegion)])] =
+      rasterRegionRDD.groupByKey(SpatialPartitioner(rasterSummary.estimatePartitionsNumber))
+
     val tiledRDD: RDD[(SpatialKey, MultibandTile)] =
-      readInSourcesRDD.flatMap { values: Seq[(SpatialKey, MultibandTile)] =>
-        val groupedValues: Map[SpatialKey, Seq[(SpatialKey, MultibandTile)]] =
-          values.groupBy { _._1 }
+      groupedRDD.mapValues { iter =>
+        val sorted = iter.toSeq.sortBy { _._1 }
 
-        val groupedTiles: Map[SpatialKey, MultibandTile] =
-          groupedValues.map { case (k, vs) =>
-            (k, MultibandTile(vs.flatMap { _._2.bands }))
-          }
-
-        groupedTiles.toSeq
+        MultibandTile(sorted.flatMap { case (_, ref) => ref.raster.toSeq.flatMap { _.tile.bands } })
       }
 
     rasterSourcesRDD.unpersist()

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/vlm/RasterSource.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/vlm/RasterSource.scala
@@ -34,7 +34,7 @@ object RasterSource {
     resampleMethod: ResampleMethod,
     readMethod: String
   ): ProjectedRasterLayer = {
-    val scalaPaths: Seq[Seq[(String, String)]] = paths.asScala.toSeq.map { _.asScala.toSeq }
+    val scalaPaths: Seq[String] = paths.asScala.toSeq
 
     val partitions =
       numPartitions match {
@@ -200,7 +200,7 @@ object RasterSource {
     resampleMethod: ResampleMethod,
     readMethod: String
   ): SpatialTiledRasterLayer = {
-    val scalaPaths: Seq[Seq[(String, String)]] = paths.asScala.toSeq.map { _.asScala.toSeq }
+    val scalaPaths: Seq[String] = paths.asScala.toSeq
 
     val partitions =
       numPartitions match {

--- a/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/vlm/SourceInfo.scala
+++ b/geopyspark-backend/geotrellis/src/main/scala/geopyspark/geotrellis/vlm/SourceInfo.scala
@@ -1,0 +1,21 @@
+package geopyspark.geotrellis.vlm
+
+import scala.collection.JavaConverters._
+
+
+case class SourceInfo(
+  source: String,
+  sourceToTargetBand: Map[Int, Int]
+) extends Serializable
+
+
+object SourceInfo {
+  def apply(source: String, sourceBand: Int, targetBand: Int): SourceInfo =
+    SourceInfo(source, Map(sourceBand -> targetBand))
+
+  def apply(source: String, targetBand: Int): SourceInfo =
+    SourceInfo(source, 0, targetBand)
+
+  def apply(source: String, javaMap: java.util.HashMap[Int, Int]): SourceInfo =
+    SourceInfo(source, javaMap.asScala.toMap)
+}

--- a/geopyspark-backend/project/plugins.sbt
+++ b/geopyspark-backend/project/plugins.sbt
@@ -4,6 +4,7 @@ resolvers ++= Seq(
 )
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
+
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.2")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M10")

--- a/geopyspark-backend/project/protoc.sbt
+++ b/geopyspark-backend/project/protoc.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.15")
+
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.0"

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -839,7 +839,7 @@ class Metadata(object):
 __all__ = ["Tile", "Extent", "ProjectedExtent", "TemporalProjectedExtent", "SpatialKey", "SpaceTimeKey",
            "Metadata", "TileLayout", "GlobalLayout", "LocalLayout", "LayoutDefinition", "Bounds", "RasterizerOptions",
            "zfactor_lat_lng_calculator", "zfactor_calculator", "HashPartitionStrategy", "SpatialPartitionStrategy",
-           "SpaceTimePartitionStrategy", "Feature", "CellValue"]
+           "SpaceTimePartitionStrategy", "Feature", "CellValue", "SourceInfo"]
 
 from . import catalog
 from . import color

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -647,6 +647,28 @@ class SpaceTimePartitionStrategy(namedtuple("SpaceTimePartitionStrategy", "time_
 
 
 class SourceInfo(namedtuple("SourceInfo", "source source_to_target_band")):
+    """Represents a data source and how its bands should be formatted when being read
+    in.
+
+    When two or more sources of data cover the same area, a single ``Tile`` will be created
+    that contains the bands specified by ``source_to_target_band``.
+
+    Args:
+        source (str): The path to the data source to be read.
+        source_to_target_band ({int: int}): A ``{int: int}`` that maps each band from the
+            source to the target band of the output.
+
+            For example, ``{0: 2}`` specifies that band ``0`` of the source be band ``2``
+            for the ``Tile``\s that were created from that source.
+    Attributes:
+        source (str): The path to the data source to be read.
+        source_to_target_band ({int: int}): A ``{int: int}`` that maps each band from the
+            source to the target band of the output.
+
+            For example, ``{0: 2}`` specifies that band ``0`` of the source be band ``2``
+            for the ``Tile``\s that were created from that source.
+
+    """
 
     __slots__ = []
 

--- a/geopyspark/geotrellis/__init__.py
+++ b/geopyspark/geotrellis/__init__.py
@@ -646,6 +646,11 @@ class SpaceTimePartitionStrategy(namedtuple("SpaceTimePartitionStrategy", "time_
         return super(cls, SpaceTimePartitionStrategy).__new__(cls, time_unit, num_partitions, bits, time_resolution)
 
 
+class SourceInfo(namedtuple("SourceInfo", "source source_to_target_band")):
+
+    __slots__ = []
+
+
 class Feature(namedtuple("Feature", "geometry properties")):
     """Represents a geometry that is derived from an OSM Element with that Element's associated metadata.
 

--- a/geopyspark/geotrellis/converters.py
+++ b/geopyspark/geotrellis/converters.py
@@ -148,6 +148,16 @@ class SpaceTimePartitionStrategyConverter:
         return ScalaTemporalStrategy.apply(obj.num_partitions, obj.bits, scala_time_unit, scala_time_resolution)
 
 
+class SourceInfoConverter(object):
+    def can_convert(self, object):
+        return isinstance(object, SourceInfo)
+
+    def convert(self, obj, gateway_client):
+        ScalaSourceInfo = JavaClass("geopyspark.geotrellis.vlm.SourceInfo", gateway_client)
+
+        return ScalaSourceInfo.apply(obj.source, obj.source_to_target_band)
+
+
 register_input_converter(CellTypeConverter(), prepend=True)
 register_input_converter(RasterizerOptionsConverter(), prepend=True)
 register_input_converter(LayoutTypeConverter(), prepend=True)
@@ -156,3 +166,4 @@ register_input_converter(LayoutDefinitionConverter(), prepend=True)
 register_input_converter(HashPartitionStrategyConverter(), prepend=True)
 register_input_converter(SpatialPartitionStrategyConverter(), prepend=True)
 register_input_converter(SpaceTimePartitionStrategyConverter(), prepend=True)
+register_input_converter(SourceInfoConverter(), prepend=True)

--- a/geopyspark/geotrellis/converters.py
+++ b/geopyspark/geotrellis/converters.py
@@ -9,7 +9,8 @@ from geopyspark.geotrellis import (RasterizerOptions,
                                    LayoutDefinition,
                                    HashPartitionStrategy,
                                    SpatialPartitionStrategy,
-                                   SpaceTimePartitionStrategy)
+                                   SpaceTimePartitionStrategy,
+                                   SourceInfo)
 
 
 from geopyspark.geotrellis.constants import ResampleMethod

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -475,6 +475,7 @@ class RasterLayer(CachableLayer, TileLayer):
                                             layer_type.value,
                                             paths,
                                             target_crs,
+                                            num_partitions,
                                             resample_method,
                                             read_method.value)
         else:
@@ -1179,6 +1180,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
                                                     paths,
                                                     layout_type,
                                                     target_crs,
+                                                    num_partitions,
                                                     resample_method,
                                                     read_method.value)
 

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -462,7 +462,6 @@ class RasterLayer(CachableLayer, TileLayer):
                                             paths,
                                             target_crs,
                                             resample_method,
-                                            partition_strategy,
                                             read_method.value)
         else:
             srdd = rastersource.read(pysc._jsc.sc(),
@@ -1152,7 +1151,6 @@ class TiledRasterLayer(CachableLayer, TileLayer):
                                                     layout_type,
                                                     target_crs,
                                                     resample_method,
-                                                    partition_strategy,
                                                     read_method.value)
 
         else:

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -458,7 +458,7 @@ class RasterLayer(CachableLayer, TileLayer):
 
         rastersource = pysc._gateway.jvm.geopyspark.geotrellis.vlm.RasterSource
 
-        if isinstance(paths, str)):
+        if isinstance(paths, str):
             paths = [paths]
 
         srdd = rastersource.read(pysc._jsc.sc(),
@@ -1089,7 +1089,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
              target_crs=None,
              num_partitions=None,
              resample_method=ResampleMethod.NEAREST_NEIGHBOR,
-             partition_strategy=None
+             partition_strategy=None,
              read_method=ReadMethod.GEOTRELLIS):
         """Creates a TiledRasterLayer from a list of data sources.
 

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -413,18 +413,8 @@ class RasterLayer(CachableLayer, TileLayer):
             supported.
 
         Args:
-            paths (str or [str] or {str: str} or [{str: str}]): The geo-spatial data
-                to be read. There are two different formats the paths can be
-                in: either alone or in a ``dict``.
-
-                If passed in as just ``str``\s, then each resulting path will
-                have its own associated ``Tile``\(s) in the layer.
-
-                ``dict``\s passed in need to be formatted as: ``{bandNumber: path}`` where
-                both ``bandNumber`` and ``path`` are ``str``s. For each ``dict``,
-                the data will be read in and combined to form a Multiband reprsentation
-                of the data. With the ordering of the bands determined by their respective
-                ``bandNumber``.
+            paths (str or [str]): The geo-spatial data to be read. Each path
+                will have its own associated ``Tile``\s in the resulting layer.
             layer_type (str or :class:`~geopyspark.geotrellis.constants.LayerType`, optional): What the layer type
                 of the geotiffs are. This is represented by either constants within ``LayerType`` or by
                 a string.
@@ -467,25 +457,16 @@ class RasterLayer(CachableLayer, TileLayer):
 
         rastersource = pysc._gateway.jvm.geopyspark.geotrellis.vlm.RasterSource
 
-        if isinstance(paths, (str, dict)):
+        if isinstance(paths, str)):
             paths = [paths]
 
-        if isinstance(paths[0], dict):
-            srdd = rastersource.readOrdered(pysc._jsc.sc(),
-                                            layer_type.value,
-                                            paths,
-                                            target_crs,
-                                            num_partitions,
-                                            resample_method,
-                                            read_method.value)
-        else:
-            srdd = rastersource.read(pysc._jsc.sc(),
-                                     layer_type.value,
-                                     paths,
-                                     target_crs,
-                                     num_partitions,
-                                     resample_method,
-                                     read_method.value)
+        srdd = rastersource.read(pysc._jsc.sc(),
+                                 layer_type.value,
+                                 paths,
+                                 target_crs,
+                                 num_partitions,
+                                 resample_method,
+                                 read_method.value)
 
         return cls(layer_type, srdd)
 

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -403,6 +403,7 @@ class RasterLayer(CachableLayer, TileLayer):
              paths,
              layer_type=LayerType.SPATIAL,
              target_crs=None,
+             num_partitions=None,
              resample_method=ResampleMethod.NEAREST_NEIGHBOR,
              read_method=ReadMethod.GEOTRELLIS):
         """Creates a RasterLayer from a list of data sources.
@@ -423,6 +424,9 @@ class RasterLayer(CachableLayer, TileLayer):
             target_crs (str or int, optional): The CRS that the output tiles should be
                 in. If ``None``, then the CRS that the tiles were originally in
                 will be used.
+            num_partitions (int, optional): The number of partitions Spark
+                will make when the data is repartitioned. If ``None``, then the
+                data will be partitioned using the default number of partitions.
             resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
                 The resample method to use when building internal overviews. Default is,
                 ``ResampleMethods.NEAREST_NEIGHBOR``.
@@ -453,14 +457,15 @@ class RasterLayer(CachableLayer, TileLayer):
 
         rastersource = pysc._gateway.jvm.geopyspark.geotrellis.vlm.RasterSource
 
-        if isinstance(paths, str):
+        if isinstance(paths, (str, dict)):
             paths = [paths]
 
-        if isinstance(paths, dict) or (isinstance(paths, list) and isinstance(paths[0], dict)):
+        if isinstance(paths[0], dict):
             srdd = rastersource.readOrdered(pysc._jsc.sc(),
                                             layer_type.value,
                                             paths,
                                             target_crs,
+                                            num_partitions,
                                             resample_method,
                                             read_method.value)
         else:
@@ -468,6 +473,7 @@ class RasterLayer(CachableLayer, TileLayer):
                                      layer_type.value,
                                      paths,
                                      target_crs,
+                                     num_partitions,
                                      resample_method,
                                      read_method.value)
 
@@ -1089,6 +1095,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
              layout_type,
              layer_type=LayerType.SPATIAL,
              target_crs=None,
+             num_partitions=None,
              resample_method=ResampleMethod.NEAREST_NEIGHBOR,
              read_method=ReadMethod.GEOTRELLIS):
         """Creates a TiledRasterLayer from a list of data sources.
@@ -1111,6 +1118,9 @@ class TiledRasterLayer(CachableLayer, TileLayer):
             target_crs (str or int, optional): The CRS that the output tiles should be
                 in. If ``None``, then the CRS that the tiles were originally in
                 will be used.
+            num_partitions (int, optional): The number of partitions Spark
+                will make when the data is repartitioned. If ``None``, then the
+                data will be partitioned using the default number of partitions.
             resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
                 The resample method to use when building internal overviews. Default is,
                 ``ResampleMethods.NEAREST_NEIGHBOR``.
@@ -1139,17 +1149,18 @@ class TiledRasterLayer(CachableLayer, TileLayer):
 
         pysc = get_spark_context()
 
-        if isinstance(paths, str):
+        if isinstance(paths, (str, dict)):
             paths = [paths]
 
         rastersource = pysc._gateway.jvm.geopyspark.geotrellis.vlm.RasterSource
 
-        if isinstance(paths, dict) or (isinstance(paths, list) and isinstance(paths[0], dict)):
+        if isinstance(paths[0], dict):
             srdd = rastersource.readOrderedToLayout(pysc._jsc.sc(),
                                                     layer_type.value,
                                                     paths,
                                                     layout_type,
                                                     target_crs,
+                                                    num_partitions,
                                                     resample_method,
                                                     read_method.value)
 
@@ -1159,6 +1170,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
                                              paths,
                                              layout_type,
                                              target_crs,
+                                             num_partitions,
                                              resample_method,
                                              read_method.value)
 

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -34,7 +34,8 @@ from geopyspark.geotrellis import (Metadata,
                                    SpatialPartitionStrategy,
                                    SpaceTimePartitionStrategy,
                                    RasterizerOptions,
-                                   check_partition_strategy)
+                                   check_partition_strategy,
+                                   SourceInfo)
 from geopyspark.geotrellis.histogram import Histogram
 from geopyspark.geotrellis.constants import (IndexingMethod,
                                              Operation,
@@ -1088,6 +1089,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
              target_crs=None,
              num_partitions=None,
              resample_method=ResampleMethod.NEAREST_NEIGHBOR,
+             partition_strategy=None
              read_method=ReadMethod.GEOTRELLIS):
         """Creates a TiledRasterLayer from a list of data sources.
 
@@ -1096,18 +1098,16 @@ class TiledRasterLayer(CachableLayer, TileLayer):
             supported.
 
         Args:
-            paths (str or [str] or {str: str} or [{str: str}]): The geo-spatial data
-                to be read. There are two different formats the paths can be
-                in: either alone or in a ``dict``.
+            paths (str or [str] or :class:`~geopyspark.geotrellis.SourceInfo` or [:class:`~geopyspark.geotrellis.SourceInfo`]): The geo-spatial data
+                to be read. There are two different formats these paths can be
+                in: either as a ``str`` or ``SourceInfo``.
 
-                If passed in as just ``str``\s, then each resulting path will
+                If passed in as ``str``\s, then each resulting path will
                 have its own associated ``Tile``\(s) in the layer.
 
-                ``dict``\s passed in need to be formatted as: ``{bandNumber: path}`` where
-                both ``bandNumber`` and ``path`` are ``str``s. For each ``dict``,
-                the data will be read in and combined to form a Multiband reprsentation
-                of the data. With the ordering of the bands determined by their respective
-                ``bandNumber``.
+                When ``SourceInfo`` is passed in, the data will be read in and combined to
+                form a Multiband reprsentation of the data. With the ordering of the bands
+                determined by their respective target index.
             layout (:class:`~geopyspark.geotrellis.LayoutDefinition` or :class:`~geopyspark.geotrellis.Metadata` or :class:`~geopyspark.geotrellis.TiledRasterLayer` or :class:`~geopyspark.geotrellis.GlobalLayout` or :class:`~geopyspark.geotrellis.LocalLayout`):
                 Target raster layout for the tiling operation.
             layer_type (str or :class:`~geopyspark.geotrellis.constants.LayerType`, optional): What the layer type
@@ -1125,6 +1125,19 @@ class TiledRasterLayer(CachableLayer, TileLayer):
             resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
                 The resample method to use when building internal overviews. Default is,
                 ``ResampleMethods.NEAREST_NEIGHBOR``.
+            partition_strategy (:class:`~geopyspark.HashPartitionStrategy` or :class:`~geopyspark.SpatialPartitioinStrategy` or :class:`~geopyspark.SpaceTimePartitionStrategy`, optional):
+                Sets the ``Partitioner`` for the resulting layer and how many partitions it has.
+                Default is, ``None``.
+
+                If ``None``, then the output layer will be the same ``Partitioner`` and number of
+                partitions as the source layer.
+
+                If ``partition_strategy`` is set but has no ``num_partitions``, then the resulting layer
+                will have the ``Partioner`` specified in the strategy with the with same number of
+                partitions the source layer had.
+
+                If ``partition_strategy`` is set and has a ``num_partitions``, then the resulting layer
+                will have the ``Partioner`` and number of partitions specified in the strategy.
             read_method(str or :class:`~geopyspark.geotrellis.constants.ReadMethod`, optional): The method
                 that should be used to read in the data. The ``GEOTRELLIS`` method can only read GeoTiffs,
                 but is already setup. While the other method, ``GDAL`` can read other data sources, but
@@ -1142,6 +1155,9 @@ class TiledRasterLayer(CachableLayer, TileLayer):
         if layer_type == LayerType.SPACETIME:
             raise NotImplementedError("The read method does not currently support the SPACETIME LayerType")
 
+        if partition_strategy:
+            check_partition_strategy(partition_strategy, self.layer_type)
+
         resample_method = ResampleMethod(resample_method)
         read_method = ReadMethod(read_method)
 
@@ -1150,19 +1166,19 @@ class TiledRasterLayer(CachableLayer, TileLayer):
 
         pysc = get_spark_context()
 
-        if isinstance(paths, (str, dict)):
+        if isinstance(paths, (str, SourceInfo)):
             paths = [paths]
 
         rastersource = pysc._gateway.jvm.geopyspark.geotrellis.vlm.RasterSource
 
-        if isinstance(paths[0], dict):
+        if isinstance(paths[0], SourceInfo):
             srdd = rastersource.readOrderedToLayout(pysc._jsc.sc(),
-                                                    layer_type.value,
                                                     paths,
                                                     layout_type,
                                                     target_crs,
                                                     num_partitions,
                                                     resample_method,
+                                                    partition_strategy,
                                                     read_method.value)
 
         else:

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -1156,7 +1156,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
             raise NotImplementedError("The read method does not currently support the SPACETIME LayerType")
 
         if partition_strategy:
-            check_partition_strategy(partition_strategy, self.layer_type)
+            check_partition_strategy(partition_strategy, layer_type)
 
         resample_method = ResampleMethod(resample_method)
         read_method = ReadMethod(read_method)

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -475,7 +475,6 @@ class RasterLayer(CachableLayer, TileLayer):
                                             layer_type.value,
                                             paths,
                                             target_crs,
-                                            num_partitions,
                                             resample_method,
                                             read_method.value)
         else:

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -413,8 +413,18 @@ class RasterLayer(CachableLayer, TileLayer):
             supported.
 
         Args:
-            paths (str or [str]): A path or a list of paths that point to geo-spatial data.
-                These strings can be in either a URI format or a relative path.
+            paths (str or [str] or {str: str} or [{str: str}]): The geo-spatial data
+                to be read. There are two different formats the paths can be
+                in: either alone or in a ``dict``.
+
+                If passed in as just ``str``\s, then each resulting path will
+                have its own associated ``Tile``\(s) in the layer.
+
+                ``dict``\s passed in need to be formatted as: ``{bandNumber: path}`` where
+                both ``bandNumber`` and ``path`` are ``str``s. For each ``dict``,
+                the data will be read in and combined to form a Multiband reprsentation
+                of the data. With the ordering of the bands determined by their respective
+                ``bandNumber``.
             layer_type (str or :class:`~geopyspark.geotrellis.constants.LayerType`, optional): What the layer type
                 of the geotiffs are. This is represented by either constants within ``LayerType`` or by
                 a string.
@@ -1105,8 +1115,18 @@ class TiledRasterLayer(CachableLayer, TileLayer):
             supported.
 
         Args:
-            paths (str or [str]): A path or a list of paths that point to geo-spatial data.
-                These strings can be in either a URI format or a relative path.
+            paths (str or [str] or {str: str} or [{str: str}]): The geo-spatial data
+                to be read. There are two different formats the paths can be
+                in: either alone or in a ``dict``.
+
+                If passed in as just ``str``\s, then each resulting path will
+                have its own associated ``Tile``\(s) in the layer.
+
+                ``dict``\s passed in need to be formatted as: ``{bandNumber: path}`` where
+                both ``bandNumber`` and ``path`` are ``str``s. For each ``dict``,
+                the data will be read in and combined to form a Multiband reprsentation
+                of the data. With the ordering of the bands determined by their respective
+                ``bandNumber``.
             layout (:class:`~geopyspark.geotrellis.LayoutDefinition` or :class:`~geopyspark.geotrellis.Metadata` or :class:`~geopyspark.geotrellis.TiledRasterLayer` or :class:`~geopyspark.geotrellis.GlobalLayout` or :class:`~geopyspark.geotrellis.LocalLayout`):
                 Target raster layout for the tiling operation.
             layer_type (str or :class:`~geopyspark.geotrellis.constants.LayerType`, optional): What the layer type

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -1180,7 +1180,6 @@ class TiledRasterLayer(CachableLayer, TileLayer):
                                                     paths,
                                                     layout_type,
                                                     target_crs,
-                                                    num_partitions,
                                                     resample_method,
                                                     read_method.value)
 

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -436,7 +436,7 @@ class RasterLayer(CachableLayer, TileLayer):
                 will be used.
             num_partitions (int, optional): The number of partitions Spark
                 will make when the data is repartitioned. If ``None``, then the
-                data will be partitioned using the default number of partitions.
+                number of partitions will be estimated based on the input data.
             resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
                 The resample method to use when building internal overviews. Default is,
                 ``ResampleMethods.NEAREST_NEIGHBOR``.
@@ -1140,7 +1140,7 @@ class TiledRasterLayer(CachableLayer, TileLayer):
                 will be used.
             num_partitions (int, optional): The number of partitions Spark
                 will make when the data is repartitioned. If ``None``, then the
-                data will be partitioned using the default number of partitions.
+                number of partitions will be estimated based on the input data.
             resample_method (str or :class:`~geopyspark.geotrellis.constants.ResampleMethod`, optional):
                 The resample method to use when building internal overviews. Default is,
                 ``ResampleMethods.NEAREST_NEIGHBOR``.

--- a/geopyspark/geotrellis/layer.py
+++ b/geopyspark/geotrellis/layer.py
@@ -456,12 +456,21 @@ class RasterLayer(CachableLayer, TileLayer):
         if isinstance(paths, str):
             paths = [paths]
 
-        srdd = rastersource.read(pysc._jsc.sc(),
-                                 layer_type.value,
-                                 paths,
-                                 target_crs,
-                                 resample_method,
-                                 read_method.value)
+        if isinstance(paths, dict) or (isinstance(paths, list) and isinstance(paths[0], dict)):
+            srdd = rastersource.readOrdered(pysc._jsc.sc(),
+                                            layer_type.value,
+                                            paths,
+                                            target_crs,
+                                            resample_method,
+                                            partition_strategy,
+                                            read_method.value)
+        else:
+            srdd = rastersource.read(pysc._jsc.sc(),
+                                     layer_type.value,
+                                     paths,
+                                     target_crs,
+                                     resample_method,
+                                     read_method.value)
 
         return cls(layer_type, srdd)
 
@@ -1136,13 +1145,24 @@ class TiledRasterLayer(CachableLayer, TileLayer):
 
         rastersource = pysc._gateway.jvm.geopyspark.geotrellis.vlm.RasterSource
 
-        srdd = rastersource.readToLayout(pysc._jsc.sc(),
-                                         layer_type.value,
-                                         paths,
-                                         layout_type,
-                                         target_crs,
-                                         resample_method,
-                                         read_method.value)
+        if isinstance(paths, dict) or (isinstance(paths, list) and isinstance(paths[0], dict)):
+            srdd = rastersource.readOrderedToLayout(pysc._jsc.sc(),
+                                                    layer_type.value,
+                                                    paths,
+                                                    layout_type,
+                                                    target_crs,
+                                                    resample_method,
+                                                    partition_strategy,
+                                                    read_method.value)
+
+        else:
+            srdd = rastersource.readToLayout(pysc._jsc.sc(),
+                                             layer_type.value,
+                                             paths,
+                                             layout_type,
+                                             target_crs,
+                                             resample_method,
+                                             read_method.value)
 
         return cls(layer_type, srdd)
 

--- a/geopyspark/tests/geotrellis/raster_layer_test.py
+++ b/geopyspark/tests/geotrellis/raster_layer_test.py
@@ -67,9 +67,6 @@ class RasterLayerTest(BaseTestClass):
 
 
     # No reprojection
-    def test_read_ordered_no_reproject_geotrellis(self):
-        self.read_no_reproject(ReadMethod.GEOTRELLIS, multiplex=True)
-
     def test_read_no_reproject_geotrellis(self):
         self.read_no_reproject(ReadMethod.GEOTRELLIS)
 
@@ -79,9 +76,6 @@ class RasterLayerTest(BaseTestClass):
     # With reprojection
     def test_read_with_reproject_geotrellis(self):
         self.read_with_reproject(ReadMethod.GEOTRELLIS)
-
-    def test_read_ordered_with_reproject_geotrellis(self):
-        self.read_with_reproject(ReadMethod.GEOTRELLIS, multiplex=True)
 
     def test_read_with_reproject_gdal(self):
         self.read_with_reproject(ReadMethod.GDAL)

--- a/geopyspark/tests/geotrellis/raster_layer_test.py
+++ b/geopyspark/tests/geotrellis/raster_layer_test.py
@@ -39,11 +39,8 @@ class RasterLayerTest(BaseTestClass):
     layer = RasterLayer.from_numpy_rdd(LayerType.SPATIAL, numpy_rdd)
     metadata = layer.collect_metadata(GlobalLayout(5))
 
-    def read_no_reproject(self, read_method, multiplex=False):
-        if multiplex:
-            actual_raster_layer = RasterLayer.read([{'1': self.path, '2': self.path}], read_method=read_method)
-        else:
-            actual_raster_layer = RasterLayer.read([self.path], read_method=read_method)
+    def read_no_reproject(self, read_method):
+        actual_raster_layer = RasterLayer.read([self.path], read_method=read_method)
 
         collected = actual_raster_layer.to_numpy_rdd().first()
 
@@ -51,38 +48,30 @@ class RasterLayerTest(BaseTestClass):
 
         self.assertEqual(projected_extent.proj4, self.projected_extent.proj4)
 
-        if multiplex:
-            for x in (0, 1):
-                self.assertTrue((self.expected_tile == tile.cells[x,:,:]).all())
-        else:
-            self.assertTrue((self.expected_tile == tile.cells).all())
+        self.assertTrue((self.expected_tile == tile.cells).all())
 
-    def read_with_reproject(self, read_method, multiplex=False):
+    def read_with_reproject(self, read_method):
         expected_raster_layer = self.rdd.reproject(target_crs=3857)
 
         expected_collected = expected_raster_layer.to_numpy_rdd().first()
         (expected_projected_extent, expected_tile) = expected_collected
 
-        if multiplex:
-            actual_raster_layer = RasterLayer.read([{'1': self.path, '2': self.path}], target_crs=3857, read_method=read_method)
-        else:
-            actual_raster_layer = RasterLayer.read([self.path], target_crs=3857, read_method=read_method)
+        actual_raster_layer = RasterLayer.read([self.path], target_crs=3857, read_method=read_method)
 
         actual_collected = actual_raster_layer.to_numpy_rdd().first()
         (actual_projected_extent, tile) = actual_collected
 
         self.assertEqual(actual_projected_extent.epsg, expected_projected_extent.epsg)
 
-        if multiplex:
-            for x in (0, 1):
-                self.assertTrue((expected_tile.cells == tile.cells[x,:,:]).all())
-        else:
-            self.assertTrue((expected_tile.cells == tile.cells).all())
+        self.assertTrue((expected_tile.cells == tile.cells).all())
 
 
     # No reprojection
     def test_read_ordered_no_reproject_geotrellis(self):
         self.read_no_reproject(ReadMethod.GEOTRELLIS, multiplex=True)
+
+    def test_read_no_reproject_geotrellis(self):
+        self.read_no_reproject(ReadMethod.GEOTRELLIS)
 
     def test_read_no_reproject_gdal(self):
         self.read_no_reproject(ReadMethod.GDAL)

--- a/geopyspark/tests/geotrellis/tiled_layer_tests/tiled_raster_layer_test.py
+++ b/geopyspark/tests/geotrellis/tiled_layer_tests/tiled_raster_layer_test.py
@@ -2,7 +2,7 @@ import unittest
 import pytest
 
 from geopyspark.geotrellis.constants import LayerType, ReadMethod
-from geopyspark.geotrellis import Extent, GlobalLayout, LocalLayout
+from geopyspark.geotrellis import Extent, GlobalLayout, LocalLayout, SourceInfo
 from geopyspark.tests.base_test_class import BaseTestClass
 from geopyspark.geotrellis.layer import TiledRasterLayer
 
@@ -20,7 +20,8 @@ class TiledRasterLayerTest(BaseTestClass):
         expected_collected = expected_tiled.to_numpy_rdd().collect()
 
         if multiplex:
-            actual_tiled = TiledRasterLayer.read([{'1': self.path, '2': self.path}],
+            sources = [SourceInfo(self.path, {0: 0}), SourceInfo(self.path, {0:1})]
+            actual_tiled = TiledRasterLayer.read(sources,
                                                  layout_type=layout,
                                                  target_crs=target_crs)
         else:


### PR DESCRIPTION
This PR adds multiplex band support to the `TiledRasterLayer.read` method. Now, it'll be possible to read in separate files as a single multiband. This is useful in cases where individual bands are split into separate files. In addition to combing multiple bands into a single tile, it's also possible to specify their order. In order to support band multiplexing, a new type: `SourceInfo` has been created.

*Note:* This PR depends on an unmerged PR: https://github.com/geotrellis/geotrellis-contrib/pull/111 to work.