### PR TITLE
Add "pyspark" to installation dependencies (setup.py)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup_args = dict(
     long_description=open('README.rst').read(),
     license='LICENSE',
     install_requires=[
+        'pyspark',
         'protobuf>=3.3.0',
         'numpy>=1.8',
         'shapely>=1.6b3',


### PR DESCRIPTION
`pyspark` is obviously a dependency for geopyspark, but not listed in `install_requires` in setup.py.

This commit fixes that.