### PR TITLE
Fix geopyspark requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pytest==3.0.6
 numpy>=1.8
-shapely>=1.6.4.post2
-rasterio==1.0a7
+shapely>=1.6.4
+rasterio>=1.0a7
 setuptools
 protobuf>=3.3.0
 pytz

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
-from setuptools import setup
-import sys
 import os
+import sys
+from setuptools import setup, find_packages
 
 if sys.version_info < (3, 3):
     sys.exit("GeoPySpark does not support Python versions before 3.3")
@@ -21,15 +21,7 @@ setup_args = dict(
         'pytz',
         'python-dateutil>=2.6.1'
     ],
-    packages=[
-        'geopyspark',
-        'geopyspark.geotrellis',
-        'geopyspark.geotrellis.protobuf',
-        'geopyspark.geotools',
-        'geopyspark.geotools.protobuf',
-        'geopyspark.command',
-        'geopyspark.jars'
-    ],
+    packages=find_packages(exclude=['tests']),
     entry_points={
         "console_scripts": ['geopyspark = geopyspark.command.configuration:main']
     },

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup_args = dict(
         'pytz',
         'python-dateutil>=2.6.1'
     ],
-    packages=find_packages(exclude=['tests']),
+    packages=find_packages(exclude=['geopyspark.tests', 'geopyspark.tests.*']),
     entry_points={
         "console_scripts": ['geopyspark = geopyspark.command.configuration:main']
     },

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup_args = dict(
     install_requires=[
         'protobuf>=3.3.0',
         'numpy>=1.8',
-        'shapely>=1.6b3',
+        'shapely>=1.6.4',
+        'rasterio>=1.0a7',
         'pytz',
         'python-dateutil>=2.6.1'
     ],


### PR DESCRIPTION
This PR contains fix for issue #683. 

Changes:
* dependencies were unified between `setup.py` and `requirements.txt`
* list of packages were replaced by `setuptools.find_packages` function
* rasterio was added to list of required dependencies
* order of import was changed according to PEP 8 standard

CC:
@jbouffard I went through source code and it looks that `rasterio` isn't only package missing in requirements. I think we should add also `GDAL`, `matplotlib`, `pyproj` and `colortools` to list of requirements. `ImportError's` are raised inside some functions bodies which is not good idea especially when required libraries are not listed. What about taking all imports from functions to the beginning of modules?