### PR TITLE
install-jar: avoid silent swallowing of curl download failure

### DIFF
--- a/geopyspark/command/configuration.py
+++ b/geopyspark/command/configuration.py
@@ -6,6 +6,7 @@ import sys
 import os
 from os import path
 import argparse
+import subprocess
 
 from geopyspark.geopyspark_constants import JAR, CWD
 
@@ -31,12 +32,14 @@ def write_jar_path(jar_path):
         f.write(jar_path)
 
 def download_jar(jar_path):
-    import subprocess
-
     jar_location = path.join(jar_path, JAR)
-    write_jar_path(jar_location)
 
-    subprocess.call(['curl', '-L', JAR_URL, '-o', jar_location])
+    print("Downloading", JAR_URL)
+    # Will raise exception when curl download fails (e.g. 404 not found)
+    subprocess.check_call(['curl', '-L', '--fail', JAR_URL, '-o', jar_location])
+    print("Downloaded to", jar_location)
+
+    write_jar_path(jar_location)
 
 def get_jar_path():
     default_jar_location = path.join(DEFAULT_JAR_PATH, JAR)


### PR DESCRIPTION
When you use `geopyspark install-jar` to download the backend jar, and something goes wrong with the curl command, the user doesn't really notice this.

For example: I was working with a forked version of geopyspark, which had a custom version defined in `geopyspark_constants.py`. I ran `geopyspark install-jar` to download the jar and that seemed to work. After losing quite some time troubleshooting, I found out that `geotrellis-backend-assembly-foobar.jar' was a very small file, just containing the text "Not Found"  :/

This PR addresses this by making sure an exception is raised when the download encounters 4xx or 5xx http codes so the user will know earlier that something is wrong. It also add showing the download URL and target path for easier troubleshooting